### PR TITLE
[Temp] Manual Redirect of Recently Deactivated Solvers

### DIFF
--- a/queries/vouch_registry.sql
+++ b/queries/vouch_registry.sql
@@ -43,7 +43,7 @@ invalidations as (
         on pool = "bondingPool"
         and sender = initial_funder
   where evt_block_number <= (select * from last_block_before_timestamp)
-    and evt_block_number < 15022969 -- block of the invouch transaction
+    and evt_block_number < 15022969 -- block of the invalidation transaction
 ),
 -- At this point we have excluded all arbitrary vouches (i.e. those not from initial funders of recognized pools)
 -- This ranks (solver, pool, sender) by most recent (vouch or invalidation)

--- a/queries/vouch_registry.sql
+++ b/queries/vouch_registry.sql
@@ -43,6 +43,7 @@ invalidations as (
         on pool = "bondingPool"
         and sender = initial_funder
   where evt_block_number <= (select * from last_block_before_timestamp)
+    and evt_block_number < 15022969 -- block of the invouch transaction
 ),
 -- At this point we have excluded all arbitrary vouches (i.e. those not from initial funders of recognized pools)
 -- This ranks (solver, pool, sender) by most recent (vouch or invalidation)

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,60 @@
+"""Temporary constant for merging transfers and slippages."""
+# This mapping is in the form name -> (OldSolver, NewSolver)
+# Created manually with this dune query:
+# select
+#     concat(environment, '-', name) as solver_name,
+#     concat('0x', encode(address, 'hex')) as address,
+#     active
+# from gnosis_protocol_v2."view_solvers"
+# where environment = 'prod'
+# order by name, active
+MERGE_DATA = {
+    "prod-Otex": (
+        "0x6fa201c3aff9f1e4897ed14c7326cf27548d9c35",
+        "0xc9ec550bea1c64d779124b23a26292cc223327b6",
+    ),
+    "prod-Baseline": (
+        "0x833f076d182123ca8dde2743045ea02957bd61ef",
+        "0x3cee8c7d9b5c8f225a8c36e7d3514e1860309651",
+    ),
+    "prod-Naive": (
+        "0x340185114f9d2617dc4c16088d0375d09fee9186",
+        "0x7a0a8890d71a4834285efdc1d18bb3828e765c6a",
+    ),
+    "prod-DexCowAgg": (
+        "0x2d15894fac906386ff7f4bd07fceac43fcf80c73",
+        "0x6d1247b8acf4dfd5ff8cfd6c47077ddc43d4500e",
+    ),
+    "prod-ParaSwap": (
+        "0x15f4c337122ec23859ec73bec00ab38445e45304",
+        "0xe9ae2d792f981c53ea7f6493a17abf5b2a45a86b",
+    ),
+    "prod-Legacy": (
+        "0xa6ddbd0de6b310819b49f680f65871bee85f517e",
+        "0x0e8f282ce027f3ac83980e6020a2463f4c841264",
+    ),
+    "prod-PLM": (
+        "0xe58c68679e7aab8ef83bf37e88b18eb1f6e30e22",
+        "0x149d0f9282333681ee41d30589824b2798e9fb47",
+    ),
+    "prod-QuasiModo": (
+        "0x77ec2a722c2393d3fd64617bbaf1499c713e616b",
+        "0x731a0a8ab2c6fcad841e82d06668af7f18e34970",
+    ),
+    "prod-BalancerSOR": (
+        "0xa97def4fbcba3b646dd169bc2eee40f0f3fe7771",
+        "0xf7995b6b051166ea52218c37b8d03a2a6bbef3da",
+    ),
+    "prod-0x": (
+        "0xe92f359e6f05564849afa933ce8f62b8007a1d5d",
+        "0xda869be4adea17ad39e1dfece1bc92c02491504f",
+    ),
+    "prod-MIP": (
+        "0xf2d21ad3c88170d4ae52bbbeba80cb6078d276f4",
+        "0xe8ff24ec26bd46e0140d1824da44efad2a0920b5",
+    ),
+    "prod-1inch": (
+        "0xde1c59bc25d806ad9ddcbe246c4b5e5505645718",
+        "0xb20b86c4e6deeb432a22d773a221898bbbd03036",
+    ),
+}

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -87,6 +87,17 @@ class SolverSlippage:
             amount_wei=int(obj["eth_slippage_wei"]),
         )
 
+    def force_merge(self, other: SolverSlippage, target: Address) -> SolverSlippage:
+        """Merges two solver slippages as long as their names are the same."""
+        assert (
+            self.solver_name == other.solver_name
+        ), "Can only merge solver with same name"
+        return SolverSlippage(
+            solver_name=self.solver_name,
+            solver_address=target,
+            amount_wei=self.amount_wei + other.amount_wei,
+        )
+
 
 @dataclass
 class SplitSlippages:

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -138,8 +138,8 @@ class SplitSlippages:
             indexed_slippage[target] = new_solver_slippage.merge(
                 old_solver_slippage, target
             )
-        for row in indexed_slippage.values():
-            results.append(slippage=SolverSlippage.from_dict(row))
+        for slippage in indexed_slippage.values():
+            results.append(slippage)
         return results
 
     def append(self, slippage: SolverSlippage) -> None:

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -123,6 +123,7 @@ class SplitSlippages:
     def from_data_set(cls, data_set: list[dict[str, str]]) -> SplitSlippages:
         """Constructs an object based on provided dataset"""
         results = cls()
+        # Intercept the constructor to merge results.
         all_slippages = [SolverSlippage.from_dict(row) for row in data_set]
         indexed_slippage = index_by(all_slippages, "solver_address")
         for name, (old, new) in MERGE_DATA.items():

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -87,7 +87,7 @@ class SolverSlippage:
             amount_wei=int(obj["eth_slippage_wei"]),
         )
 
-    def force_merge(self, other: SolverSlippage, target: Address) -> SolverSlippage:
+    def merge(self, other: SolverSlippage, target: Address) -> SolverSlippage:
         """Merges two solver slippages as long as their names are the same."""
         assert (
             self.solver_name == other.solver_name
@@ -97,6 +97,13 @@ class SolverSlippage:
             solver_address=target,
             amount_wei=self.amount_wei + other.amount_wei,
         )
+
+    @classmethod
+    def zero(cls, address: str | Address, name: str) -> SolverSlippage:
+        """Used as default instance"""
+        if isinstance(address, str):
+            address = Address(address)
+        return cls(solver_name=name, solver_address=address, amount_wei=0)
 
 
 @dataclass

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -12,6 +12,7 @@ from duneapi.file_io import File, write_to_csv
 from duneapi.types import DuneQuery, QueryParameter, Network, Address
 from duneapi.util import open_query
 
+from src.constants import MERGE_DATA
 from src.fetch.period_slippage import SolverSlippage, get_period_slippage
 from src.fetch.reward_targets import get_vouches, Vouch
 
@@ -143,6 +144,26 @@ class Transfer:
                 token_type=self.token_type,
                 token_address=self.token_address,
                 receiver=self.receiver,
+                amount=self.amount + other.amount,
+            )
+        raise ValueError(
+            f"Can't merge tokens {self}, {other}. "
+            f"Requirements met {merge_requirements}"
+        )
+
+    def force_merge(self, other: Transfer, target: Address) -> Transfer:
+        """
+        Merge two transfers even if recipient is not equal
+        """
+        merge_requirements = [
+            self.token_type == other.token_type,
+            self.token_address == other.token_address,
+        ]
+        if all(merge_requirements):
+            return Transfer(
+                token_type=self.token_type,
+                token_address=self.token_address,
+                receiver=target,
                 amount=self.amount + other.amount,
             )
         raise ValueError(
@@ -311,76 +332,25 @@ def get_transfers(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:
         ],
     )
     reimbursements_and_rewards = [Transfer.from_dict(t) for t in dune.fetch(query)]
-    # TODO - Here we could also merge all the transfers with the merge data from below!
     split_transfers = SplitTransfers(period, reimbursements_and_rewards)
-
-    negative_slippage = get_period_slippage(dune, period).negative
-
-    # This mapping is in the form name -> (OldSolver, NewSolver)
-    merge_data = {
-        "prod-Otex": (
-            "0x6fa201c3aff9f1e4897ed14c7326cf27548d9c35",
-            "0xc9ec550bea1c64d779124b23a26292cc223327b6",
-        ),
-        "prod-Baseline": (
-            "0x833f076d182123ca8dde2743045ea02957bd61ef",
-            "0x3cee8c7d9b5c8f225a8c36e7d3514e1860309651",
-        ),
-        "prod-Naive": (
-            "0x340185114f9d2617dc4c16088d0375d09fee9186",
-            "0x7a0a8890d71a4834285efdc1d18bb3828e765c6a",
-        ),
-        "prod-DexCowAgg": (
-            "0x2d15894fac906386ff7f4bd07fceac43fcf80c73",
-            "0x6d1247b8acf4dfd5ff8cfd6c47077ddc43d4500e",
-        ),
-        "prod-ParaSwap": (
-            "0x15f4c337122ec23859ec73bec00ab38445e45304",
-            "0xe9ae2d792f981c53ea7f6493a17abf5b2a45a86b",
-        ),
-        "prod-Legacy": (
-            "0xa6ddbd0de6b310819b49f680f65871bee85f517e",
-            "0x0e8f282ce027f3ac83980e6020a2463f4c841264",
-        ),
-        "prod-PLM": (
-            "0xe58c68679e7aab8ef83bf37e88b18eb1f6e30e22",
-            "0x149d0f9282333681ee41d30589824b2798e9fb47",
-        ),
-        "prod-QuasiModo": (
-            "0x77ec2a722c2393d3fd64617bbaf1499c713e616b",
-            "0x731a0a8ab2c6fcad841e82d06668af7f18e34970",
-        ),
-        "prod-BalancerSOR": (
-            "0xa97def4fbcba3b646dd169bc2eee40f0f3fe7771",
-            "0xf7995b6b051166ea52218c37b8d03a2a6bbef3da",
-        ),
-        "prod-0x": (
-            "0xe92f359e6f05564849afa933ce8f62b8007a1d5d",
-            "0xda869be4adea17ad39e1dfece1bc92c02491504f",
-        ),
-        "prod-MIP": (
-            "0xf2d21ad3c88170d4ae52bbbeba80cb6078d276f4",
-            "0xe8ff24ec26bd46e0140d1824da44efad2a0920b5",
-        ),
-        "prod-1inch": (
-            "0xde1c59bc25d806ad9ddcbe246c4b5e5505645718",
-            "0xb20b86c4e6deeb432a22d773a221898bbbd03036",
-        ),
-    }
-    indexed_slippage = index_by(negative_slippage, "solver_address")
-    for name, (old, new) in merge_data.items():
+    indexed_native_transfers = index_by(split_transfers.unprocessed_native, "receiver")
+    for _, (old, new) in MERGE_DATA.items():
         # Remove the old one.
         old_address, target = Address(old), Address(new)
-        old_solver_slippage: SolverSlippage = indexed_slippage.pop(
-            old_address, SolverSlippage.zero(address=old_address, name=name)
+        old_transfer: Transfer = indexed_native_transfers.pop(
+            old_address, Transfer.native(receiver=old_address, amount=0)
         )
-        new_solver_slippage: SolverSlippage = indexed_slippage.pop(
-            target, SolverSlippage.zero(address=target, name=name)
+        new_transfer: Transfer = indexed_native_transfers.pop(
+            target, Transfer.native(receiver=target, amount=0)
         )
         # Merge old with new.
-        indexed_slippage[target] = new_solver_slippage.merge(
-            old_solver_slippage, target
+        indexed_native_transfers[target] = new_transfer.force_merge(
+            old_transfer, target
         )
+    # Set the unprocessed native transfers to be the merged results.
+    split_transfers.unprocessed_native = list(indexed_native_transfers.values())
+
+    negative_slippage = get_period_slippage(dune, period).negative
 
     return split_transfers.process(
         indexed_slippage=index_by(negative_slippage, "solver_address"),

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -314,28 +314,70 @@ def get_transfers(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:
     split_transfers = SplitTransfers(period, reimbursements_and_rewards)
 
     negative_slippage = get_period_slippage(dune, period).negative
+
+    # This mapping is in the form name -> (OldSolver, NewSolver)
     merge_data = {
-        "0x6fa201c3aff9f1e4897ed14c7326cf27548d9c35": "0xc9ec550bea1c64d779124b23a26292cc223327b6",
-        "0x833f076d182123ca8dde2743045ea02957bd61ef": "0x3cee8c7d9b5c8f225a8c36e7d3514e1860309651",
-        "0x340185114f9d2617dc4c16088d0375d09fee9186": "0x7a0a8890d71a4834285efdc1d18bb3828e765c6a",
-        "0x2d15894fac906386ff7f4bd07fceac43fcf80c73": "0x6d1247b8acf4dfd5ff8cfd6c47077ddc43d4500e",
-        "0x15f4c337122ec23859ec73bec00ab38445e45304": "0xe9ae2d792f981c53ea7f6493a17abf5b2a45a86b",
-        "0xa6ddbd0de6b310819b49f680f65871bee85f517e": "0x0e8f282ce027f3ac83980e6020a2463f4c841264",
-        "0xe58c68679e7aab8ef83bf37e88b18eb1f6e30e22": "0x149d0f9282333681ee41d30589824b2798e9fb47",
-        "0x77ec2a722c2393d3fd64617bbaf1499c713e616b": "0x731a0a8ab2c6fcad841e82d06668af7f18e34970",
-        "0xa97def4fbcba3b646dd169bc2eee40f0f3fe7771": "0xf7995b6b051166ea52218c37b8d03a2a6bbef3da",
-        "0xe92f359e6f05564849afa933ce8f62b8007a1d5d": "0xda869be4adea17ad39e1dfece1bc92c02491504f",
-        "0xf2d21ad3c88170d4ae52bbbeba80cb6078d276f4": "0xe8ff24ec26bd46e0140d1824da44efad2a0920b5",
-        "0xde1c59bc25d806ad9ddcbe246c4b5e5505645718": "0xb20b86c4e6deeb432a22d773a221898bbbd03036",
+        "prod-Otex": (
+            "0x6fa201c3aff9f1e4897ed14c7326cf27548d9c35",
+            "0xc9ec550bea1c64d779124b23a26292cc223327b6",
+        ),
+        "prod-Baseline": (
+            "0x833f076d182123ca8dde2743045ea02957bd61ef",
+            "0x3cee8c7d9b5c8f225a8c36e7d3514e1860309651",
+        ),
+        "prod-Naive": (
+            "0x340185114f9d2617dc4c16088d0375d09fee9186",
+            "0x7a0a8890d71a4834285efdc1d18bb3828e765c6a",
+        ),
+        "prod-DexCowAgg": (
+            "0x2d15894fac906386ff7f4bd07fceac43fcf80c73",
+            "0x6d1247b8acf4dfd5ff8cfd6c47077ddc43d4500e",
+        ),
+        "prod-ParaSwap": (
+            "0x15f4c337122ec23859ec73bec00ab38445e45304",
+            "0xe9ae2d792f981c53ea7f6493a17abf5b2a45a86b",
+        ),
+        "prod-Legacy": (
+            "0xa6ddbd0de6b310819b49f680f65871bee85f517e",
+            "0x0e8f282ce027f3ac83980e6020a2463f4c841264",
+        ),
+        "prod-PLM": (
+            "0xe58c68679e7aab8ef83bf37e88b18eb1f6e30e22",
+            "0x149d0f9282333681ee41d30589824b2798e9fb47",
+        ),
+        "prod-QuasiModo": (
+            "0x77ec2a722c2393d3fd64617bbaf1499c713e616b",
+            "0x731a0a8ab2c6fcad841e82d06668af7f18e34970",
+        ),
+        "prod-BalancerSOR": (
+            "0xa97def4fbcba3b646dd169bc2eee40f0f3fe7771",
+            "0xf7995b6b051166ea52218c37b8d03a2a6bbef3da",
+        ),
+        "prod-0x": (
+            "0xe92f359e6f05564849afa933ce8f62b8007a1d5d",
+            "0xda869be4adea17ad39e1dfece1bc92c02491504f",
+        ),
+        "prod-MIP": (
+            "0xf2d21ad3c88170d4ae52bbbeba80cb6078d276f4",
+            "0xe8ff24ec26bd46e0140d1824da44efad2a0920b5",
+        ),
+        "prod-1inch": (
+            "0xde1c59bc25d806ad9ddcbe246c4b5e5505645718",
+            "0xb20b86c4e6deeb432a22d773a221898bbbd03036",
+        ),
     }
     indexed_slippage = index_by(negative_slippage, "solver_address")
-    for old, new in merge_data.items():
+    for name, (old, new) in merge_data.items():
         # Remove the old one.
-        old_solver_slippage: SolverSlippage = indexed_slippage.pop(Address(old))
-        target = Address(new)
-        new_solver_slippage: SolverSlippage = indexed_slippage.pop(target)
+        old_address, target = Address(old), Address(new)
+        old_solver_slippage: SolverSlippage = indexed_slippage.pop(
+            old_address, SolverSlippage.zero(address=old_address, name=name)
+        )
+        new_solver_slippage: SolverSlippage = indexed_slippage.pop(
+            target, SolverSlippage.zero(address=target, name=name)
+        )
         # Merge old with new.
-        indexed_slippage[target] = new_solver_slippage.force_merge(
+        indexed_slippage[target] = new_solver_slippage.merge(
             old_solver_slippage, target
         )
 

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -311,6 +311,7 @@ def get_transfers(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:
         ],
     )
     reimbursements_and_rewards = [Transfer.from_dict(t) for t in dune.fetch(query)]
+    # TODO - Here we could also merge all the transfers with the merge data from below!
     split_transfers = SplitTransfers(period, reimbursements_and_rewards)
 
     negative_slippage = get_period_slippage(dune, period).negative

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -314,6 +314,30 @@ def get_transfers(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:
     split_transfers = SplitTransfers(period, reimbursements_and_rewards)
 
     negative_slippage = get_period_slippage(dune, period).negative
+    merge_data = {
+        "0x6fa201c3aff9f1e4897ed14c7326cf27548d9c35": "0xc9ec550bea1c64d779124b23a26292cc223327b6",
+        "0x833f076d182123ca8dde2743045ea02957bd61ef": "0x3cee8c7d9b5c8f225a8c36e7d3514e1860309651",
+        "0x340185114f9d2617dc4c16088d0375d09fee9186": "0x7a0a8890d71a4834285efdc1d18bb3828e765c6a",
+        "0x2d15894fac906386ff7f4bd07fceac43fcf80c73": "0x6d1247b8acf4dfd5ff8cfd6c47077ddc43d4500e",
+        "0x15f4c337122ec23859ec73bec00ab38445e45304": "0xe9ae2d792f981c53ea7f6493a17abf5b2a45a86b",
+        "0xa6ddbd0de6b310819b49f680f65871bee85f517e": "0x0e8f282ce027f3ac83980e6020a2463f4c841264",
+        "0xe58c68679e7aab8ef83bf37e88b18eb1f6e30e22": "0x149d0f9282333681ee41d30589824b2798e9fb47",
+        "0x77ec2a722c2393d3fd64617bbaf1499c713e616b": "0x731a0a8ab2c6fcad841e82d06668af7f18e34970",
+        "0xa97def4fbcba3b646dd169bc2eee40f0f3fe7771": "0xf7995b6b051166ea52218c37b8d03a2a6bbef3da",
+        "0xe92f359e6f05564849afa933ce8f62b8007a1d5d": "0xda869be4adea17ad39e1dfece1bc92c02491504f",
+        "0xf2d21ad3c88170d4ae52bbbeba80cb6078d276f4": "0xe8ff24ec26bd46e0140d1824da44efad2a0920b5",
+        "0xde1c59bc25d806ad9ddcbe246c4b5e5505645718": "0xb20b86c4e6deeb432a22d773a221898bbbd03036",
+    }
+    indexed_slippage = index_by(negative_slippage, "solver_address")
+    for old, new in merge_data.items():
+        # Remove the old one.
+        old_solver_slippage: SolverSlippage = indexed_slippage.pop(Address(old))
+        target = Address(new)
+        new_solver_slippage: SolverSlippage = indexed_slippage.pop(target)
+        # Merge old with new.
+        indexed_slippage[target] = new_solver_slippage.force_merge(
+            old_solver_slippage, target
+        )
 
     return split_transfers.process(
         indexed_slippage=index_by(negative_slippage, "solver_address"),

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -344,9 +344,9 @@ def get_transfers(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:
             target, Transfer.native(receiver=target, amount=0)
         )
         # Merge old with new.
-        indexed_native_transfers[target] = new_transfer.force_merge(
-            old_transfer, target
-        )
+        merged_transfer = new_transfer.force_merge(old_transfer, target)
+        if merged_transfer.amount > 0:
+            indexed_native_transfers[target] = merged_transfer
     # Set the unprocessed native transfers to be the merged results.
     split_transfers.unprocessed_native = list(indexed_native_transfers.values())
 


### PR DESCRIPTION
The recent production solver's that were deactivated were also unvouched for (although the COW rewards should go to their destined COW targets). This temporary PR excludes invalidations so that the rewards for the period (2022-06-21, 2022-06-28) are directed as one would expect.


@nlordell  - Since you are oncall you will want to run this week's payout from this branch!

This is related to the following [slack message](https://cowservices.slack.com/archives/C036L44JY77/p1656084593327159?thread_ts=1656084138.312779&cid=C036L44JY77)
