### PR TITLE
[Temp] Manual Redirect of Recently Deactivated Solvers

### DIFF
--- a/queries/vouch_registry.sql
+++ b/queries/vouch_registry.sql
@@ -55,8 +55,8 @@ ranked_vouches as (
     *
   from (
       select * from vouches
-      union
-      select * from invalidations
+--       union
+--       select * from invalidations
     ) as _
 ),
 -- This will contain all latest active vouches,


### PR DESCRIPTION
The recent production solver's that were deactivated were also unvouched for (although the COW rewards should go to their destined COW targets). This temporary PR excludes invalidations so that the rewards for the period (2022-06-21, 2022-06-28) are directed as one would expect.

