### PR TITLE
[hotfix] Drop cascade on tokenlist update

### DIFF
--- a/queries/token_list.sql
+++ b/queries/token_list.sql
@@ -1,4 +1,4 @@
-DROP MATERIALIZED VIEW IF EXISTS dune_user_generated.cow_trusted_tokens;
+DROP MATERIALIZED VIEW IF EXISTS dune_user_generated.cow_trusted_tokens CASCADE;
 CREATE MATERIALIZED VIEW dune_user_generated.cow_trusted_tokens (address) AS (
   SELECT *
   FROM (


### PR DESCRIPTION
We have recently been getting the following error message:

```
2022-06-24 20:44:51,334 WARNING duneapi.api failed with Dune API Request failed with errors
'message': 'cannot drop materialized view dune_user_generated.cow_trusted_tokens because other objects depend on it. 
Use DROP ... CASCADE to drop the dependent objects too.'
```


Which suggests there is another table depending on this list somewhere. My guess would be another user generated view that builds on top of this one. I will have to figure out what exactly is using this, but in the meantime the hint in the error message resolves the issue.
