### PR TITLE
1. Query: VouchRegistry

### DIFF
--- a/queries/vouch_registry.sql
+++ b/queries/vouch_registry.sql
@@ -1,49 +1,103 @@
 with
 -- Find permanent version of this query at: https://dune.com/queries/674947
-recognized_bonding_pools (pool, name, initial_funder) as (
+-- Contract events queried here are from the VouchRegister verified at
+-- https://etherscan.io/address/0xb422f2520b0b7fd86f7da61b32cc631a59ed7e8f#code
+test_bonding_pools (pool, name, initial_funder) as (
   select *
   from (
     values
-        -- This Pool has not yet been funded.
-        -- ('\x8353713b6D2F728Ed763a04B886B16aAD2b16eBD'::bytea, 'Gnosis'),
+        ('\xb0'::bytea, 'Pool 0', '\xf0'::bytea),
+        ('\xb1'::bytea, 'Pool 1', '\xf1'::bytea),
+        ('\xb2'::bytea, 'Pool 2', '\xf2'::bytea),
+        ('\xb3'::bytea, 'Pool 3', '\xf3'::bytea),
+        ('\xb4'::bytea, 'Pool 4', '\xf4'::bytea),
+        ('\xb5'::bytea, 'Pool 5', '\xf5'::bytea)
+    ) as _
+),
+test_vouch_events (evt_block_number, evt_index, solver, "cowRewardTarget", "bondingPool", sender) as (
+    select * from (
+        values
+            -- Test Case 0: vouch for same solver, two different pools then invalidate the first
+            (0, 0, '\x50'::bytea, '\xc1'::bytea, '\xb0'::bytea, '\xf0'::bytea), -- vouch(solver0, pool0)
+            (1, 0, '\x50'::bytea, '\xc1'::bytea, '\xb1'::bytea, '\xf1'::bytea),  -- vouch(solver0, pool1)
+            -- Test Case 1: Invalidation before Vouch
+            (1, 0, '\x51'::bytea, '\xc1'::bytea, '\xb0'::bytea, '\xf0'::bytea),  -- vouch(solver1, pool0)
+            -- Test Case 2: Vouch with wrong sender
+            (1, 0, '\x52'::bytea, '\xc1'::bytea, '\xb0'::bytea, '\xf1'::bytea),  -- vouch(solver2, pool0, sender1)
+            -- Test Case 3: Valid Vouch
+            (1, 0, '\x53'::bytea, '\xc1'::bytea, '\xb2'::bytea, '\xf2'::bytea),  -- vouch(solver3, pool2, sender2)
+            -- Test Case 4: Update Cow Reward Target
+            (1, 0, '\x54'::bytea, '\xc1'::bytea, '\xb2'::bytea, '\xf2'::bytea),  -- vouch(solver4, pool2, reward_target1)
+            (1, 1, '\x54'::bytea, '\xc2'::bytea, '\xb2'::bytea, '\xf2'::bytea),  -- vouch(solver4, pool2, reward_target2)
+            (2, 0, '\x54'::bytea, '\xc3'::bytea, '\xb2'::bytea, '\xf2'::bytea),  -- vouch(solver4, pool2, reward_target3)
+            -- Last dummy Row
+            (99999, 0, '\xff'::bytea, '\xff'::bytea, '\xff'::bytea, '\xff'::bytea)
+    ) as _
+),
+test_invalidation_events (evt_block_number, evt_index, solver, "bondingPool", sender) as (
+    select * from (
+        values
+            -- Test Case 0: vouch for same solver, two different pools then invalidate the first
+            (3, 0, '\x50'::bytea, '\xb0'::bytea, '\xf0'::bytea), -- invalidate(solver0, pool0)
+            -- Test Case 1: Invalidation before Vouch
+            (0, 0, '\x51'::bytea, '\xb0'::bytea, '\xf0'::bytea), -- invalidate(solver1, pool0)
+            -- Last dummy Row: here so that we can comment out the above entries
+            (99999, 0, '\xff'::bytea, '\xff'::bytea, '\xff'::bytea)
+    ) as _
+),
+real_bonding_pools (pool, name, initial_funder) as (
+  select *
+  from (
+    values
+        ('\x8353713b6D2F728Ed763a04B886B16aAD2b16eBD'::bytea, 'Gnosis', '\x6c642cafcbd9d8383250bb25f67ae409147f78b2'::bytea),
         ('\x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6'::bytea, 'CoW Services', '\x423cec87f19f0778f549846e0801ee267a917935'::bytea)
     ) as _
 ),
+real_vouch_events as (
+    select evt_block_number, evt_index, solver, "cowRewardTarget", "bondingPool", sender
+    from cow_protocol."VouchRegister_evt_Vouch"
+),
+real_invalidation_events as (
+    select evt_block_number, evt_index, solver, "bondingPool", sender
+    from cow_protocol."VouchRegister_evt_InvalidateVouch"
+),
+
+-- Query Logic Begins here!
 vouches as (
   select
-    evt_block_time,
+    evt_block_number,
     evt_index,
     solver,
     "cowRewardTarget" as reward_target,
     pool,
     sender,
     True as active
-  from cow_protocol."VouchRegister_evt_Vouch"
-    join recognized_bonding_pools
+  from {{Scenario}}_vouch_events
+    join {{Scenario}}_bonding_pools
         on pool = "bondingPool"
         and sender = initial_funder
 ),
 invalidations as (
   select
-    evt_block_time,
+    evt_block_number,
     evt_index,
     solver,
     Null::bytea as reward_target,  -- This is just ot align with vouches to take a union
     pool,
     sender,
     False as active
-  from cow_protocol."VouchRegister_evt_InvalidateVouch"
-    join recognized_bonding_pools
+  from {{Scenario}}_invalidation_events
+    join {{Scenario}}_bonding_pools
         on pool = "bondingPool"
         and sender = initial_funder
 ),
 -- At this point we have excluded all arbitrary vouches (i.e. those not from initial funders of recognized pools)
--- This ranks (solver, pool, sender) by most recent (vouch or invalidation) 
+-- This ranks (solver, pool, sender) by most recent (vouch or invalidation)
 -- and yields as rank 1, the current "active" status of the triplet.
 ranked_vouches as (
   select rank() over (
       partition by solver, pool, sender
-      order by evt_block_time desc, evt_index desc
+      order by evt_block_number desc, evt_index desc
     ) as rk,
     *
   from (
@@ -58,7 +112,7 @@ ranked_vouches as (
 current_active_vouches as (
   select rank() over (
       partition by solver
-      order by evt_block_time, evt_index
+      order by evt_block_number, evt_index
     ) as time_rank,
     *
   from ranked_vouches

--- a/queries/vouch_registry.sql
+++ b/queries/vouch_registry.sql
@@ -1,0 +1,125 @@
+with valid_tokens as (
+  select *
+  from erc20.tokens
+  where contract_address in (
+      '\xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB', -- COW Token
+      '\x39AA39c021dfbaE8faC545936693aC917d5E7563' -- cUSDC
+    )
+),
+-- Bonding Pool Addresses
+-- Gnosis: 0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD
+-- CoW Services: 0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6
+recognized_bonding_pools (pool, name) as (
+  SELECT *
+  from (
+      values (
+          replace('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD', '0x', '\x')::bytea,
+          'Gnosis'
+        ),
+        (
+          replace('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6', '0x', '\x')::bytea,
+          'CoW Services'
+        )
+    ) as _
+),
+-- TODO: Make initial funders front-running resistant.
+--       This would involve detecting the magnitude of the deposits 
+--       and choosing the first sender with "substantial" deposit
+initial_funders as (
+  select name,
+    pool,
+    (
+      select "from"
+      from erc20."ERC20_evt_Transfer"
+      where "to" = pool
+        and contract_address in (
+          select contract_address
+          from valid_tokens
+        )
+      order by evt_block_number,
+        evt_index
+      limit 1
+    ) as initial_funder,
+    case
+      when (
+        select count(distinct "from")
+        from erc20."ERC20_evt_Transfer"
+        where "to" = pool
+          and contract_address in (
+            select contract_address
+            from valid_tokens
+          )
+      ) = 1 then True
+      else False
+    end as unique_depositor
+  from recognized_bonding_pools
+),
+vouches as (
+  select evt_block_time,
+    evt_index,
+    solver,
+    "cowRewardTarget" as reward_target,
+    pool,
+    sender,
+    True as active
+  from cow_protocol."VouchRegister_evt_Vouch"
+    join initial_funders on pool = "bondingPool"
+    and sender = initial_funder
+),
+invalidations as (
+  select evt_block_time,
+    evt_index,
+    solver,
+    Null::bytea as reward_target,
+    pool,
+    sender,
+    False as active
+  from cow_protocol."VouchRegister_evt_InvalidateVouch"
+    join initial_funders on pool = "bondingPool"
+    and sender = initial_funder
+),
+-- At this point we have excluded all arbitrary vouches (i.e. those not from initial funders of recognized pools)
+-- This ranks (solver, pool, sender) by most recent (vouch or invalidation) 
+-- and yields as rank 1, the current "active" status of the triplet.
+ranked_vouches as (
+  select rank() over (
+      partition by solver,
+      pool,
+      sender
+      order by evt_block_time desc,
+        evt_index desc
+    ) as rk,
+    *
+  from (
+      select *
+      from vouches
+      union
+      select *
+      from invalidations
+    ) as _
+),
+-- This will contain all latest active vouches,
+-- but could still contain solvers with multiplicity > 1 for different pools.
+-- Rank here again by solver, and time.
+current_active_vouches as (
+  select rank() over (
+      partition by solver
+      order by evt_block_time,
+        evt_index
+    ) as time_rank,
+    *
+  from ranked_vouches
+  where rk = 1
+    and active = True
+),
+-- To filter for the case of "same solver, different pool",
+-- rank the current_active vouches and choose the earliest
+valid_vouches as (
+  select solver,
+    reward_target,
+    pool
+  from current_active_vouches
+  where time_rank = 1
+)
+select *
+from valid_vouches

--- a/queries/vouch_registry.sql
+++ b/queries/vouch_registry.sql
@@ -6,9 +6,6 @@ with valid_tokens as (
       '\x39AA39c021dfbaE8faC545936693aC917d5E7563' -- cUSDC
     )
 ),
--- Bonding Pool Addresses
--- Gnosis: 0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD
--- CoW Services: 0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6
 recognized_bonding_pools (pool, name) as (
   select *
   from (
@@ -28,8 +25,7 @@ initial_funders as (
       from erc20."ERC20_evt_Transfer"
       where "to" = pool
         and contract_address in (select contract_address from valid_tokens)
-      order by evt_block_number,
-        evt_index
+      order by evt_block_number, evt_index
       limit 1
     ) as initial_funder,
     case
@@ -81,11 +77,9 @@ ranked_vouches as (
     ) as rk,
     *
   from (
-      select *
-      from vouches
+      select * from vouches
       union
-      select *
-      from invalidations
+      select * from invalidations
     ) as _
 ),
 -- This will contain all latest active vouches,

--- a/src/fetch/reward_targets.py
+++ b/src/fetch/reward_targets.py
@@ -1,0 +1,50 @@
+"""
+Script to query and display total funds distributed for specified accounting period.
+"""
+from dataclasses import dataclass
+
+from duneapi.api import DuneAPI
+from duneapi.types import DuneQuery, Network
+from duneapi.util import open_query
+
+from src.models import Address
+from src.utils.dataset import index_by
+
+
+@dataclass
+class Vouch:
+    """Data triplet linking solvers to bonding pools and COW reward destination"""
+
+    solver: Address
+    reward_target: Address
+    bonding_pool: Address
+
+
+def get_vouches(dune: DuneAPI) -> dict[Address, Vouch]:
+    """
+    Fetches & Returns Dune Results for accounting period totals.
+    """
+    query = DuneQuery.from_environment(
+        raw_sql=open_query("./queries/vouch_registry.sql"),
+        network=Network.MAINNET,
+        name="Solver Reward Targets",
+    )
+    data_set = dune.fetch(query)
+    result_list = [
+        Vouch(
+            solver=Address(rec["solver"]),
+            reward_target=Address(rec["reward_target"]),
+            bonding_pool=Address(rec["pool"]),
+        )
+        for rec in data_set
+    ]
+    # Indexing here ensures the solver's returned from Dune are unique!
+    return index_by(result_list, "solver")
+
+
+if __name__ == "__main__":
+    dune_conn = DuneAPI.new_from_environment()
+    vouch_map = get_vouches(dune=dune_conn)
+
+    for solver, vouch in vouch_map.items():
+        print("Solver", solver, "Reward Target", vouch.reward_target)

--- a/src/models.py
+++ b/src/models.py
@@ -19,6 +19,10 @@ class Address:
     """
 
     def __init__(self, address: str):
+        # Dune uses \x instead of 0x (i.e. bytea instead of hex string)
+        # This is just a courtesy to query writers,
+        # so they don't have to convert all addresses to hex strings manually
+        address = address.replace("\\x", "0x")
         if Address._is_valid(address):
             self.address: str = Web3.toChecksumAddress(address)
         else:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -14,6 +14,7 @@ class TestAddress(unittest.TestCase):
         self.lower_case_address = "0xde1c59bc25d806ad9ddcbe246c4b5e5505645718"
         self.check_sum_address = "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB"
         self.invalid_address = "0x12"
+        self.dune_format = "\\x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6"
 
     def test_invalid(self):
         with self.assertRaises(ValueError) as err:
@@ -30,6 +31,10 @@ class TestAddress(unittest.TestCase):
         self.assertEqual(
             Address(address=self.check_sum_address).address,
             "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+        )
+        self.assertEqual(
+            Address(address=self.dune_format).address,
+            "0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6",
         )
 
 


### PR DESCRIPTION
Part of #22

According to the documentation specified [here](https://github.com/cowprotocol/solver-vouch-register) this query does the following (sequentially).

1. Fix the `valid_tokens` and `recognized_bonding_pools` (given by hard-coded token addresses for COW, and cUSDC along with two bonding pool contract addresses).
2. Determines each recognized pool's "Initial Funder" as the sender of the earliest incoming transfer of a "valid token".
3. Collects all the "relevant" vouches and invalidations where _relevant_ here means events pertaining to the recognized bonding pools sent from initial funders of the pool.
4. Merges the vouches and invalidations in a way so that they can be grouped and ordered by occurrence to extract/classify the most recent status of the `(solver, pool, reward_target)` as active or inactive. At this point we can now easily access all the current active vouches. However, it could still be that the same solver appears for multiple bonding pools.
5. To filter solver multiplicity we finally rank/order the results by `(block_time, evt_index)` per solver and choose only the earliest valid active vouch as the final `valid_vouches` table used to map solver addresses to cow reward targets.

Note that, one TODO remains here and this is to make the bonding pool initial funders resistant to front running. This means, instead of choosing the sender of the earliest deposit, we should choose the largest deposit. However, this query is already complex enough, I think it would be best to introduce front-running resistance in a follow up PR. Please save the discussion regarding this TODO on initial funders for the follow-up.

# Test Plan

PoC Query can be found here: https://dune.com/queries/668644



