### PR TITLE
Use WEI Everywhere

### DIFF
--- a/queries/period_transfers.sql
+++ b/queries/period_transfers.sql
@@ -2,7 +2,7 @@ with
 -- For a configurable permanent version visit: https://dune.xyz/queries/469110
 relevant_batch_info as (
     select concat('0x', encode(solver_address, 'hex')) as solver,
-           sum(gas_price_gwei * gas_used) / 10 ^ 9     as eth_spent,
+           sum(gas_price_gwei * gas_used) * 10 ^ 9     as eth_spent,
            count(*) * '{{PerBatchReward}}'             as batch_reward,
            sum(num_trades) * '{{PerTradeReward}}'      as trade_reward
     from gnosis_protocol_v2.batches
@@ -22,7 +22,7 @@ from (
          select 'erc20'                                      as token_type,
                 '0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB' as token_address,
                 solver                                       as receiver,
-                batch_reward + trade_reward                  as amount
+                (batch_reward + trade_reward) * 10 ^ 18      as amount
          from relevant_batch_info
      ) as _
 order by receiver, token_address desc

--- a/queries/period_transfers.sql
+++ b/queries/period_transfers.sql
@@ -16,13 +16,13 @@ from (
          select 'native'  as token_type,
                 null      as token_address,
                 solver    as receiver,
-                eth_spent as amount
+                eth_spent::numeric::text as amount
          from relevant_batch_info
          union
          select 'erc20'                                      as token_type,
                 '0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB' as token_address,
                 solver                                       as receiver,
-                (batch_reward + trade_reward) * 10 ^ 18      as amount
+                (10^18 * (batch_reward + trade_reward))::numeric::text    as amount
          from relevant_batch_info
      ) as _
 order by receiver, token_address desc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-black==22.3.0
+black==22.6.0
 duneapi==3.0.7
-mypy==0.942
+mypy==0.961
 psycopg2==2.9.3
-pylint==2.13.4
-pytest==7.1.1
+pylint==2.14.4
+pytest==7.1.2
 python-dotenv>=0.20.0
 coinpaprika>=0.1.0
 requests>=2.27.1

--- a/src/utils/prices.py
+++ b/src/utils/prices.py
@@ -57,11 +57,11 @@ def token_in_eth(token: TokenId, amount: int, day: datetime) -> int:
     return int(token_amount_usd / eth_price_usd * 10 ** TokenId.ETH.decimals())
 
 
-def token_in_usd(token: TokenId, amount: int, day: datetime) -> float:
+def token_in_usd(token: TokenId, amount_wei: int, day: datetime) -> float:
     """
-    Converts token amount to usd amount on given day.
+    Converts token amount [wei] to usd amount on given day.
     """
-    return float(amount) * usd_price(token, day) / 10.0 ** token.decimals()
+    return float(amount_wei) * usd_price(token, day) / 10.0 ** token.decimals()
 
 
 @functools.cache

--- a/src/utils/prices.py
+++ b/src/utils/prices.py
@@ -29,33 +29,39 @@ class TokenId(Enum):
     COW = "cow-cow-protocol-token"
     USDC = "usdc-usd-coin"
 
+    def decimals(self) -> int:
+        """Decimals for each of the token variants."""
+        if self == TokenId.USDC:
+            return 6
+        return 18
 
-def eth_in_token(quote_token: TokenId, amount: float, day: datetime) -> float:
+
+def eth_in_token(quote_token: TokenId, amount: int, day: datetime) -> float:
     """
     Compute how much of `token` is equivalent to `amount` ETH on `day`.
     Use current price if day not specified.
     """
     eth_amount_usd = token_in_usd(TokenId.ETH, amount, day)
-    quote_price_usd = token_in_usd(quote_token, 1, day)
+    quote_price_usd = token_in_usd(quote_token, 10 ** quote_token.decimals(), day)
     return eth_amount_usd / quote_price_usd
 
 
-def token_in_eth(token: TokenId, amount: float, day: datetime) -> float:
+def token_in_eth(token: TokenId, amount: int, day: datetime) -> float:
     """
     The inverse of eth_in_token;
     how much ETH is equivalent to `amount` of `token` on `day`
     """
     token_amount_usd = token_in_usd(token, amount, day)
-    eth_price_usd = token_in_usd(TokenId.ETH, 1, day)
+    eth_price_usd = token_in_usd(TokenId.ETH, 10 ** TokenId.ETH.decimals(), day)
 
     return token_amount_usd / eth_price_usd
 
 
-def token_in_usd(token: TokenId, amount: float, day: datetime) -> float:
+def token_in_usd(token: TokenId, amount: int, day: datetime) -> float:
     """
     Converts token amount to usd amount on given day.
     """
-    return amount * usd_price(token, day)
+    return float(amount) * usd_price(token, day) / 10.0 ** token.decimals()
 
 
 @functools.cache

--- a/src/utils/prices.py
+++ b/src/utils/prices.py
@@ -36,17 +36,17 @@ class TokenId(Enum):
         return 18
 
 
-def eth_in_token(quote_token: TokenId, amount: int, day: datetime) -> float:
+def eth_in_token(quote_token: TokenId, amount: int, day: datetime) -> int:
     """
     Compute how much of `token` is equivalent to `amount` ETH on `day`.
     Use current price if day not specified.
     """
     eth_amount_usd = token_in_usd(TokenId.ETH, amount, day)
     quote_price_usd = token_in_usd(quote_token, 10 ** quote_token.decimals(), day)
-    return eth_amount_usd / quote_price_usd
+    return int(eth_amount_usd / quote_price_usd * 10 ** quote_token.decimals())
 
 
-def token_in_eth(token: TokenId, amount: int, day: datetime) -> float:
+def token_in_eth(token: TokenId, amount: int, day: datetime) -> int:
     """
     The inverse of eth_in_token;
     how much ETH is equivalent to `amount` of `token` on `day`
@@ -54,7 +54,7 @@ def token_in_eth(token: TokenId, amount: int, day: datetime) -> float:
     token_amount_usd = token_in_usd(token, amount, day)
     eth_price_usd = token_in_usd(TokenId.ETH, 10 ** TokenId.ETH.decimals(), day)
 
-    return token_amount_usd / eth_price_usd
+    return int(token_amount_usd / eth_price_usd * 10 ** TokenId.ETH.decimals())
 
 
 def token_in_usd(token: TokenId, amount: int, day: datetime) -> float:

--- a/tests/e2e/test_prices.py
+++ b/tests/e2e/test_prices.py
@@ -9,6 +9,9 @@ from src.utils.prices import (
     usd_price,
 )
 
+ONE_ETH = 10**18
+DELTA = 0.00001
+
 
 class TestPrices(unittest.TestCase):
     def setUp(self) -> None:
@@ -19,49 +22,55 @@ class TestPrices(unittest.TestCase):
 
     def test_token_in_usd(self):
         with self.assertRaises(AssertionError):
-            token_in_usd(TokenId.COW, 1, self.day_before_cow)
+            token_in_usd(TokenId.COW, ONE_ETH, self.day_before_cow)
 
         with self.assertRaises(AssertionError):
-            token_in_usd(TokenId.COW, 1, datetime.today())
+            token_in_usd(TokenId.COW, ONE_ETH, datetime.today())
 
-        self.assertEqual(token_in_usd(TokenId.ETH, 1, self.first_cow_day), 3032.45)
-        self.assertEqual(token_in_usd(TokenId.COW, 1, self.first_cow_day), 0.435229)
-        self.assertEqual(token_in_usd(TokenId.USDC, 1, self.first_cow_day), 1.001656)
+        self.assertEqual(
+            token_in_usd(TokenId.ETH, ONE_ETH, self.first_cow_day), 3032.45
+        )
+        self.assertEqual(
+            token_in_usd(TokenId.COW, ONE_ETH, self.first_cow_day), 0.435229
+        )
+        self.assertEqual(
+            token_in_usd(TokenId.USDC, 10**6, self.first_cow_day), 1.001656
+        )
 
     def test_eth_in_token(self):
         with self.assertRaises(AssertionError):
-            eth_in_token(TokenId.COW, 1, self.day_before_cow)
+            eth_in_token(TokenId.COW, ONE_ETH, self.day_before_cow)
 
         # cow_price =  0.435229
         # eth_price = 3032.45
         # usdc_price = 1.001656
         self.assertAlmostEqual(
-            eth_in_token(TokenId.COW, 1, self.first_cow_day),
+            eth_in_token(TokenId.COW, ONE_ETH, self.first_cow_day),
             3032.45 / 0.435229,
-            delta=0.0001,
+            delta=DELTA,
         )
         self.equal = self.assertAlmostEqual(
-            eth_in_token(TokenId.USDC, 1, self.first_cow_day),
+            eth_in_token(TokenId.USDC, ONE_ETH, self.first_cow_day),
             3032.45 / 1.001656,
-            delta=0.0001,
+            delta=DELTA,
         )
 
     def test_token_in_eth(self):
         with self.assertRaises(AssertionError):
-            token_in_eth(TokenId.COW, 1, self.day_before_cow)
+            token_in_eth(TokenId.COW, ONE_ETH, self.day_before_cow)
 
         # cow_price =  0.435229
         # eth_price = 3032.45
         # usdc_price = 1.001656
         self.assertAlmostEqual(
-            token_in_eth(TokenId.COW, 1, self.first_cow_day),
+            token_in_eth(TokenId.COW, ONE_ETH, self.first_cow_day),
             0.435229 / 3032.45,
-            delta=0.0001,
+            delta=DELTA,
         )
         self.assertAlmostEqual(
-            token_in_eth(TokenId.USDC, 1, self.first_cow_day),
+            token_in_eth(TokenId.USDC, 10**6, self.first_cow_day),
             1.001656 / 3032.45,
-            delta=0.0001,
+            delta=DELTA,
         )
 
     def test_price_cache(self):

--- a/tests/e2e/test_prices.py
+++ b/tests/e2e/test_prices.py
@@ -44,15 +44,13 @@ class TestPrices(unittest.TestCase):
         # cow_price =  0.435229
         # eth_price = 3032.45
         # usdc_price = 1.001656
-        self.assertAlmostEqual(
+        self.assertEqual(
             eth_in_token(TokenId.COW, ONE_ETH, self.first_cow_day),
-            3032.45 / 0.435229,
-            delta=DELTA,
+            10**18 * 3032.45 // 0.435229,
         )
-        self.equal = self.assertAlmostEqual(
+        self.assertEqual(
             eth_in_token(TokenId.USDC, ONE_ETH, self.first_cow_day),
-            3032.45 / 1.001656,
-            delta=DELTA,
+            10**6 * 3032.45 // 1.001656,
         )
 
     def test_token_in_eth(self):
@@ -64,12 +62,12 @@ class TestPrices(unittest.TestCase):
         # usdc_price = 1.001656
         self.assertAlmostEqual(
             token_in_eth(TokenId.COW, ONE_ETH, self.first_cow_day),
-            0.435229 / 3032.45,
+            10**18 * 0.435229 // 3032.45,
             delta=DELTA,
         )
         self.assertAlmostEqual(
             token_in_eth(TokenId.USDC, 10**6, self.first_cow_day),
-            1.001656 / 3032.45,
+            10**18 * 1.001656 // 3032.45,
             delta=DELTA,
         )
 

--- a/tests/e2e/test_transfer_file.py
+++ b/tests/e2e/test_transfer_file.py
@@ -5,6 +5,8 @@ from src.fetch.period_slippage import SolverSlippage
 from src.fetch.transfer_file import Transfer, SplitTransfers, Overdraft
 from src.models import AccountingPeriod
 
+ONE_ETH = 10**18
+
 
 # TODO - mock the price feed so that this test doesn't require API call.
 class TestPrices(unittest.TestCase):
@@ -16,11 +18,13 @@ class TestPrices(unittest.TestCase):
         mixed_transfers = [
             Transfer.native(
                 receiver=barn_zerox,
-                amount=0.18536027477313313,
+                amount=185360274773133130,
             ),
-            Transfer.native(receiver=other_solver, amount=1),
-            Transfer.erc20(receiver=barn_zerox, amount=600, token=cow_token),
-            Transfer.erc20(receiver=other_solver, amount=2000, token=cow_token),
+            Transfer.native(receiver=other_solver, amount=1 * ONE_ETH),
+            Transfer.erc20(receiver=barn_zerox, amount=600 * ONE_ETH, token=cow_token),
+            Transfer.erc20(
+                receiver=other_solver, amount=2000 * ONE_ETH, token=cow_token
+            ),
         ]
 
         barn_slippage = SolverSlippage(
@@ -44,14 +48,14 @@ class TestPrices(unittest.TestCase):
             transfers,
             [
                 Transfer.erc20(
-                    receiver=other_solver, token=cow_token, amount=845.0943770281408
+                    receiver=other_solver, token=cow_token, amount=845094377028141056000
                 )
             ],
         )
         # barn_zerox still has outstanding overdraft
         self.assertEqual(
             accounting.overdrafts,
-            {barn_zerox: Overdraft(period, barn_zerox, "barn-0x", 0.08738479495718031)},
+            {barn_zerox: Overdraft(period, barn_zerox, "barn-0x", 87384794957180304)},
         )
         # All unprocessed entries have been processed.
         self.assertEqual(accounting.unprocessed_cow, [])

--- a/tests/e2e/test_transfer_file.py
+++ b/tests/e2e/test_transfer_file.py
@@ -33,7 +33,7 @@ class TestPrices(unittest.TestCase):
             solver_address=barn_zerox,
         )
         other_slippage = SolverSlippage(
-            amount_wei=-1100000000000000000,
+            amount_wei=-11 * 10**17,
             solver_name="Other Solver",
             solver_address=other_solver,
         )
@@ -44,6 +44,8 @@ class TestPrices(unittest.TestCase):
 
         transfers = accounting.process(indexed_slippage, cow_redirects)
         # The only remaining transfer is the other_solver's COW reward.
+        print(transfers[0].amount)
+        print(transfers[0].amount_wei)
         self.assertEqual(
             transfers,
             [

--- a/tests/e2e/test_transfer_file.py
+++ b/tests/e2e/test_transfer_file.py
@@ -44,7 +44,6 @@ class TestPrices(unittest.TestCase):
 
         transfers = accounting.process(indexed_slippage, cow_redirects)
         # The only remaining transfer is the other_solver's COW reward.
-        print(transfers[0].amount)
         print(transfers[0].amount_wei)
         self.assertEqual(
             transfers,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -9,6 +9,7 @@ from tests.queries.test_internal_trades import TransferType
 
 ONE_ADDRESS = Address("0x1111111111111111111111111111111111111111")
 TWO_ADDRESS = Address("0x2222222222222222222222222222222222222222")
+ONE_ETH = 10**18
 
 
 class TestTransferType(unittest.TestCase):
@@ -37,15 +38,18 @@ class TestTransfer(unittest.TestCase):
     def test_add_slippage(self):
         solver = Address.zero()
         transfer = Transfer(
-            token_type=TokenType.NATIVE, token_address=None, receiver=solver, amount=1.0
+            token_type=TokenType.NATIVE,
+            token_address=None,
+            receiver=solver,
+            amount_wei=ONE_ETH,
         )
         positive_slippage = SolverSlippage(
-            solver_name="Test Solver", solver_address=solver, amount_wei=10**18 // 2
+            solver_name="Test Solver", solver_address=solver, amount_wei=ONE_ETH // 2
         )
         negative_slippage = SolverSlippage(
             solver_name="Test Solver",
             solver_address=solver,
-            amount_wei=-(10**18) // 2,
+            amount_wei=-ONE_ETH // 2,
         )
         transfer.add_slippage(positive_slippage)
         self.assertAlmostEqual(transfer.amount, 1.5, delta=0.0000000001)
@@ -53,14 +57,15 @@ class TestTransfer(unittest.TestCase):
         self.assertAlmostEqual(transfer.amount, 1.0, delta=0.0000000001)
 
         overdraft_slippage = SolverSlippage(
-            solver_name="Test Solver", solver_address=solver, amount_wei=-2 * (10**18)
+            solver_name="Test Solver", solver_address=solver, amount_wei=-2 * ONE_ETH
         )
 
         with self.assertRaises(ValueError) as err:
             transfer.add_slippage(overdraft_slippage)
         self.assertEqual(
             str(err.exception),
-            f"Invalid adjustment {transfer} by {overdraft_slippage.amount_wei / 10 ** 18}",
+            f"Invalid adjustment {transfer} "
+            f"by {overdraft_slippage.amount_wei / 10**18}",
         )
 
     def test_merge(self):
@@ -70,13 +75,13 @@ class TestTransfer(unittest.TestCase):
             token_type=TokenType.NATIVE,
             token_address=None,
             receiver=receiver,
-            amount=1.0,
+            amount_wei=ONE_ETH,
         )
         native_transfer2 = Transfer(
             token_type=TokenType.NATIVE,
             token_address=None,
             receiver=receiver,
-            amount=1.0,
+            amount_wei=ONE_ETH,
         )
         self.assertEqual(
             native_transfer1.merge(native_transfer2),
@@ -84,7 +89,7 @@ class TestTransfer(unittest.TestCase):
                 token_type=TokenType.NATIVE,
                 token_address=None,
                 receiver=receiver,
-                amount=2.0,
+                amount_wei=2 * ONE_ETH,
             ),
         )
         token = ONE_ADDRESS
@@ -93,13 +98,13 @@ class TestTransfer(unittest.TestCase):
             token_type=TokenType.ERC20,
             token_address=token,
             receiver=receiver,
-            amount=1.0,
+            amount_wei=ONE_ETH,
         )
         erc20_transfer2 = Transfer(
             token_type=TokenType.ERC20,
             token_address=token,
             receiver=receiver,
-            amount=1.0,
+            amount_wei=ONE_ETH,
         )
         self.assertEqual(
             erc20_transfer1.merge(erc20_transfer2),
@@ -107,7 +112,7 @@ class TestTransfer(unittest.TestCase):
                 token_type=TokenType.ERC20,
                 token_address=token,
                 receiver=receiver,
-                amount=2.0,
+                amount_wei=2 * ONE_ETH,
             ),
         )
 
@@ -125,13 +130,13 @@ class TestTransfer(unittest.TestCase):
                 token_type=TokenType.ERC20,
                 token_address=token,
                 receiver=ONE_ADDRESS,
-                amount=2.0,
+                amount_wei=2 * ONE_ETH,
             )
             t2 = Transfer(
                 token_type=TokenType.ERC20,
                 token_address=token,
                 receiver=TWO_ADDRESS,
-                amount=2.0,
+                amount_wei=2 * ONE_ETH,
             )
             t1.merge(t2)
         self.assertEqual(
@@ -145,13 +150,13 @@ class TestTransfer(unittest.TestCase):
                 token_type=TokenType.ERC20,
                 token_address=ONE_ADDRESS,
                 receiver=receiver,
-                amount=2.0,
+                amount_wei=2 * ONE_ETH,
             )
             t2 = Transfer(
                 token_type=TokenType.ERC20,
                 token_address=TWO_ADDRESS,
                 receiver=receiver,
-                amount=2.0,
+                amount_wei=2 * ONE_ETH,
             )
             t1.merge(t2)
         self.assertEqual(
@@ -173,49 +178,49 @@ class TestTransfer(unittest.TestCase):
                 token_type=TokenType.ERC20,
                 token_address=tokens[0],
                 receiver=recipients[0],
-                amount=1.0,
+                amount_wei=1 * ONE_ETH,
             ),
             Transfer(
                 token_type=TokenType.ERC20,
                 token_address=tokens[0],
                 receiver=recipients[0],
-                amount=2.0,
+                amount_wei=2 * ONE_ETH,
             ),
             Transfer(
                 token_type=TokenType.ERC20,
                 token_address=tokens[1],
                 receiver=recipients[0],
-                amount=3.0,
+                amount_wei=3 * ONE_ETH,
             ),
             Transfer(
                 token_type=TokenType.ERC20,
                 token_address=tokens[0],
                 receiver=recipients[1],
-                amount=4.0,
+                amount_wei=4 * ONE_ETH,
             ),
             Transfer(
                 token_type=TokenType.NATIVE,
                 token_address=None,
                 receiver=recipients[0],
-                amount=5.0,
+                amount_wei=5 * ONE_ETH,
             ),
             Transfer(
                 token_type=TokenType.NATIVE,
                 token_address=None,
                 receiver=recipients[0],
-                amount=6.0,
+                amount_wei=6 * ONE_ETH,
             ),
             Transfer(
                 token_type=TokenType.NATIVE,
                 token_address=None,
                 receiver=recipients[1],
-                amount=7.0,
+                amount_wei=7 * ONE_ETH,
             ),
             Transfer(
                 token_type=TokenType.NATIVE,
                 token_address=None,
                 receiver=recipients[1],
-                amount=8.0,
+                amount_wei=8 * ONE_ETH,
             ),
         ]
 
@@ -224,31 +229,31 @@ class TestTransfer(unittest.TestCase):
                 token_type=TokenType.NATIVE,
                 token_address=None,
                 receiver=recipients[1],
-                amount=15.0,
+                amount_wei=15 * ONE_ETH,
             ),
             Transfer(
                 token_type=TokenType.NATIVE,
                 token_address=None,
                 receiver=recipients[0],
-                amount=11.0,
+                amount_wei=11 * ONE_ETH,
             ),
             Transfer(
                 token_type=TokenType.ERC20,
                 token_address=tokens[0],
                 receiver=recipients[1],
-                amount=4.0,
+                amount_wei=4 * ONE_ETH,
             ),
             Transfer(
                 token_type=TokenType.ERC20,
                 token_address=tokens[0],
                 receiver=recipients[0],
-                amount=3.0,
+                amount_wei=3 * ONE_ETH,
             ),
             Transfer(
                 token_type=TokenType.ERC20,
                 token_address=tokens[1],
                 receiver=recipients[0],
-                amount=3.0,
+                amount_wei=3 * ONE_ETH,
             ),
         ]
         self.assertEqual(expected, consolidate_transfers(transfer_list))
@@ -258,7 +263,7 @@ class TestTransfer(unittest.TestCase):
             token_type=TokenType.NATIVE,
             token_address=None,
             receiver=ONE_ADDRESS,
-            amount=1.0,
+            amount_wei=1 * ONE_ETH,
         )
         with self.assertRaises(AssertionError) as err:
             transfer.add_slippage(
@@ -275,14 +280,14 @@ class TestTransfer(unittest.TestCase):
                     "token_type": "native",
                     "token_address": None,
                     "receiver": ONE_ADDRESS.address,
-                    "amount": "1.234",
+                    "amount": "1234000000000000000",
                 }
             ),
             Transfer(
                 token_type=TokenType.NATIVE,
                 token_address=None,
                 receiver=ONE_ADDRESS,
-                amount=1.234,
+                amount_wei=1234 * 10**15,
             ),
         )
 
@@ -292,7 +297,7 @@ class TestTransfer(unittest.TestCase):
                     "token_type": "erc20",
                     "token_address": None,
                     "receiver": ONE_ADDRESS.address,
-                    "amount": "1.234",
+                    "amount": "1000000000000000000",
                 }
             )
         self.assertEqual(
@@ -304,7 +309,7 @@ class TestTransfer(unittest.TestCase):
                     "token_type": "native",
                     "token_address": ONE_ADDRESS.address,
                     "receiver": ONE_ADDRESS.address,
-                    "amount": "1.234",
+                    "amount": "1000000000000000000",
                 }
             )
         self.assertEqual(


### PR DESCRIPTION
Closes #67 

As an intermediate step in our transition to automate this workflow, we must first start by using WEI precision. This improves our overall accuracy by limiting our precision loss. The transition was quite tricky and involved

1. an SQL hack to avoid scientific notation (`amount_wei::numeric::text`) we cast our WEI amounts to string in the Dune Query.
2. Update Prices to incorporate token decimals (i.e. to work in WEI). <--- This may have been the hardest part. 
3. Create an Auxiliary class CSVTransfer which is just the conversion of `amount_wei` to `amount`. The reason for this is that we don't own `write_to_csv` method which generically writes CSVs for any dataclass. Our `Transfer` dataclass no longer had the the correct fields or values to be generically converted into the csv transfer file. 


Note that 
- `CSVTransfer` is only temporary and will be deprecated as soon as we stop pasting the transfer file into CSV Airdrop.
- It was good that we had so many tests in place to guide the changes here!


## Test Plan

Existing CI demonstrates that everything is still working as expected.