### PR TITLE
Remove Request for Unusual Slippage

### DIFF
--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -126,34 +126,6 @@ class SplitSlippages:
         return sum(pos.amount_wei for pos in self.positive)
 
 
-def detect_unusual_slippage(
-    dune: DuneAPI,
-    period: AccountingPeriod,
-) -> None:
-    """Constructs query and fetches results for unusual solver"""
-    query = DuneQuery.from_environment(
-        raw_sql=slippage_query(QueryType.UNUSUAL),
-        network=Network.MAINNET,
-        name="Unusual Slippage",
-        parameters=[
-            QueryParameter.date_type("StartTime", period.start),
-            QueryParameter.date_type("EndTime", period.end),
-            QueryParameter.text_type("TxHash", "0x"),
-            QueryParameter.number_type("RelativeTolerance", 0.3),
-            QueryParameter.number_type("SignificantValue", 100),
-        ],
-    )
-    unusual_slippage = dune.fetch(query)
-    if unusual_slippage:
-        print(f"Found {len(unusual_slippage)} batch(es) with unusual slippage!")
-        pprint(unusual_slippage)
-        print("Please double check these on etherscan or with the batch token ledger:")
-        for batch in unusual_slippage:
-            print(f"https://dune.com/queries/459494?TxHash={batch['tx_hash']}")
-    else:
-        print("No unusual slippage detected!")
-
-
 def fetch_dune_slippage(
     dune: DuneAPI,
     period: AccountingPeriod,
@@ -192,5 +164,4 @@ if __name__ == "__main__":
     slippage_for_period = get_period_slippage(
         dune=dune_connection, period=accounting_period
     )
-    detect_unusual_slippage(dune=dune_connection, period=accounting_period)
     pprint(slippage_for_period)

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -11,11 +11,7 @@ from duneapi.file_io import File, write_to_csv
 from duneapi.types import DuneQuery, QueryParameter, Network, Address
 from duneapi.util import open_query
 
-from src.fetch.period_slippage import (
-    SolverSlippage,
-    get_period_slippage,
-    detect_unusual_slippage,
-)
+from src.fetch.period_slippage import SolverSlippage, get_period_slippage
 from src.fetch.reward_targets import get_vouches
 
 from src.models import AccountingPeriod
@@ -245,6 +241,13 @@ def dashboard_url(period: AccountingPeriod) -> str:
     return base + urllib.parse.quote_plus(slug + query, safe="=&?")
 
 
+def unusual_slippage_url(period: AccountingPeriod) -> str:
+    """Returns a link to unusual slippage query for period"""
+    base = "https://dune.com/queries/645559"
+    query = f"?StartTime={period.start}&EndTime={period.end}"
+    return base + urllib.parse.quote_plus(query, safe="=&?")
+
+
 if __name__ == "__main__":
     dune_connection, accounting_period = generic_script_init(
         description="Fetch Complete Reimbursement"
@@ -253,7 +256,10 @@ if __name__ == "__main__":
         f"While you are waiting, The data being compiled here can be visualized at\n"
         f"{dashboard_url(accounting_period)}\n"
     )
-    detect_unusual_slippage(dune=dune_connection, period=accounting_period)
+    print(
+        f"In particular, please double check the batches with unusual slippage: "
+        f"{unusual_slippage_url(accounting_period)}"
+    )
     transfers = consolidate_transfers(
         get_transfers(
             dune=dune_connection,


### PR DESCRIPTION
Since we can simply redirect the user to the Query URL for the period in question, it is better to send them there and wait for the query execution than it is to await the results here and polute the logs. 

This was always meant to be a temporary change and with the upcoming dashboard migration, all the queries referenced here should be in sync.