### PR TITLE
Eliminate e2e test using tokenlist URL

### DIFF
--- a/tests/unit/test_update_token_list.py
+++ b/tests/unit/test_update_token_list.py
@@ -6,7 +6,6 @@ from src.update.token_list import update_token_list
 
 
 class TestTokenList(unittest.TestCase):
-
     def test_empty_token_list_update(self):
         dune = DuneAPI("user", "password")
         with self.assertRaises(ValueError) as err:

--- a/tests/unit/test_update_token_list.py
+++ b/tests/unit/test_update_token_list.py
@@ -2,16 +2,10 @@ import unittest
 
 from duneapi.api import DuneAPI
 
-from src.token_list import fetch_trusted_tokens
 from src.update.token_list import update_token_list
 
 
 class TestTokenList(unittest.TestCase):
-    def test_token_list_update(self):
-        dune = DuneAPI.new_from_environment()
-        fetched_tokens = fetch_trusted_tokens()
-        dune_list = update_token_list(dune, fetched_tokens)
-        self.assertEqual(len(dune_list), len(fetched_tokens))
 
     def test_empty_token_list_update(self):
         dune = DuneAPI("user", "password")


### PR DESCRIPTION
This link is so unreliable it is causing our CI to fail consistently more often than half the time.

Dependency on this URL is expected to be resolved next week (see issue #45). In the meantime, it should still be possible to run the payout script even with this terrible URL.

Note that, eliminating this test was already discussed and agreed upon with @josojo (since the `update_token_list` method makes an assertion on whether its execution was successful at runtime). 