### PR TITLE
Add time contraint to Vouch query

### DIFF
--- a/queries/vouch_registry.sql
+++ b/queries/vouch_registry.sql
@@ -14,6 +14,11 @@ invalidation_events (evt_block_number, evt_index, solver, "bondingPool", sender)
 {{InvalidationEvents}}
 ),
 
+last_block_before_timestamp as (
+    select max("number") from ethereum.blocks
+    where time < '{{EndTime}}'
+),
+
 -- Query Logic Begins here!
 vouches as (
   select
@@ -28,6 +33,7 @@ vouches as (
     join bonding_pools
         on pool = "bondingPool"
         and sender = initial_funder
+  where evt_block_number <= (select * from last_block_before_timestamp)
 ),
 invalidations as (
   select
@@ -42,6 +48,7 @@ invalidations as (
     join bonding_pools
         on pool = "bondingPool"
         and sender = initial_funder
+  where evt_block_number <= (select * from last_block_before_timestamp)
 ),
 -- At this point we have excluded all arbitrary vouches (i.e. those not from initial funders of recognized pools)
 -- This ranks (solver, pool, sender) by most recent (vouch or invalidation)

--- a/src/fetch/reward_targets.py
+++ b/src/fetch/reward_targets.py
@@ -2,16 +2,19 @@
 Script to query and display total funds distributed for specified accounting period.
 """
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional
 
 from duneapi.api import DuneAPI
-from duneapi.types import DuneQuery, Network
+from duneapi.types import DuneQuery, Network, QueryParameter
 from duneapi.util import open_query
 
-from src.models import Address
+from src.models import Address, AccountingPeriod
 from src.utils.dataset import index_by
 
 # pylint: disable=line-too-long
+from src.utils.script_args import generic_script_init
+
 RECOGNIZED_BONDING_POOLS = [
     "('\\x8353713b6D2F728Ed763a04B886B16aAD2b16eBD'::bytea, 'Gnosis', '\\x6c642cafcbd9d8383250bb25f67ae409147f78b2'::bytea)",
     "('\\x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6'::bytea, 'CoW Services', '\\x423cec87f19f0778f549846e0801ee267a917935'::bytea)",
@@ -56,7 +59,9 @@ def vouch_query(
     return query
 
 
-def get_raw_vouches(dune: DuneAPI, raw_query: str) -> list[dict[str, str]]:
+def get_raw_vouches(
+    dune: DuneAPI, raw_query: str, end_time: datetime = datetime.now()
+) -> list[dict[str, str]]:
     """
     Fetches & Returns Dune Results for vouch registry
     """
@@ -64,6 +69,7 @@ def get_raw_vouches(dune: DuneAPI, raw_query: str) -> list[dict[str, str]]:
         raw_sql=raw_query,
         network=Network.MAINNET,
         name="Solver Reward Targets",
+        parameters=[QueryParameter.date_type("EndTime", end_time)],
     )
     return dune.fetch(query)
 
@@ -82,17 +88,19 @@ def parse_vouches(raw_data: list[dict[str, str]]) -> dict[Address, Vouch]:
     return index_by(result_list, "solver")
 
 
-def get_vouches(dune: DuneAPI) -> dict[Address, Vouch]:
+def get_vouches(dune: DuneAPI, end_time: datetime) -> dict[Address, Vouch]:
     """
     Fetches & Returns Parsed Results for VouchRegistry query.
     """
-    raw_data_set = get_raw_vouches(dune, raw_query=vouch_query())
+    raw_data_set = get_raw_vouches(dune, raw_query=vouch_query(), end_time=end_time)
     return parse_vouches(raw_data_set)
 
 
 if __name__ == "__main__":
-    dune_conn = DuneAPI.new_from_environment()
-    vouch_map = get_vouches(dune=dune_conn)
+    dune_connection, accounting_period = generic_script_init(
+        description="Fetch Reward Targets"
+    )
+    vouch_map = get_vouches(dune=dune_connection, end_time=accounting_period.end)
 
     for solver, vouch in vouch_map.items():
         print("Solver", solver, "Reward Target", vouch.reward_target)

--- a/src/fetch/reward_targets.py
+++ b/src/fetch/reward_targets.py
@@ -9,7 +9,7 @@ from duneapi.api import DuneAPI
 from duneapi.types import DuneQuery, Network, QueryParameter
 from duneapi.util import open_query
 
-from src.models import Address, AccountingPeriod
+from src.models import Address
 from src.utils.dataset import index_by
 
 # pylint: disable=line-too-long

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -131,7 +131,7 @@ def get_transfers(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:
 
     negative_slippage = get_period_slippage(dune, period).negative
     indexed_slippage = index_by(negative_slippage, "solver_address")
-    cow_redirects = get_vouches(dune)
+    cow_redirects = get_vouches(dune, period.end)
 
     results = []
     for row in reimbursements_and_rewards:

--- a/tests/e2e/test_vouch_registry.py
+++ b/tests/e2e/test_vouch_registry.py
@@ -1,8 +1,10 @@
 import unittest
+from datetime import datetime
 
 from duneapi.api import DuneAPI
 
-from src.fetch.reward_targets import get_raw_vouches, vouch_query
+from src.fetch.reward_targets import get_raw_vouches, vouch_query, get_vouches, Vouch
+from src.models import Address
 
 
 def solver_from(num: int) -> str:
@@ -80,6 +82,31 @@ class TestVouchRegistry(unittest.TestCase):
         self.pools = list(map(lambda t: pool_from(t), range(5)))
         self.targets = list(map(lambda t: target_from(t), range(5)))
         self.senders = list(map(lambda t: sender_from(t), range(5)))
+
+    def test_real_data(self):
+        may_fifth = datetime.strptime("2022-05-05", "%Y-%m-%d")
+        fetched_records = get_vouches(self.dune, end_time=may_fifth)
+        solvers = [
+            Address("\\x109bf9e0287cc95cc623fbe7380dd841d4bdeb03"),
+            Address("\\x6fa201c3aff9f1e4897ed14c7326cf27548d9c35"),
+        ]
+        reward_target = Address("\\x84dbae2549d67caf00f65c355de3d6f4df59a32c")
+        bonding_pool = Address("\\x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6")
+        self.assertEqual(
+            list(fetched_records.values()),
+            [
+                Vouch(
+                    solver=solvers[0],
+                    bonding_pool=bonding_pool,
+                    reward_target=reward_target,
+                ),
+                Vouch(
+                    solver=solvers[1],
+                    bonding_pool=bonding_pool,
+                    reward_target=reward_target,
+                ),
+            ],
+        )
 
     def test_vouch_for_same_solver_in_different_pools(self):
         # vouch for same solver, two different pools then invalidate the first


### PR DESCRIPTION
In order to be sure the payouts are redirected correctly (regardless of when the payout is executed) we put a time query on the vouch. To keep the other tests running we include default `end_time=now()` in the raw fetch query.

Note that we could have changed all the `evt_block_numbers` to `evt_block_time`, but then the unit tests would be much much longer. Instead we introduce a sub query `last_block_before`. I am not married to this idea, and open to suggestions.

# Test Plan

New e2e test on real data
