### PR TITLE
[Easy] Use WEI for penalty total

### DIFF
--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -123,8 +123,8 @@ class Transfer:
         assert self.receiver == slippage.solver_address, "receiver != solver"
         adjustment = slippage.amount_wei
         print(
-            f"Adjusting {self.receiver}({slippage.solver_name}) "
-            f"transfer by {adjustment / 10 ** 18:.5f} (slippage)"
+            f"Deducting slippage for solver {self.receiver}"
+            f"by {adjustment / 10 ** 18:.5f} ({slippage.solver_name})"
         )
         new_amount = self.amount_wei + adjustment
         if new_amount <= 0:
@@ -281,7 +281,7 @@ class SplitTransfers:
         """
         penalty_total = self._process_native_transfers(indexed_slippage)
         self._process_token_transfers(cow_redirects)
-        print(f"Total Slippage deducted {penalty_total / 10**18}")
+        print(f"Total Slippage deducted (ETH): {penalty_total / 10**18}")
         if self.overdrafts:
             print("Additional owed", "\n".join(map(str, self.overdrafts.values())))
         return self.cow_transfers + self.eth_transfers


### PR DESCRIPTION
Closes #76 - This is not actually a logical change since the penalty total is just a cumulative sum used for "logging" purposes.

I also used this opportunity to make the slippage logs easier to digest (Now it has uniform width):

**Before:**
```
Adjusting 0x080a8b1E2f3695E179453c5e617b72A381BE44B9(barn-ParaSwap) transfer by -0.00167 (slippage)
Adjusting 0x109BF9E0287Cc95cc623FBE7380dD841d4bdEb03(barn-Otex) transfer by -0.37244 (slippage)
Adjusting 0x15F4c337122Ec23859EC73Bec00aB38445E45304(prod-ParaSwap) transfer by -0.42032 (slippage)
```

**After:**
```
Deducting solver slippage 0x080a8b1E2f3695E179453c5e617b72A381BE44B9 by -0.00167 (barn-ParaSwap)
Deducting solver slippage 0x109BF9E0287Cc95cc623FBE7380dD841d4bdEb03 by -0.37244 (barn-Otex)
Deducting solver slippage 0x15F4c337122Ec23859EC73Bec00aB38445E45304 by -0.42032 (prod-ParaSwap)
```