### PR TITLE
adjust end_prices to have non-zero sample size

### DIFF
--- a/queries/period_slippage.sql
+++ b/queries/period_slippage.sql
@@ -320,10 +320,11 @@ final_token_balance_sheet as (
 ),
 end_prices as (
     select median_price as price,
-           p_complete.contract_address,
+           contract_address,
            decimals
-    from prices.prices_from_dex_data p_complete
-    where p_complete.hour = '{{EndTime}}'
+    from prices.prices_from_dex_data
+    where hour = '{{EndTime}}'
+    and sample_size > 0
 ),
 results_per_tx as (
     select solver_address,


### PR DESCRIPTION
Based on the transaction alluded to in https://github.com/cowprotocol/solver-rewards/issues/29

The problem was that the "end prices" used to compute slippage at the accounting period were invalid because they were based on a sample size of zero. 

Here we adjust the query to only include prices for which there was at least one trade of the token in the hour of the accounting period end time.

To cross check this, we run the transfer file script on a sample of previous weeks


## Old Query (suppressed logs)
```
(venv) ➜  solver-rewards git:(main)   python -m src.fetch.transfer_file --start '2022-03-01'
Adjusting 0x340185114F9D2617DC4c16088d0375D09fee9186(prod-Naive) transfer by -0.00627 (slippage)
Adjusting 0x77ec2A722c2393D3fD64617BBaF1499C713e616b(prod-QuasiModo) transfer by -0.02253 (slippage)
Adjusting 0x8ccc61dBA297833dbe5D95FD6360f106b9A7576e(barn-Naive) transfer by -0.00012 (slippage)
Adjusting 0xda324c2f06d3544E7965767ce9ca536dcb67a660(barn-QuasiModo) transfer by -0.26076 (slippage)
Adjusting 0xdAE69AffE582d36f330Ee1145995A53Fab670962(barn-DexCowAgg) transfer by -0.03236 (slippage)
Adjusting 0xdE1c59Bc25D806aD9DdCbe246c4B5e5505645718(prod-1inch) transfer by -0.54002 (slippage)
Adjusting 0xDe786877a10DBb7EBa25a4DA65aEcf47654F08ab(barn-0x) transfer by -0.02015 (slippage)
Adjusting 0xe33062a24149f7801a48B2675Ed5111d3278F0f5(barn-1inch) transfer by -0.02785 (slippage)
dumping 36 results to transfers-2022-03-01-to-2022-03-08.csv
Total ETH Funds needed: 73.70810071218094
Total COW Funds needed: 455100.0

(venv) ➜  solver-rewards git:(main) python -m src.fetch.transfer_file --start '2022-04-05'
Adjusting 0x080a8b1E2f3695E179453c5e617b72A381BE44B9(barn-ParaSwap) transfer by -0.03387 (slippage)
Adjusting 0x0d2584DA2F637805071f184bCFa1268eBAe8a24A(barn-Baseline) transfer by -0.00032 (slippage)
Adjusting 0x15F4c337122Ec23859EC73Bec00aB38445E45304(prod-ParaSwap) transfer by -0.86657 (slippage)
Adjusting 0x22DEE0935c77d32c7241362b14e76fc2D5eF657d(barn-BalancerSOR) transfer by -0.00085 (slippage)
Adjusting 0xa97DEF4fBCBa3b646dd169Bc2eeE40f0f3fE7771(prod-BalancerSOR) transfer by -0.00183 (slippage)
Adjusting 0xda324c2f06d3544E7965767ce9ca536dcb67a660(barn-QuasiModo) transfer by -0.00450 (slippage)
Adjusting 0xdE1c59Bc25D806aD9DdCbe246c4B5e5505645718(prod-1inch) transfer by -1.45495 (slippage)
dumping 34 results to transfers-2022-04-05-to-2022-04-12.csv
Total ETH Funds needed: 116.49135000381195
Total COW Funds needed: 545400.0

(venv) ➜  solver-rewards git:(main) python -m src.fetch.transfer_file --start '2022-05-10'

Adjusting 0x080a8b1E2f3695E179453c5e617b72A381BE44B9(barn-ParaSwap) transfer by -0.00639 (slippage)
Adjusting 0x15F4c337122Ec23859EC73Bec00aB38445E45304(prod-ParaSwap) transfer by -6.97079 (slippage)
Adjusting 0x6fa201C3Aff9f1e4897Ed14c7326cF27548d9c35(prod-Otex) transfer by -0.66078 (slippage)
Adjusting 0x77ec2A722c2393D3fD64617BBaF1499C713e616b(prod-QuasiModo) transfer by -0.40134 (slippage)
Adjusting 0xda324c2f06d3544E7965767ce9ca536dcb67a660(barn-QuasiModo) transfer by -0.00046 (slippage)
Adjusting 0xdE1c59Bc25D806aD9DdCbe246c4B5e5505645718(prod-1inch) transfer by -3.91198 (slippage)
Adjusting 0xDe786877a10DBb7EBa25a4DA65aEcf47654F08ab(barn-0x) transfer by -0.15157 (slippage)
Adjusting 0xf2D21ad3c88170D4AE52bBBeBA80Cb6078D276F4(prod-MIP) transfer by -0.00000 (slippage)
dumping 20 results to transfers-2022-05-10-to-2022-05-17.csv
Total ETH Funds needed: 126.357063504751
Total COW Funds needed: 366900.0

(venv) ➜  solver-rewards git:(main) python -m src.fetch.transfer_file --start '2022-05-17'

Adjusting 0x080a8b1E2f3695E179453c5e617b72A381BE44B9(barn-ParaSwap) transfer by -0.00170 (slippage)
Adjusting 0x109BF9E0287Cc95cc623FBE7380dD841d4bdEb03(barn-Otex) transfer by -0.36233 (slippage)
Adjusting 0x15F4c337122Ec23859EC73Bec00aB38445E45304(prod-ParaSwap) transfer by -0.42267 (slippage)
Adjusting 0x340185114F9D2617DC4c16088d0375D09fee9186(prod-Naive) transfer by -0.00139 (slippage)
Adjusting 0xa97DEF4fBCBa3b646dd169Bc2eeE40f0f3fE7771(prod-BalancerSOR) transfer by -0.00387 (slippage)
Adjusting 0xDe786877a10DBb7EBa25a4DA65aEcf47654F08ab(barn-0x) transfer by -0.00295 (slippage)
Adjusting 0xe33062a24149f7801a48B2675Ed5111d3278F0f5(barn-1inch) transfer by -0.02586 (slippage)
Adjusting 0xf2D21ad3c88170D4AE52bBBeBA80Cb6078D276F4(prod-MIP) transfer by -0.00000 (slippage)
dumping 19 results to transfers-2022-05-17-to-2022-05-24.csv
Total ETH Funds needed: 40.39769086329161
Total COW Funds needed: 340300.0
```

## New Query (suppressed logs)

```
(venv) ➜  solver-rewards git:(incorporate-sample-size) ✗ python -m src.fetch.transfer_file --start '2022-03-01'

Adjusting 0x2d15894FaC906386fF7f4Bd07fcEAc43fcF80C73(prod-DexCowAgg) transfer by -0.39913 (slippage)
Adjusting 0x340185114F9D2617DC4c16088d0375D09fee9186(prod-Naive) transfer by -0.00627 (slippage)
Adjusting 0x77ec2A722c2393D3fD64617BBaF1499C713e616b(prod-QuasiModo) transfer by -0.01206 (slippage)
Adjusting 0x833f076D182123cA8DDE2743045Ea02957bD61ef(prod-Baseline) transfer by -0.03644 (slippage)
Adjusting 0x8ccc61dBA297833dbe5D95FD6360f106b9A7576e(barn-Naive) transfer by -0.00012 (slippage)
Adjusting 0xda324c2f06d3544E7965767ce9ca536dcb67a660(barn-QuasiModo) transfer by -0.67405 (slippage)
Adjusting 0xdAE69AffE582d36f330Ee1145995A53Fab670962(barn-DexCowAgg) transfer by -0.87010 (slippage)
Adjusting 0xdE1c59Bc25D806aD9DdCbe246c4B5e5505645718(prod-1inch) transfer by -0.47724 (slippage)
Adjusting 0xDe786877a10DBb7EBa25a4DA65aEcf47654F08ab(barn-0x) transfer by -0.02015 (slippage)
Adjusting 0xe33062a24149f7801a48B2675Ed5111d3278F0f5(barn-1inch) transfer by -0.02671 (slippage)
Adjusting 0xf2D21ad3c88170D4AE52bBBeBA80Cb6078D276F4(prod-MIP) transfer by -0.11946 (slippage)
dumping 36 results to transfers-2022-03-01-to-2022-03-08.csv
Total ETH Funds needed: 71.97641542152785
Total COW Funds needed: 455100.0

(venv) ➜  solver-rewards git:(incorporate-sample-size) ✗ python -m src.fetch.transfer_file --start '2022-04-05'

Adjusting 0x080a8b1E2f3695E179453c5e617b72A381BE44B9(barn-ParaSwap) transfer by -0.03387 (slippage)
Adjusting 0x0d2584DA2F637805071f184bCFa1268eBAe8a24A(barn-Baseline) transfer by -0.00032 (slippage)
Adjusting 0x15F4c337122Ec23859EC73Bec00aB38445E45304(prod-ParaSwap) transfer by -0.90054 (slippage)
Adjusting 0x22DEE0935c77d32c7241362b14e76fc2D5eF657d(barn-BalancerSOR) transfer by -0.00085 (slippage)
Adjusting 0x2d15894FaC906386fF7f4Bd07fcEAc43fcF80C73(prod-DexCowAgg) transfer by -1.13428 (slippage)
Adjusting 0xa97DEF4fBCBa3b646dd169Bc2eeE40f0f3fE7771(prod-BalancerSOR) transfer by -0.00183 (slippage)
Adjusting 0xda324c2f06d3544E7965767ce9ca536dcb67a660(barn-QuasiModo) transfer by -0.00450 (slippage)
Adjusting 0xdE1c59Bc25D806aD9DdCbe246c4B5e5505645718(prod-1inch) transfer by -1.41948 (slippage)
Adjusting 0xf2D21ad3c88170D4AE52bBBeBA80Cb6078D276F4(prod-MIP) transfer by -0.53589 (slippage)
dumping 34 results to transfers-2022-04-05-to-2022-04-12.csv
Total ETH Funds needed: 114.82268794232907
Total COW Funds needed: 545400.0

(venv) ➜  solver-rewards git:(incorporate-sample-size) ✗ python -m src.fetch.transfer_file --start '2022-05-10'

Adjusting 0x080a8b1E2f3695E179453c5e617b72A381BE44B9(barn-ParaSwap) transfer by -0.00639 (slippage)
Adjusting 0x15F4c337122Ec23859EC73Bec00aB38445E45304(prod-ParaSwap) transfer by -6.99099 (slippage)
Adjusting 0x6fa201C3Aff9f1e4897Ed14c7326cF27548d9c35(prod-Otex) transfer by -0.81212 (slippage)
Adjusting 0x77ec2A722c2393D3fD64617BBaF1499C713e616b(prod-QuasiModo) transfer by -0.14819 (slippage)
Adjusting 0xda324c2f06d3544E7965767ce9ca536dcb67a660(barn-QuasiModo) transfer by -0.00046 (slippage)
Adjusting 0xdE1c59Bc25D806aD9DdCbe246c4B5e5505645718(prod-1inch) transfer by -3.89086 (slippage)
Adjusting 0xDe786877a10DBb7EBa25a4DA65aEcf47654F08ab(barn-0x) transfer by -0.15157 (slippage)
Adjusting 0xf2D21ad3c88170D4AE52bBBeBA80Cb6078D276F4(prod-MIP) transfer by -0.00000 (slippage)
dumping 20 results to transfers-2022-05-10-to-2022-05-17.csv
Total ETH Funds needed: 126.45979391188212
Total COW Funds needed: 366900.0

(venv) ➜  solver-rewards git:(incorporate-sample-size) ✗ python -m src.fetch.transfer_file --start '2022-05-17'

Adjusting 0x080a8b1E2f3695E179453c5e617b72A381BE44B9(barn-ParaSwap) transfer by -0.00170 (slippage)
Adjusting 0x109BF9E0287Cc95cc623FBE7380dD841d4bdEb03(barn-Otex) transfer by -0.20019 (slippage)
Adjusting 0x15F4c337122Ec23859EC73Bec00aB38445E45304(prod-ParaSwap) transfer by -0.33005 (slippage)
Adjusting 0x340185114F9D2617DC4c16088d0375D09fee9186(prod-Naive) transfer by -0.00139 (slippage)
Adjusting 0x6fa201C3Aff9f1e4897Ed14c7326cF27548d9c35(prod-Otex) transfer by -6.74390 (slippage)
Adjusting 0x77ec2A722c2393D3fD64617BBaF1499C713e616b(prod-QuasiModo) transfer by -0.03915 (slippage)
Adjusting 0xa97DEF4fBCBa3b646dd169Bc2eeE40f0f3fE7771(prod-BalancerSOR) transfer by -0.00387 (slippage)
Adjusting 0xdE1c59Bc25D806aD9DdCbe246c4B5e5505645718(prod-1inch) transfer by -0.59136 (slippage)
Adjusting 0xDe786877a10DBb7EBa25a4DA65aEcf47654F08ab(barn-0x) transfer by -0.00295 (slippage)
Adjusting 0xe33062a24149f7801a48B2675Ed5111d3278F0f5(barn-1inch) transfer by -0.02586 (slippage)
Adjusting 0xf2D21ad3c88170D4AE52bBBeBA80Cb6078D276F4(prod-MIP) transfer by -0.00000 (slippage)
dumping 19 results to transfers-2022-05-17-to-2022-05-24.csv
Total ETH Funds needed: 33.278039442967376
Total COW Funds needed: 340300.0
```


Specifically, we find the expected 6 ETH difference from last week `2022-05-17` that was the result of too high (incorrect) positive slippage.

For all other weeks we only see very small differences.