### PR TITLE
Multisend Part II: Post Tx to Safe

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,6 +4,7 @@ import os
 
 from duneapi.types import Address
 from dotenv import load_dotenv
+from gnosis.eth.ethereum_network import EthereumNetwork
 from web3 import Web3
 
 COW_TOKEN_ADDRESS = Address("0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB")
@@ -12,10 +13,16 @@ COW_SAFE_ADDRESS = Web3.toChecksumAddress("0xA03be496e67Ec29bC62F01a428683D7F9c2
 load_dotenv()
 ENV = os.environ
 INFURA_KEY = ENV.get("INFURA_KEY")
-NODE_URL = f"https://{ENV.get('NETWORK', 'mainnet')}.infura.io/v3/{INFURA_KEY}"
+NETWORK_STRING = ENV.get("NETWORK", "mainnet")
+NODE_URL = f"https://{NETWORK_STRING}.infura.io/v3/{INFURA_KEY}"
+NETWORK = {
+    "mainnet": EthereumNetwork.MAINNET,
+    "rinkeby": EthereumNetwork.RINKEBY,
+    "gnosis": EthereumNetwork.XDAI,
+    "goerli": EthereumNetwork.GOERLI,
+}[NETWORK_STRING]
 
-# Things requiring Web3 instance
-w3 = Web3(Web3.HTTPProvider(NODE_URL))
+# Things requiring dummy Web3 instance
 ERC20_ABI = json.loads(
     """[
     {
@@ -46,3 +53,5 @@ ERC20_ABI = json.loads(
 """
 )
 ERC20_TOKEN = Web3().eth.contract(abi=ERC20_ABI)
+# Real Web3 Instance
+w3 = Web3(Web3.HTTPProvider(NODE_URL))

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -4,8 +4,15 @@ Safe Multisend transaction consisting of Transfers
 """
 import logging.config
 
+from eth_typing.evm import ChecksumAddress
 from gnosis.eth.ethereum_client import EthereumClient
-from gnosis.safe.multi_send import MultiSend, MultiSendTx
+from gnosis.eth.ethereum_network import EthereumNetwork
+from gnosis.safe.safe import Safe
+from gnosis.safe.multi_send import MultiSend, MultiSendOperation, MultiSendTx
+
+# This dependency can be removed once this issue is resolved:
+# https://github.com/safe-global/safe-eth-py/issues/284
+from safe_cli.api.transaction_service_api import TransactionServiceApi
 
 log = logging.getLogger(__name__)
 logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=False)
@@ -24,3 +31,30 @@ def build_encoded_multisend(
     log.info(f"Packing {len(transactions)} transfers into MultiSend")
     tx_bytes: bytes = multisend.build_tx_data(transactions)
     return tx_bytes
+
+
+def post_multisend(
+    safe_address: ChecksumAddress,
+    network: EthereumNetwork,
+    transfers: list[MultiSendTx],
+    client: EthereumClient,
+    signing_key: str,
+) -> None:
+    """Posts a MultiSend Transaction from a list of Transfers."""
+    encoded_multisend = build_encoded_multisend(transactions=transfers, client=client)
+    safe = Safe(address=safe_address, ethereum_client=client)
+    safe_tx = safe.build_multisig_tx(
+        to=MULTISEND_CONTRACT,
+        value=0,
+        data=encoded_multisend,
+        operation=MultiSendOperation.DELEGATE_CALL.value,
+    )
+    # There is a deep warning being raised here:
+    # Details in issue: https://github.com/safe-global/safe-eth-py/issues/294
+    safe_tx.sign(signing_key)
+    tx_service = TransactionServiceApi(client, network)
+    print(
+        f"Posting transaction with hash"
+        f" {safe_tx.safe_tx_hash.hex()} to {safe.address}"
+    )
+    tx_service.post_transaction(safe_address=safe.address, safe_tx=safe_tx)

--- a/tests/e2e/test_post_transaction.py
+++ b/tests/e2e/test_post_transaction.py
@@ -1,0 +1,46 @@
+import os
+import unittest
+
+from duneapi.types import Address
+from eth_typing import URI
+from gnosis.eth import EthereumNetwork, EthereumClient
+
+from web3 import Web3
+from src.fetch.transfer_file import Transfer
+from src.models import Token
+from src.multisend import post_multisend
+
+
+class TestTransactionPost(unittest.TestCase):
+    def setUp(self) -> None:
+        # PK for deterministic ganache default account `ganache-cli -d`
+        self.pk = "0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d"
+        self.test_safe = "0x8990c564ec303C7b26d3d5556ef0910E58Be08Ce"
+        self.owl = Token("0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D", 18)
+        self.receiver = Address("0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0")
+        self.client = EthereumClient(
+            URI(f"https://rinkeby.infura.io/v3/{os.environ.get('INFURA_KEY')}")
+        )
+
+    def test_token_decimals(self):
+        token_transfer = Transfer(
+            token=self.owl,
+            amount_wei=15,
+            receiver=self.receiver,
+        )
+        native_transfer = Transfer(token=None, receiver=self.receiver, amount_wei=2)
+
+        post_multisend(
+            safe_address=Web3().toChecksumAddress(self.test_safe),
+            network=EthereumNetwork.RINKEBY,
+            transfers=[
+                token_transfer.as_multisend_tx(),
+                native_transfer.as_multisend_tx(),
+            ],
+            client=self.client,
+            signing_key=self.pk,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
As a second part of the PR (based on #66) this is based on we test the Multisend Functionality all the way to transaction posting:

You can see the currently pending proposed Multisend transaction here:
https://gnosis-safe.io/app/rin:0x8990c564ec303C7b26d3d5556ef0910E58Be08Ce/transactions/queue

That is the result of this e2e test:
```sh
python -m pytest tests/e2e/test_post_transaction.py
```

to reproduce you will need to provide a valid `INFURA_KEY` in your `env`.

Also see an already executed (successful transaction resulting from this test script):

https://rinkeby.etherscan.io/tx/0x1416e80a6622c2caebb21d6e434259159baebbe0a76b2d64ec935487e74cbdb6

Additionally, many other unit tests have been introduced as well as a prompt message for the script user.


# Special Note:

This test will require the end user to provide an `INFURA_KEY` and the `PROPOSER_PK` (private key).

