### PR TITLE
update duneapi to 3.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 black==22.3.0
-duneapi==3.0.1
+duneapi==3.0.3
 mypy==0.942
 pylint==2.13.4
 pytest==7.1.1

--- a/src/update/token_list.py
+++ b/src/update/token_list.py
@@ -19,6 +19,8 @@ logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=False)
 
 def update_token_list(dune: DuneAPI, token_list: list[str]) -> list[dict[str, str]]:
     """Fetches current trusted token list and builds a user generated view from it"""
+    if not token_list:
+        raise ValueError("Can't update and empty token list")
     raw_sql = open_query("./queries/token_list.sql").replace(
         "'{{TokenList}}'",
         ",\n             ".join(token_list),

--- a/tests/e2e/test_update_token_list.py
+++ b/tests/e2e/test_update_token_list.py
@@ -15,8 +15,10 @@ class TestTokenList(unittest.TestCase):
 
     def test_empty_token_list_update(self):
         dune = DuneAPI.new_from_environment()
-        dune_list = update_token_list(dune, [])
-        self.assertEqual(len(dune_list), 0)
+        with self.assertRaises(ValueError) as err:
+            update_token_list(dune, [])
+
+        self.assertEqual(str(err.exception), "Can't update and empty token list")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Based on recent changes to dune's unsupported api, all previous package versions are no longer viable. 

# Test Plan

CI - verifies functionality.