### PR TITLE
[Trivial] Update Token List URL

### DIFF
--- a/src/token_list.py
+++ b/src/token_list.py
@@ -3,7 +3,7 @@ import json
 
 import requests
 
-ALLOWED_TOKEN_LIST_URL = "https://token-list.cow.eth.link/"
+ALLOWED_TOKEN_LIST_URL = "https://files.cow.fi/token_list.json"
 
 
 def parse_token_list(token_list_json: str) -> list[str]:


### PR DESCRIPTION
Closes #45 - we are now using our own (self-hosted) tokenlist url.