### PR TITLE
2. Fetch: Reward Targets

### DIFF
--- a/src/fetch/reward_targets.py
+++ b/src/fetch/reward_targets.py
@@ -1,0 +1,50 @@
+"""
+Script to query and display total funds distributed for specified accounting period.
+"""
+from dataclasses import dataclass
+
+from duneapi.api import DuneAPI
+from duneapi.types import DuneQuery, Network
+from duneapi.util import open_query
+
+from src.models import Address
+from src.utils.dataset import index_by
+
+
+@dataclass
+class Vouch:
+    """Data triplet linking solvers to bonding pools and COW reward destination"""
+
+    solver: Address
+    reward_target: Address
+    bonding_pool: Address
+
+
+def get_vouches(dune: DuneAPI) -> dict[Address, Vouch]:
+    """
+    Fetches & Returns Dune Results for accounting period totals.
+    """
+    query = DuneQuery.from_environment(
+        raw_sql=open_query("./queries/vouch_registry.sql"),
+        network=Network.MAINNET,
+        name="Solver Reward Targets",
+    )
+    data_set = dune.fetch(query)
+    result_list = [
+        Vouch(
+            solver=Address(rec["solver"]),
+            reward_target=Address(rec["reward_target"]),
+            bonding_pool=Address(rec["pool"]),
+        )
+        for rec in data_set
+    ]
+    # Indexing here ensures the solver's returned from Dune are unique!
+    return index_by(result_list, "solver")
+
+
+if __name__ == "__main__":
+    dune_conn = DuneAPI.new_from_environment()
+    vouch_map = get_vouches(dune=dune_conn)
+
+    for solver, vouch in vouch_map.items():
+        print("Solver", solver, "Reward Target", vouch.reward_target)

--- a/src/models.py
+++ b/src/models.py
@@ -19,6 +19,10 @@ class Address:
     """
 
     def __init__(self, address: str):
+        # Dune uses \x instead of 0x (i.e. bytea instead of hex string)
+        # This is just a courtesy to query writers,
+        # so they don't have to convert all addresses to hex strings manually
+        address = address.replace("\\x", "0x")
         if Address._is_valid(address):
             self.address: str = Web3.toChecksumAddress(address)
         else:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -14,6 +14,7 @@ class TestAddress(unittest.TestCase):
         self.lower_case_address = "0xde1c59bc25d806ad9ddcbe246c4b5e5505645718"
         self.check_sum_address = "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB"
         self.invalid_address = "0x12"
+        self.dune_format = "\\x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6"
 
     def test_invalid(self):
         with self.assertRaises(ValueError) as err:
@@ -30,6 +31,10 @@ class TestAddress(unittest.TestCase):
         self.assertEqual(
             Address(address=self.check_sum_address).address,
             "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+        )
+        self.assertEqual(
+            Address(address=self.dune_format).address,
+            "0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6",
         )
 
 


### PR DESCRIPTION
Part of #22

Introducing a script to fetch the `solver -> rewardTarget` mapping from the query introduced in #19.

Follow up to this will utilize this script in the transfer file method to direct the COW rewards to the target specified by this mapping.

Note - we introduced a small convenience change to the Address constructor, allowing Addresses to be created from dune address strings (bytea).

# Test Plan

New and existing unit tests.