### PR TITLE
Overdraft I: Log Statement

### DIFF
--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -156,7 +156,7 @@ class Overdraft:
         self.account = slippage.solver_address
         self.eth = eth_amount
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"Overdraft(\n"
             f"    solver={self.name}({self.account}),\n"

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -190,9 +190,9 @@ def get_transfers(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:
                 transfer.add_slippage(slippage)
             except ValueError as err:
                 print(
-                    f"Failed to add slippage: {err} \n"
-                    f"Excluding from reimbursement and appending excess to overdraft"
-                    f"{slippage.solver_name}({slippage.solver_address})"
+                    f"Slippage for {slippage.solver_address}({slippage.solver_name}) "
+                    f"exceeds reimbursement: {err} \n"
+                    f"Excluding payout and appending excess to overdraft"
                 )
                 overdrafts.append(Overdraft(transfer, slippage, period))
                 continue
@@ -204,7 +204,7 @@ def get_transfers(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:
 
         results.append(transfer)
     if overdrafts:
-        print("Additional Owed", "\n".join(map(str, overdrafts)))
+        print("Additional owed", "\n".join(map(str, overdrafts)))
     return results
 
 

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -136,7 +136,13 @@ class Transfer:
         raise ValueError(f"Invalid Token Type {self.token_type}")
 
 
+# pylint: disable=too-few-public-methods
 class Overdraft:
+    """
+    Contains the data for a solver's overdraft;
+    Namely, overdraft = |transfer - negative slippage| when the difference is negative
+    """
+
     def __init__(
         self, transfer: Transfer, slippage: SolverSlippage, period: AccountingPeriod
     ):
@@ -158,6 +164,9 @@ class Overdraft:
             f"    owed={self.eth} ETH\n"
             f")"
         )
+
+
+# pylint: enable=too-few-public-methods
 
 
 def get_transfers(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:


### PR DESCRIPTION
We have recently encountered the scenario where the slippage penalty is greater than the transaction cost reimbursement. Hence some solvers are owing at the time of reward disbursement.

This tiny change simply prints the amount owed at the time of the script. So, for example, last week would have shown this:

```
.
.
Failed to add slippage: 
Excluding from reimbursement and appending excess to overdraft
Slippage for 0xDe786877a10DBb7EBa25a4DA65aEcf47654F08ab(barn-0x) exceeds reimbursement: Invalid adjustment TransferETH(receiver=0xDe786877a10DBb7EBa25a4DA65aEcf47654F08ab, amount=0.18536027477313313) by -0.32469736678953554 
Excluding payout and appending excess to overdraft
.
.
Additional Owed Overdraft(
    solver=barn-0x(0xDe786877a10DBb7EBa25a4DA65aEcf47654F08ab),
    period=2022-06-14-to-2022-06-21,
    owed=0.13933709201640243 ETH
)
```

I have put together a follow up PR that may not actually be used, but it takes the ETH owed and fetches the equivalent amounts in COW and USD. The equivalent COW amount could be used to deduct from the COW rewards (if this is something we want to do). Either way, it was a nice experiment with external price feeds.
