### PR TITLE
Trim Test Scope

### DIFF
--- a/tests/e2e/test_internal_trades.py
+++ b/tests/e2e/test_internal_trades.py
@@ -71,7 +71,7 @@ def token_slippage(
 class TestDuneAnalytics(unittest.TestCase):
     def setUp(self):
         self.dune = DuneAPI.new_from_environment()
-        self.period = AccountingPeriod("2022-03-01", length_days=14)
+        self.period = AccountingPeriod("2022-03-01", length_days=10)
 
     def get_internal_transfers(self, tx_hash: str) -> list[InternalTransfer]:
         raw_sql = "\n".join(

--- a/tests/e2e/test_slippage_investigation.py
+++ b/tests/e2e/test_slippage_investigation.py
@@ -6,6 +6,7 @@ from duneapi.api import DuneAPI
 from duneapi.types import DuneQuery, QueryParameter, Network
 
 from src.fetch.period_slippage import QueryType, slippage_query
+from src.models import AccountingPeriod
 
 
 class TestDuneAnalytics(unittest.TestCase):
@@ -15,16 +16,15 @@ class TestDuneAnalytics(unittest.TestCase):
         which tx are having high slippage values in dollar terms
         """
         dune = DuneAPI.new_from_environment()
-        period_start = datetime.strptime("2022-03-10", "%Y-%m-%d")
-        period_end = datetime.strptime("2022-03-11", "%Y-%m-%d")
+        period = AccountingPeriod("2022-03-10", 1)
         slippage_per_tx = dune.fetch(
             DuneQuery.from_environment(
                 raw_sql=slippage_query(QueryType.PER_TX),
                 network=Network.MAINNET,
                 name="Slippage Accounting",
                 parameters=[
-                    QueryParameter.date_type("StartTime", period_start),
-                    QueryParameter.date_type("EndTime", period_end),
+                    QueryParameter.date_type("StartTime", period.start),
+                    QueryParameter.date_type("EndTime", period.end),
                     QueryParameter.text_type("TxHash", "0x"),
                 ],
             )
@@ -36,7 +36,7 @@ class TestDuneAnalytics(unittest.TestCase):
 
         pprint(top_five_negative + top_five_positive)
         for obj in top_five_negative + top_five_positive:
-            assert abs(obj["eth_slippage_wei"]) < 1 * 10**18
+            assert abs(int(obj["eth_slippage_wei"])) < 1 * 10**18
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reducing length of accounting interval in e2e tests so to require a smaller slice of data.

I am in the process of making a local DB image an wanted to reduce the scope of required data for our tests.