### PR TITLE
Rename `view_batches` to `batches`

### DIFF
--- a/queries/period_slippage.sql
+++ b/queries/period_slippage.sql
@@ -15,7 +15,7 @@ filtered_trades as (
            atoms_bought                                          as "buyAmount",
            '\x9008D19f58AAbD9eD0D60971565AA8510560ab41' :: bytea as contract_address
     from gnosis_protocol_v2."trades" t
-             join gnosis_protocol_v2."view_batches" b on t.tx_hash = b.tx_hash
+             join gnosis_protocol_v2."batches" b on t.tx_hash = b.tx_hash
     where b.block_time between '{{StartTime}}'
         and '{{EndTime}}'
       and case
@@ -69,7 +69,7 @@ other_transfers as (
                    then 'OUT_AMM'
                end            as transfer_type
     from erc20."ERC20_evt_Transfer" t
-             inner join gnosis_protocol_v2."view_batches" b
+             inner join gnosis_protocol_v2."batches" b
                         on evt_tx_hash = tx_hash
     where b.block_time between '{{StartTime}}'
         and '{{EndTime}}'

--- a/queries/period_totals.sql
+++ b/queries/period_totals.sql
@@ -10,7 +10,7 @@ solver_rewards as (
         ) as accounting_period,
         sum(gas_price_gwei * gas_used) / 10 ^ 9 as execution_cost_eth,
         count(*) * 100 as cow_rewards
-    from gnosis_protocol_v2."view_batches"
+    from gnosis_protocol_v2."batches"
     where block_time >= '{{StartTime}}'
     and block_time < '{{EndTime}}'
 ),

--- a/queries/period_transfers.sql
+++ b/queries/period_transfers.sql
@@ -4,7 +4,7 @@ relevant_batch_info as (
     select concat('0x', encode(solver_address, 'hex')) as solver,
            sum(gas_price_gwei * gas_used) / 10 ^ 9     as eth_spent,
            count(*) * 100                              as cow_reward
-    from gnosis_protocol_v2."view_batches"
+    from gnosis_protocol_v2."batches"
     where block_time >= '{{StartTime}}'
       and block_time < '{{EndTime}}'
     group by solver


### PR DESCRIPTION
This PR just renames the `view_batches` table to the `batches` one - as the former no longer appears to exist.

Specifically, it looks like the alternative was introduced https://github.com/duneanalytics/abstractions/pull/1015 and the "view" table was dropped here https://github.com/duneanalytics/abstractions/pull/1065.

### Test Plan

Check to see that generating the solver payout CSV file works again!