### PR TITLE
Update Allowed Token List URL

### DIFF
--- a/src/token_list.py
+++ b/src/token_list.py
@@ -16,7 +16,9 @@ def parse_token_list(token_list_json: str) -> list[str]:
         print("Could not parse JSON data!")
         raise
     return [
-        f"('\\{token['address'].lower()[1:]}'::bytea)" for token in token_list["tokens"]
+        f"('\\{token['address'].lower()[1:]}'::bytea)"
+        for token in token_list["tokens"]
+        if token["chainId"] == 1
     ]
 
 

--- a/src/token_list.py
+++ b/src/token_list.py
@@ -4,7 +4,7 @@ import json
 import requests
 
 # pylint: disable=line-too-long
-ALLOWED_TOKEN_LIST_URL = "https://raw.githubusercontent.com/gnosis/cow-dex-solver/main/data/token_list_for_buffer_trading.json"
+ALLOWED_TOKEN_LIST_URL = "https://token-list.cow.eth.link/"
 
 
 def parse_token_list(token_list_json: str) -> list[str]:

--- a/src/token_list.py
+++ b/src/token_list.py
@@ -4,7 +4,7 @@ import json
 import requests
 
 # pylint: disable=line-too-long
-ALLOWED_TOKEN_LIST_URL = "https://token-list.cow.eth.link/"
+ALLOWED_TOKEN_LIST_URL = "https://token-list.cow.eth.limo/"
 
 
 def parse_token_list(token_list_json: str) -> list[str]:

--- a/src/token_list.py
+++ b/src/token_list.py
@@ -3,7 +3,6 @@ import json
 
 import requests
 
-# pylint: disable=line-too-long
 ALLOWED_TOKEN_LIST_URL = "https://token-list.cow.eth.link/"
 
 

--- a/src/token_list.py
+++ b/src/token_list.py
@@ -4,7 +4,7 @@ import json
 import requests
 
 # pylint: disable=line-too-long
-ALLOWED_TOKEN_LIST_URL = "https://token-list.cow.eth.limo/"
+ALLOWED_TOKEN_LIST_URL = "https://token-list.cow.eth.link/"
 
 
 def parse_token_list(token_list_json: str) -> list[str]:

--- a/src/update/token_list.py
+++ b/src/update/token_list.py
@@ -32,7 +32,6 @@ def update_token_list(dune: DuneAPI, token_list: list[str]) -> list[dict[str, st
     # but we really only care that the data has been pushed and updated
     results = dune.fetch(query)
     # This assertion ensures that the token list was successfully updated.
-    print(token_list)
     assert len(results) == len(token_list), (
         f"Query Failed to push token list with results "
         f"{len(results)}!={len(token_list)}. This is likely due to missing ERC20 Tokens "

--- a/src/update/token_list.py
+++ b/src/update/token_list.py
@@ -32,7 +32,12 @@ def update_token_list(dune: DuneAPI, token_list: list[str]) -> list[dict[str, st
     # but we really only care that the data has been pushed and updated
     results = dune.fetch(query)
     # This assertion ensures that the token list was successfully updated.
-    assert len(results) == len(token_list), "Query Failed to push token list"
+    print(token_list)
+    assert len(results) == len(token_list), (
+        f"Query Failed to push token list with results "
+        f"{len(results)}!={len(token_list)}. This is likely due to missing ERC20 Tokens "
+        f"(cf. https://dune.com/queries/236085)"
+    )
     return results
 
 


### PR DESCRIPTION
The allowed token list has been decentralized and this is the new one.

Note that this PR depends on this update to Dunes erc20.tokens table: 
https://github.com/duneanalytics/abstractions/pull/1161
which has been merged.

When changing URLs here I found that the two files:

old URL
https://raw.githubusercontent.com/gnosis/cow-dex-solver/main/data/token_list_for_buffer_trading.json

new URL:
https://token-list.cow.eth.limo/

Previously we were not filtering by network. In this PR I have explicitly filtered for mainnet since this project only used on mainnet (currently).


Issues:

`.eth.link` urls are completely unreliable so we use `.limo`

## Test Plan

There is a CI test that the token list updates as expected. This URL is used in the code path.