### PR TITLE
Unusual Slippage Alert

### DIFF
--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -30,8 +30,8 @@ select
 from results_per_tx rpt
 join gnosis_protocol_v2."batches" b
     on rpt.tx_hash = b.tx_hash
-where -1 * usd_value > '{{SignificantValue}}'
-and -100 * usd_value / batch_value > '{{RelativeTolerance}}'
+where abs(usd_value) > '{{SignificantValue}}'
+and 100.0 * abs(usd_value) / batch_value > '{{RelativeTolerance}}'
 order by relative_slippage"""
 
 

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -197,7 +197,10 @@ if __name__ == "__main__":
     dune_connection, accounting_period = generic_script_init(
         description="Fetch Complete Reimbursement"
     )
-    print(dashboard_url(accounting_period))
+    print(
+        f"While you are waiting, The data being compiled here can be visualized at\n "
+        f"{dashboard_url(accounting_period)}\n"
+    )
     detect_unusual_slippage(dune=dune_connection, period=accounting_period)
     transfers = consolidate_transfers(
         get_transfers(
@@ -215,8 +218,7 @@ if __name__ == "__main__":
     print(
         f"Total ETH Funds needed: {eth_total}\n"
         f"Total COW Funds needed: {cow_total}\n"
-        f"The data compiled here can be visualized and validated at\n "
-        f"{dashboard_url(accounting_period)}\n"
+        f"Please cross check these results with the dashboard linked above.\n "
         f"For solver payouts, paste the transfer file CSV Airdrop at:\n"
         f"{safe_url()}"
     )

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -198,7 +198,7 @@ if __name__ == "__main__":
         description="Fetch Complete Reimbursement"
     )
     print(
-        f"While you are waiting, The data being compiled here can be visualized at\n "
+        f"While you are waiting, The data being compiled here can be visualized at\n"
         f"{dashboard_url(accounting_period)}\n"
     )
     detect_unusual_slippage(dune=dune_connection, period=accounting_period)

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -215,8 +215,8 @@ if __name__ == "__main__":
     print(
         f"Total ETH Funds needed: {eth_total}\n"
         f"Total COW Funds needed: {cow_total}\n"
+        f"The data compiled here can be visualized and validated at\n "
+        f"{dashboard_url(accounting_period)}\n"
         f"For solver payouts, paste the transfer file CSV Airdrop at:\n"
         f"{safe_url()}"
-        f"The data compiled here can be visualized and validated at\n "
-        f"{dashboard_url(accounting_period)}"
     )

--- a/tests/unit/test_data_utils.py
+++ b/tests/unit/test_data_utils.py
@@ -1,6 +1,8 @@
 import unittest
 from dataclasses import dataclass
 
+from src.fetch.transfer_file import dashboard_url
+from src.models import AccountingPeriod
 from src.utils.dataset import index_by
 
 
@@ -10,7 +12,15 @@ class DummyDataClass:
     y: str
 
 
-class MyTestCase(unittest.TestCase):
+class TestDataUtils(unittest.TestCase):
+    def test_dashboard_url(self):
+        expected = "https://dune.com/gnosis.protocol/CoW-Protocol%3A-Solver-Accounting?StartTime=2022-05-31+00%3A00%3A00&EndTime=2022-06-07+00%3A00%3A00"
+        result = dashboard_url(AccountingPeriod("2022-05-31"))
+        self.assertEqual(
+            expected,
+            result,
+        )
+
     def test_index_by(self):
         data_set = [
             DummyDataClass(1, "a"),


### PR DESCRIPTION
We are currently roadblocked from doing the full dashboard migration (pending #47), so in the meantime I have updated the main dashboard:

https://dune.com/gnosis.protocol/CoW-Protocol%253A-Solver-Accounting

and introduced a additional check for "Unusual Slippage" (that is the primary content of this PR). Specifically we define outliers as having slippage value > 0.3% of the batch value and being more than 100 USD.

We also add an additional log message displayed before the fetching begins:

```
While you are waiting, The data being compiled here can be visualized at
https://dune.com/gnosis.protocol/CoW-Protocol%3A-Solver-Accounting?StartTime=2022-06-07+00%3A00%3A00&EndTime=2022-06-14+00%3A00%3A00
```

# Test Plan

You can test detection 

If you run this for the accounting period with `--start=2022-05-31`

Result logs will yield:

```
Found 1 batches with unusual slippage!
[{'batch_value': 417503.099061498,
  'block_time': '2022-06-01T18:50:44+00:00',
  'relative_slippage': -0.4423103989709573,
  'solver_name': 'prod-PLM',
  'tx_hash': '0xc16b5fc03729772f897361d1c34c2cfc2bf7b7fac729022f1f83020f2b49b2d3',
  'usd_value': -1846.659623175023}]
Please double check these on etherscan or with the batch token ledger:
https://dune.com/queries/459494?TxHash=0xc16b5fc03729772f897361d1c34c2cfc2bf7b7fac729022f1f83020f2b49b2d3
```


If you run this for the current week you will find that there is no unusual slippage (so far).

```
2022-06-20 13:28:38,768 INFO duneapi.api Fetching Unusual Slippage on Ethereum Mainnet...
2022-06-20 13:30:16,224 INFO duneapi.api got 0 records from last query
No unusual slippage detected!
```


## Follow Up.

The reason we are roadblocked by #47


- The dashboard manager only supports a single dependency. (i.e. one required subquery file).
- In order to build the Transfer File Query we require 3 separate subqueries from the project (vouch_registry, period_slippage and  period_transfers)
- The natural solution here is to  merge the three queries into a single file

However then we have conflicting issue with the unit testing framework for the `vouch_registry` because it introduces these weird hacky parameters meant for injecting test data.

Solutions are:
- Finish local query testing (will take some time).
- Pull the dashboard into the project as is with query duplication (not pretty) and come back later.
- (what I this PR does) Write an additional script for “Unusual Slippage” with the payouts that alerts the user of any detected batches unusual slippage and encourages the user to investigate (using links provided by the script).