### PR TITLE
HotFix: Fix Broken Docker Deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:alpine
-RUN apk add --update gcc libc-dev linux-headers
+RUN apk add --update gcc libc-dev linux-headers postgresql-dev
 
 WORKDIR /app
 


### PR DESCRIPTION
Currently our docker deployment is [failing on main](https://github.com/cowprotocol/solver-rewards/runs/6841845347?check_suite_focus=true)

This is because of the following error:
```
Error: pg_config executable not found.
pg_config is required to build psycopg2 from source. 
```


This fixes the broken docker deploy by installing the tools required to install `psycopg2` (a dependency recently introduced for local testing). 

## Alternate Solution
A probably better alternative solution is to split the requirements into a directory structure like this:
```
-- project_root
|-- requirements
    |-- common.txt
    |-- dev.txt
    `-- prod.txt
```

and changing the install instructions to this:

```sh
pip install -r requirements/dev.txt
pip install -r requirements/prod.txt
```

The only difference being saving some space on the size of the docker image.


## Test Plan

```sh
docker build .
```
