### PR TITLE
Update Docker docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,13 @@ docker pull ghcr.io/cowprotocol/solver-rewards:main
 # Prepare environment variables
 cp .env.sample .env  # Fill in your Dune Credentials
 # Run
-docker run -it --rm --env-file .env -v $(PWD):/app/out ghcr.io/cowprotocol/solver-rewards --start 'YYYY-MM-DD'
+docker run -it --rm --env-file .env -v $PWD:/app/out ghcr.io/cowprotocol/solver-rewards:main --start 'YYYY-MM-DD'
 ```
 
 and (usually after about 30 seconds) find the transfer file written to your current working directory.
+
+For a one-liner that makes sure that the latest version of the code is the one being used, you can run Docker with:
+
+```sh
+docker run --pull=always -it --rm --env-file .env -v $PWD:/app/out ghcr.io/cowprotocol/solver-rewards:main --start 'YYYY-MM-DD'
+```


### PR DESCRIPTION
I tried to run the code in Docker and wanted to improve the readme after my test.

The changes are namely:
1. `$(PWD)` only works in MacOS, while `$PWD` should work in both Linux and Mac.
2. My Docker version automatically defaults to the label `:latest`, which is why I made `:main` explicit.
3. I added a one-liner that make sure that the latest version of the Docker image is pulled (thanks @ahhda for the suggestion). I imagine it could be useful for our oncall rotation.