### PR TITLE
HotFix: Update Internal Buffer Solvers

### DIFF
--- a/queries/period_slippage.sql
+++ b/queries/period_slippage.sql
@@ -200,15 +200,19 @@ valued_potential_buffered_trades as (
                                  and date_trunc('minute', block_time) = pusd.minute
 ),
 internal_buffer_trader_solvers as (
-    Select
+    select
         CONCAT('0x', ENCODE(address, 'hex'))
     from gnosis_protocol_v2."view_solvers"
-    where
-            name = 'DexCowAgg' or
-            name = 'CowDexAg' or
-            name = 'MIP' or
-            name = 'Quasimodo' or
-            name = 'QuasiModo'
+    -- Exclude Single Order Solvers
+    where name not in (
+        '1inch',
+        '0x',
+        'ParaSwap',
+        'Baseline',
+        'BalancerSOR'
+    )
+    -- Exclude services and test solvers
+    and environment not in ('service', 'test')
 ),
 buffer_trades as (
     Select date(a.block_time) as block_time,

--- a/queries/period_slippage.sql
+++ b/queries/period_slippage.sql
@@ -200,6 +200,7 @@ valued_potential_buffered_trades as (
                                  and date_trunc('minute', block_time) = pusd.minute
 ),
 internal_buffer_trader_solvers as (
+    -- See the resulting list at: https://dune.com/queries/908642
     select
         CONCAT('0x', ENCODE(address, 'hex'))
     from gnosis_protocol_v2."view_solvers"


### PR DESCRIPTION
Recent new solvers have joined the competition and instead of keeping a hard coded list of solver known to use buffers, we reverse the logic and exclude solvers which are known not to. This will result in less overall maintenance and also make the current week more accurate.


# Test Plan

Existing CI.

There is also a [PoC query](https://dune.com/queries/908642) showing the solvers listed as internal buffer solvers as a result of this change