### PR TITLE
Update Dashboard Link and Report Total Slippage Deducted

### DIFF
--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -189,7 +189,7 @@ class SplitTransfers:
     def _process_native_transfers(
         self, indexed_slippage: dict[Address, SolverSlippage]
     ) -> float:
-        penalty_total = 0
+        penalty_total = 0.0
         while self.unprocessed_native:
             transfer = self.unprocessed_native.pop(0)
             solver = transfer.receiver

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -188,7 +188,8 @@ class SplitTransfers:
 
     def _process_native_transfers(
         self, indexed_slippage: dict[Address, SolverSlippage]
-    ) -> None:
+    ) -> float:
+        penalty_total = 0
         while self.unprocessed_native:
             transfer = self.unprocessed_native.pop(0)
             solver = transfer.receiver
@@ -196,6 +197,7 @@ class SplitTransfers:
             if slippage is not None:
                 try:
                     transfer.add_slippage(slippage)
+                    penalty_total += slippage.amount_wei / 10**18
                 except ValueError as err:
                     name, address = slippage.solver_name, slippage.solver_address
                     print(
@@ -205,8 +207,11 @@ class SplitTransfers:
                     self.overdrafts[solver] = Overdraft.from_objects(
                         transfer, slippage, self.period
                     )
+                    # Deduct entire transfer value.
+                    penalty_total += transfer.amount
                     continue
             self.eth_transfers.append(transfer)
+        return penalty_total
 
     def _process_token_transfers(self, cow_redirects: dict[Address, Vouch]) -> None:
         price_day = self.period.end - timedelta(days=1)
@@ -252,8 +257,9 @@ class SplitTransfers:
         so that and overdraft from slippage can be carried over and deducted from
         the COW rewards.
         """
-        self._process_native_transfers(indexed_slippage)
+        penalty_total = self._process_native_transfers(indexed_slippage)
         self._process_token_transfers(cow_redirects)
+        print(f"Total Slippage deducted {penalty_total}")
         if self.overdrafts:
             print("Additional owed", "\n".join(map(str, self.overdrafts.values())))
         return self.cow_transfers + self.eth_transfers
@@ -344,7 +350,7 @@ def consolidate_transfers(transfer_list: list[Transfer]) -> list[Transfer]:
 def dashboard_url(period: AccountingPeriod) -> str:
     """Constructs Solver Accounting Dashboard URL for Period"""
     base = "https://dune.com/gnosis.protocol/"
-    slug = "CoW-Protocol:-Solver-Accounting"
+    slug = "solver-rewards-accounting"
     query = f"?StartTime={period.start}&EndTime={period.end}"
     return base + urllib.parse.quote_plus(slug + query, safe="=&?")
 

--- a/tests/unit/test_data_utils.py
+++ b/tests/unit/test_data_utils.py
@@ -14,7 +14,7 @@ class DummyDataClass:
 
 class TestDataUtils(unittest.TestCase):
     def test_dashboard_url(self):
-        expected = "https://dune.com/gnosis.protocol/CoW-Protocol%3A-Solver-Accounting?StartTime=2022-05-31+00%3A00%3A00&EndTime=2022-06-07+00%3A00%3A00"
+        expected = "https://dune.com/gnosis.protocol/solver-rewards-accounting?StartTime=2022-05-31+00%3A00%3A00&EndTime=2022-06-07+00%3A00%3A00"
         result = dashboard_url(AccountingPeriod("2022-05-31"))
         self.assertEqual(
             expected,


### PR DESCRIPTION
Recent PR #54 added the "new" dashboard for which we now link to.

Additionally we report on slippage, because for example for the accounting period `2022-06-21` I look at this part of the dashboard: saying there was 52 spent

![Screenshot 2022-06-28 at 2 56 38 PM](https://user-images.githubusercontent.com/11778116/176183926-0f4c5433-fa6a-4860-8f10-9d327e38c841.png)

and this output log saying that 44 is being sent out. 

<img width="520" alt="Screenshot 2022-06-28 at 2 57 34 PM" src="https://user-images.githubusercontent.com/11778116/176184135-48b7e419-1807-4e27-aae8-2770310b5caf.png">

# Question: 
But whats the difference????

# Answer
Its this:

<img width="356" alt="Screenshot 2022-06-28 at 2 58 06 PM" src="https://user-images.githubusercontent.com/11778116/176184257-e3cac8b1-089b-4f11-8694-90f3ffa7eea7.png">


