### PR TITLE
Slim Dashboard Migration

### DIFF
--- a/dashboards/solver-rewards-accounting/_config.json
+++ b/dashboards/solver-rewards-accounting/_config.json
@@ -1,0 +1,148 @@
+{
+  "meta": {
+    "name": "Solver Rewards Accounting",
+    "slug": "solver-rewards-accounting",
+    "user": "gnosis.protocol",
+    "query_path": "./dashboards/solver-rewards-accounting"
+  },
+  "queries": [
+    {
+      "id": 674947,
+      "name": "Vouch Registry",
+      "description": "",
+      "requires": "./queries/vouch_registry.sql",
+      "query_file": "vouches.sql",
+      "network": "Ethereum Mainnet",
+      "parameters": [
+        {
+          "key": "EndTime",
+          "value": "2022-06-28 00:00:00",
+          "type": "datetime"
+        },
+        {
+          "key": "BondingPoolData",
+          "value": "('\\x8353713b6D2F728Ed763a04B886B16aAD2b16eBD'::bytea, 'Gnosis', '\\x6c642cafcbd9d8383250bb25f67ae409147f78b2'::bytea),('\\x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6'::bytea, 'CoW Services', '\\x423cec87f19f0778f549846e0801ee267a917935'::bytea)",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "id": 448457,
+      "name": "Total Solver Rewards",
+      "description": "",
+      "query_file": "period-totals.sql",
+      "network": "Ethereum Mainnet",
+      "parameters": [
+        {
+          "key": "EndTime",
+          "value": "2022-06-28 00:00:00",
+          "type": "datetime"
+        },
+        {
+          "key": "PerBatchReward",
+          "value": 50,
+          "type": "number"
+        },
+        {
+          "key": "PerTradeReward",
+          "value": 35,
+          "type": "number"
+        },
+        {
+          "key": "StartTime",
+          "value": "2022-06-21 00:00:00",
+          "type": "datetime"
+        }
+      ]
+    },
+    {
+      "id": 446799,
+      "name": "Solver Execution Costs",
+      "description": "",
+      "query_file": "solver-totals.sql",
+      "network": "Ethereum Mainnet",
+      "parameters": [
+        {
+          "key": "EndTime",
+          "value": "2022-06-28 00:00:00",
+          "type": "datetime"
+        },
+        {
+          "key": "PerBatchReward",
+          "value": 50,
+          "type": "number"
+        },
+        {
+          "key": "PerTradeReward",
+          "value": 35,
+          "type": "number"
+        },
+        {
+          "key": "StartTime",
+          "value": "2022-06-21 00:00:00",
+          "type": "datetime"
+        }
+      ]
+    },
+    {
+      "id": 645559,
+      "name": "Unusual Slippage",
+      "description": "",
+      "requires": "./queries/period_slippage.sql",
+      "query_file": "unusual-slippage.sql",
+      "network": "Ethereum Mainnet",
+      "parameters": [
+        {
+          "key": "EndTime",
+          "value": "2022-06-28 00:00:00",
+          "type": "datetime"
+        },
+        {
+          "key": "RelativeSlippageTolerance",
+          "value": 0.3,
+          "type": "number"
+        },
+        {
+          "key": "SignificantSlippageValue",
+          "value": 100,
+          "type": "number"
+        },
+        {
+          "key": "StartTime",
+          "value": "2022-06-21 00:00:00",
+          "type": "datetime"
+        },
+        {
+          "key": "TxHash",
+          "value": "0x",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "id": 970879,
+      "name": "Solver Slippage for Period",
+      "description": "",
+      "requires": "./queries/period_slippage.sql",
+      "query_file": "solver-slippage.sql",
+      "network": "Ethereum Mainnet",
+      "parameters": [
+        {
+          "key": "EndTime",
+          "value": "2022-06-28 00:00:00",
+          "type": "datetime"
+        },
+        {
+          "key": "StartTime",
+          "value": "2022-06-21 00:00:00",
+          "type": "datetime"
+        },
+        {
+          "key": "TxHash",
+          "value": "0x",
+          "type": "text"
+        }
+      ]
+    }
+  ]
+}

--- a/dashboards/solver-rewards-accounting/solver-slippage.sql
+++ b/dashboards/solver-rewards-accounting/solver-slippage.sql
@@ -1,0 +1,7 @@
+select
+    solver_address, 
+    solver_name, 
+    usd_value, 
+    eth_slippage_wei / 10^18 eth_slippage
+from results
+order by usd_value

--- a/dashboards/solver-rewards-accounting/solver-totals.sql
+++ b/dashboards/solver-rewards-accounting/solver-totals.sql
@@ -1,0 +1,39 @@
+with
+solver_data as (
+    select
+        solver_address as solver,
+        environment,
+        name,
+        solver_name,
+        sum(gas_price_gwei * gas_used) / 10 ^ 9 as execution_cost_eth,
+        count(*) as batches_settled,
+        sum(num_trades) as num_trades
+    from gnosis_protocol_v2."batches"
+    join gnosis_protocol_v2."view_solvers"
+        on solver_address = address
+    where block_time >= '{{StartTime}}'
+    and block_time < '{{EndTime}}'
+    group by solver,solver_name, environment, name
+    order by execution_cost_eth desc
+),
+
+per_solver_results as (
+    select
+        concat('0x', encode(solver, 'hex')) as solver_address,
+        environment,
+        name,
+        execution_cost_eth,
+        batches_settled,
+        num_trades
+    from solver_data sd
+)
+
+-- -- END SOLVER REWARDS
+select
+    solver_address, 
+    concat(environment, '-', name) as solver_name, 
+    execution_cost_eth, 
+    batches_settled,
+    num_trades,
+    batches_settled * '{{PerBatchReward}}' + num_trades * '{{PerTradeReward}}' as cow_reward
+from per_solver_results

--- a/dashboards/solver-rewards-accounting/unusual-slippage.sql
+++ b/dashboards/solver-rewards-accounting/unusual-slippage.sql
@@ -1,0 +1,13 @@
+select
+    block_time,
+    rpt.solver_name,
+    concat('0x', encode(rpt.tx_hash, 'hex')) as tx_hash,
+    usd_value,
+    batch_value,
+    100 * usd_value / batch_value as relative_slippage
+from results_per_tx rpt
+join gnosis_protocol_v2."batches" b
+    on rpt.tx_hash = b.tx_hash
+where abs(usd_value) > '{{SignificantSlippageValue}}'
+and 100.0 * abs(usd_value) / batch_value > '{{RelativeSlippageTolerance}}'
+order by relative_slippage

--- a/dashboards/solver-rewards-accounting/vouches.sql
+++ b/dashboards/solver-rewards-accounting/vouches.sql
@@ -1,0 +1,11 @@
+select
+ concat('0x', encode(solver, 'hex')) as solver,
+ concat(environment, '-', s.name) as solver_name,
+ concat('0x', encode(reward_target, 'hex')) as reward_target,
+ concat('0x', encode(vv.pool, 'hex')) as bonding_pool,
+ bp.name as pool_name
+from valid_vouches vv
+join gnosis_protocol_v2."view_solvers" s
+    on address = solver
+join bonding_pools bp
+    on vv.pool = bp.pool

--- a/queries/vouch_registry.sql
+++ b/queries/vouch_registry.sql
@@ -82,5 +82,3 @@ valid_vouches as (
   from current_active_vouches
   where time_rank = 1
 )
-select *
-from valid_vouches

--- a/src/dashboard/common.py
+++ b/src/dashboard/common.py
@@ -1,0 +1,20 @@
+"""Common method for initializing setup for scripts"""
+import argparse
+
+from duneapi.api import DuneAPI
+
+
+def arg_parse(description: str) -> tuple[DuneAPI, argparse.Namespace]:
+    """
+    1. Parses command line arguments
+    2. Establishes dune connection and
+    returns this info
+    """
+    parser = argparse.ArgumentParser(description)
+    parser.add_argument(
+        "--dashboard-slug",
+        type=str,
+        required=True,
+        help="The hyphenated last part of the dashboard URL",
+    )
+    return DuneAPI.new_from_environment(), parser.parse_args()

--- a/src/dashboard/load.py
+++ b/src/dashboard/load.py
@@ -1,0 +1,11 @@
+"""
+Script to fetch/load dashboard into a config file.
+Essentially scraping SQL from Dune
+"""
+from duneapi.dashboard import DuneDashboard
+
+from src.dashboard.common import arg_parse
+
+if __name__ == "__main__":
+    dune_connection, args = arg_parse(description="Load Dashboard")
+    dashboard = DuneDashboard.from_dune(dune_connection, args.dashboard_slug)

--- a/src/dashboard/save.py
+++ b/src/dashboard/save.py
@@ -1,0 +1,15 @@
+"""
+Script to load dashboard from configuration file and update.
+"""
+
+from duneapi.dashboard import DuneDashboard
+from src.dashboard.common import arg_parse
+
+if __name__ == "__main__":
+    dune_connection, args = arg_parse(description="Save Dashboard")
+
+    dashboard = DuneDashboard.from_file(
+        dune_connection, f"dashboards/{args.dashboard_slug}/_config.json"
+    )
+    dashboard.update()
+    print("Updated", dashboard)

--- a/src/fetch/period_totals.py
+++ b/src/fetch/period_totals.py
@@ -27,7 +27,7 @@ def get_period_totals(dune: DuneAPI, period: AccountingPeriod) -> PeriodTotals:
     Fetches & Returns Dune Results for accounting period totals.
     """
     query = DuneQuery.from_environment(
-        raw_sql=open_query("./queries/period_totals.sql"),
+        raw_sql=open_query("./dashboards/period-totals.sql"),
         network=Network.MAINNET,
         name="Accounting Period Totals",
         parameters=[

--- a/src/fetch/reward_targets.py
+++ b/src/fetch/reward_targets.py
@@ -47,7 +47,10 @@ def get_vouches(dune: DuneAPI, end_time: datetime) -> dict[Address, Vouch]:
     """
     pool_values = ",\n           ".join(RECOGNIZED_BONDING_POOLS)
     query = DuneQuery.from_environment(
-        raw_sql=open_query("./queries/vouch_registry.sql"),
+        raw_sql="\n".join([
+            open_query("./queries/vouch_registry.sql"),
+            "select * from vouches"
+        ]),
         network=Network.MAINNET,
         name="Solver Reward Targets",
         parameters=[

--- a/src/fetch/reward_targets.py
+++ b/src/fetch/reward_targets.py
@@ -49,7 +49,7 @@ def get_vouches(dune: DuneAPI, end_time: datetime) -> dict[Address, Vouch]:
     query = DuneQuery.from_environment(
         raw_sql="\n".join([
             open_query("./queries/vouch_registry.sql"),
-            "select * from vouches"
+            "select * from valid_vouches"
         ]),
         network=Network.MAINNET,
         name="Solver Reward Targets",

--- a/src/fetch/reward_targets.py
+++ b/src/fetch/reward_targets.py
@@ -47,10 +47,9 @@ def get_vouches(dune: DuneAPI, end_time: datetime) -> dict[Address, Vouch]:
     """
     pool_values = ",\n           ".join(RECOGNIZED_BONDING_POOLS)
     query = DuneQuery.from_environment(
-        raw_sql="\n".join([
-            open_query("./queries/vouch_registry.sql"),
-            "select * from valid_vouches"
-        ]),
+        raw_sql="\n".join(
+            [open_query("./queries/vouch_registry.sql"), "select * from valid_vouches"]
+        ),
         network=Network.MAINNET,
         name="Solver Reward Targets",
         parameters=[

--- a/tests/queries/test_vouch_registry.py
+++ b/tests/queries/test_vouch_registry.py
@@ -87,10 +87,9 @@ def invalidate_vouch(
 
 def query_for(date_str: str, bonding_pools: list[str]) -> DuneQuery:
     return DuneQuery(
-        raw_sql="\n".join([
-            open_query("./queries/vouch_registry.sql"),
-            "select * from valid_vouches"
-        ]),
+        raw_sql="\n".join(
+            [open_query("./queries/vouch_registry.sql"), "select * from valid_vouches"]
+        ),
         network=Network.MAINNET,
         name="Solver Reward Targets",
         parameters=[

--- a/tests/queries/test_vouch_registry.py
+++ b/tests/queries/test_vouch_registry.py
@@ -87,7 +87,10 @@ def invalidate_vouch(
 
 def query_for(date_str: str, bonding_pools: list[str]) -> DuneQuery:
     return DuneQuery(
-        raw_sql=open_query("./queries/vouch_registry.sql"),
+        raw_sql="\n".join([
+            open_query("./queries/vouch_registry.sql"),
+            "select * from vouches"
+        ]),
         network=Network.MAINNET,
         name="Solver Reward Targets",
         parameters=[

--- a/tests/queries/test_vouch_registry.py
+++ b/tests/queries/test_vouch_registry.py
@@ -89,7 +89,7 @@ def query_for(date_str: str, bonding_pools: list[str]) -> DuneQuery:
     return DuneQuery(
         raw_sql="\n".join([
             open_query("./queries/vouch_registry.sql"),
-            "select * from vouches"
+            "select * from valid_vouches"
         ]),
         network=Network.MAINNET,
         name="Solver Reward Targets",


### PR DESCRIPTION
In comparison with this alternative solution #54 (that basically requires a refactor of the entire project), we have settled on showing all the data that is required to reconstruct the results of the solver rewards script.

This PR pulls the query content for the main solver accounting dashboard: 
https://dune.xyz/gnosis.protocol/solver-rewards-accounting

and links it to the script queries in a way that, whenever a script query is updated, we can "sync" the dashboard with the same query using the following script:

```sh
python -m src.dashboard.save --dashboard-slug=solver-rewards-accounting
```

which will result in the following logs


```
Updated Dashboard "Solver Rewards Accounting": https://dune.xyz/gnosis.protocol/solver-rewards-accounting
Queries:
  Vouch Registry: https://dune.xyz/queries/674947
  Total Solver Rewards: https://dune.xyz/queries/448457
  Solver Execution Costs: https://dune.xyz/queries/446799
  Unusual Slippage: https://dune.xyz/queries/645559
  Solver Slippage for Period: https://dune.xyz/queries/970879
```