### PR TITLE
Use Hourly Average ETH Price

### DIFF
--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -39,11 +39,7 @@ def slippage_query(query_type: QueryType = QueryType.TOTAL) -> str:
     per transaction results for testing
     """
 
-    select_statement = f"""
-    select *, 
-        usd_value / (select price from eth_price) * 10 ^ 18 as eth_slippage_wei 
-    from {query_type}
-    """.strip()
+    select_statement = f"select * from {query_type}"
 
     return "\n".join([open_query("./queries/period_slippage.sql"), select_statement])
 


### PR DESCRIPTION
Since the Recent change to price feed (using hourly average prices closest to the batch times), we also adapt the ETH price use in computing slippage.

Here we adapt the slippage query to use hourly average ETH prices.

Test Plan:
Follow this [PoC Query](https://dune.com/queries/911308?TxHash_t6c1ea=0xcefe7dc5511c393ab8b1904e837a2a747c50c9b88bd12d6db4617c20d2f6925b):

Which isolates a single batch (discussed last week)
Namely this transaction [0xcefe7dc5511c393ab8b1904e837a2a747c50c9b88bd12d6db4617c20d2f6925b](https://etherscan.io/tx/0xcefe7dc5511c393ab8b1904e837a2a747c50c9b88bd12d6db4617c20d2f6925b)


Find USD value 17.4 (at the time of the batch) and 
```
eth_slippage = 9624616874124970
```

Comparing with coin gecko

<img width="873" alt="Screenshot 2022-06-17 at 1 55 42 PM" src="https://user-images.githubusercontent.com/11778116/174294487-478e1cfb-a986-4d8d-86c6-46a1fcf53117.png">

This evaluates to 
```
9624616874124970 / 10^18 * 1801 ~ 17.33 USD
```

we could add a test for this comparison, but I would hesitate to introduce an e2e test based on prices.

If we do add a test here, I would also like to add an optimization to the query (namely the tx_hash isolation trick inside clearing prices). 