### PR TITLE
Split Entrypoint by Runtime Argument

### DIFF
--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -144,10 +144,6 @@ def get_period_slippage(
 
 
 if __name__ == "__main__":
-    dune_connection, accounting_period = generic_script_init(
-        description="Fetch Accounting Period Totals"
-    )
-    slippage_for_period = get_period_slippage(
-        dune=dune_connection, period=accounting_period
-    )
+    args = generic_script_init(description="Fetch Accounting Period Totals")
+    slippage_for_period = get_period_slippage(dune=args.dune, period=args.period)
     pprint(slippage_for_period)

--- a/src/fetch/period_totals.py
+++ b/src/fetch/period_totals.py
@@ -47,10 +47,8 @@ def get_period_totals(dune: DuneAPI, period: AccountingPeriod) -> PeriodTotals:
 
 
 if __name__ == "__main__":
-    dune_connection, accounting_period = generic_script_init(
-        description="Fetch Accounting Period Totals"
-    )
+    args = generic_script_init(description="Fetch Accounting Period Totals")
 
-    total_for_period = get_period_totals(dune=dune_connection, period=accounting_period)
+    total_for_period = get_period_totals(dune=args.dune, period=args.period)
 
     pprint(total_for_period)

--- a/src/fetch/reward_targets.py
+++ b/src/fetch/reward_targets.py
@@ -61,10 +61,8 @@ def get_vouches(dune: DuneAPI, end_time: datetime) -> dict[Address, Vouch]:
 
 
 if __name__ == "__main__":
-    dune_connection, accounting_period = generic_script_init(
-        description="Fetch Reward Targets"
-    )
-    vouch_map = get_vouches(dune=dune_connection, end_time=accounting_period.end)
+    args = generic_script_init(description="Fetch Reward Targets")
+    vouch_map = get_vouches(dune=args.dune, end_time=args.period.end)
 
     for solver, vouch in vouch_map.items():
         print("Solver", solver, "Reward Target", vouch.reward_target)

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -390,27 +390,21 @@ def unusual_slippage_url(period: AccountingPeriod) -> str:
     return base + urllib.parse.quote_plus(query, safe="=&?")
 
 
-if __name__ == "__main__":
-    dune_connection, accounting_period = generic_script_init(
-        description="Fetch Complete Reimbursement"
-    )
+def manual_propose(dune: DuneAPI, period: AccountingPeriod) -> None:
+    """
+    Entry point to manual creation of rewards payout transaction.
+    This function generates the CSV transfer file to be pasted into the COW Safe app
+    """
     print(
         f"While you are waiting, The data being compiled here can be visualized at\n"
-        f"{dashboard_url(accounting_period)}"
-    )
-    print(
+        f"{dashboard_url(period)}\n"
         f"In particular, please double check the batches with unusual slippage: "
-        f"{unusual_slippage_url(accounting_period)}"
+        f"{unusual_slippage_url(period)}"
     )
-    transfers = consolidate_transfers(
-        get_transfers(
-            dune=dune_connection,
-            period=accounting_period,
-        )
-    )
+    transfers = consolidate_transfers(get_transfers(dune, period))
     write_to_csv(
         data_list=[CSVTransfer.from_transfer(t) for t in transfers],
-        outfile=File(name=f"transfers-{accounting_period}.csv"),
+        outfile=File(name=f"transfers-{period}.csv"),
     )
     eth_total = sum(t.amount_wei for t in transfers if t.token_type == TokenType.NATIVE)
     cow_total = sum(t.amount_wei for t in transfers if t.token_type == TokenType.ERC20)
@@ -419,24 +413,38 @@ if __name__ == "__main__":
         f"Total ETH Funds needed: {eth_total / 10 ** 18}\n"
         f"Total COW Funds needed: {cow_total / 10 ** 18}\n"
         f"Please cross check these results with the dashboard linked above.\n "
+        f"For solver payouts, paste the transfer file CSV Airdrop at:\n"
+        f"{safe_url()}"
     )
 
-    if input("Would you like to send this transaction to the Safe? (y/n)") != "y":
-        print(
-            "Not posting transaction to safe interface: "
-            "You can do this manually with the csv file written here via CSV Airdrop"
-            f"at {safe_url()}"
-        )
+
+def auto_propose(dune: DuneAPI, period: AccountingPeriod) -> None:
+    """
+    Entry point auto creation of rewards payout transaction.
+    This function encodes the multisend of reward transfers and posts
+    the transaction to the COW TEAM SAFE from the proposer account.
+    """
+    # Check early not to wait for query execution to realize it's not available.
+    assert "PROPOSER_PK" in os.environ, "Missing Proposer PK"
+    transfers = consolidate_transfers(get_transfers(dune, period))
+    post_multisend(
+        safe_address=COW_SAFE_ADDRESS,
+        transfers=[t.as_multisend_tx() for t in transfers],
+        network=NETWORK,
+        signing_key=os.environ["PROPOSER_PK"],
+        client=EthereumClient(URI(NODE_URL)),
+    )
+    print(
+        f"Transaction successfully posted. Please visit "
+        f"https://gnosis-safe.io/app/eth:{COW_SAFE_ADDRESS}/transactions/queue "
+        f"to sign and execute"
+    )
+
+
+if __name__ == "__main__":
+    args = generic_script_init(description="Fetch Complete Reimbursement")
+
+    if args.post_tx:
+        auto_propose(args.dune, args.period)
     else:
-        post_multisend(
-            safe_address=COW_SAFE_ADDRESS,
-            transfers=[t.as_multisend_tx() for t in transfers],
-            network=NETWORK,
-            signing_key=os.environ["PROPOSER_PK"],
-            client=EthereumClient(URI(NODE_URL)),
-        )
-        print(
-            f"Transaction successfully posted. Please visit "
-            f"https://gnosis-safe.io/app/eth:{COW_SAFE_ADDRESS}/transactions/queue "
-            f"to sign and execute"
-        )
+        manual_propose(args.dune, args.period)

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -424,15 +424,19 @@ def auto_propose(dune: DuneAPI, period: AccountingPeriod) -> None:
     This function encodes the multisend of reward transfers and posts
     the transaction to the COW TEAM SAFE from the proposer account.
     """
-    # Check early not to wait for query execution to realize it's not available.
-    assert "PROPOSER_PK" in os.environ, "Missing Proposer PK"
+    # Check for required env vars early
+    # so not to wait for query execution to realize it's not available.
+    signing_key = os.environ["PROPOSER_PK"]
+    client = EthereumClient(URI(NODE_URL))
+    network = NETWORK
+
     transfers = consolidate_transfers(get_transfers(dune, period))
     post_multisend(
         safe_address=COW_SAFE_ADDRESS,
         transfers=[t.as_multisend_tx() for t in transfers],
-        network=NETWORK,
-        signing_key=os.environ["PROPOSER_PK"],
-        client=EthereumClient(URI(NODE_URL)),
+        network=network,
+        signing_key=signing_key,
+        client=client,
     )
     print(
         f"Transaction successfully posted. Please visit "

--- a/src/update/token_list.py
+++ b/src/update/token_list.py
@@ -41,5 +41,5 @@ def update_token_list(dune: DuneAPI, token_list: list[str]) -> list[dict[str, st
 
 
 if __name__ == "__main__":
-    dune_connection, _ = generic_script_init(description="Update Token List")
+    dune_connection = generic_script_init(description="Update Token List").dune
     update_token_list(dune_connection, fetch_trusted_tokens())

--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -1,12 +1,21 @@
 """Common method for initializing setup for scripts"""
 import argparse
+from dataclasses import dataclass
 
 from duneapi.api import DuneAPI
-
 from src.models import AccountingPeriod
 
 
-def generic_script_init(description: str) -> tuple[DuneAPI, AccountingPeriod]:
+@dataclass
+class ScriptArgs:
+    """A collection of common script arguments relevant to this project"""
+
+    dune: DuneAPI
+    period: AccountingPeriod
+    post_tx: bool
+
+
+def generic_script_init(description: str) -> ScriptArgs:
     """
     1. parses parses command line arguments,
     2. establishes dune connection
@@ -16,6 +25,16 @@ def generic_script_init(description: str) -> tuple[DuneAPI, AccountingPeriod]:
     parser.add_argument(
         "--start", type=str, help="Accounting Period Start", required=True
     )
+    parser.add_argument(
+        "--post-tx",
+        type=bool,
+        help="Flag indicating whether multisend should be posted to safe "
+        "(requires valid env var `PROPOSER_PK`)",
+        default=False,
+    )
     args = parser.parse_args()
-
-    return DuneAPI.new_from_environment(), AccountingPeriod(args.start)
+    return ScriptArgs(
+        dune=DuneAPI.new_from_environment(),
+        period=AccountingPeriod(args.start),
+        post_tx=args.post_tx,
+    )


### PR DESCRIPTION
In order to keep the main branch running the way people are used to (as the README describes), we add an additional runtime argument `--post-tx` which, defaults to False, but can be set to True for backend deployments like so:

```sh
python -m src.fetch.transfer_file --start '2022-07-10' --post-tx True
```

This would then expect that some additional env vars are set. Namely:

```
# Safe Transaction Service Requirements.
INFURA_KEY=
NETWORK= this would default to mainnet if not provided.
PROPOSER_PK=
```