### PR TITLE
[Automation] Slack Alerts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,9 +1,15 @@
+# Dune Analytics Credentials
 DUNE_USER=
 DUNE_PASSWORD=
 DUNE_QUERY_ID=
 FILE_OUT_PATH=./out
 
 # Safe Transaction Service Requirements.
+SAFE_ADDRESS=  # defaults to COW Team Safe
 INFURA_KEY=
 NETWORK=
 PROPOSER_PK=
+
+# Slack Bot Credentials
+SLACK_TOKEN=
+SLACK_ALERT_CHANNEL=

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black==22.6.0
+certifi==2022.6.15
 duneapi==3.0.7
 mypy==0.961
 psycopg2==2.9.3
@@ -9,4 +10,5 @@ coinpaprika>=0.1.0
 requests>=2.28.1
 safe-cli>=0.3.1
 safe-eth-py==4.1.3
+slackclient==2.9.4
 web3>=5.30.0

--- a/src/constants.py
+++ b/src/constants.py
@@ -8,10 +8,13 @@ from gnosis.eth.ethereum_network import EthereumNetwork
 from web3 import Web3
 
 COW_TOKEN_ADDRESS = Address("0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB")
-COW_SAFE_ADDRESS = Web3.toChecksumAddress("0xA03be496e67Ec29bC62F01a428683D7F9c204930")
+
 # Things requiring network
 load_dotenv()
 ENV = os.environ
+SAFE_ADDRESS = Web3.toChecksumAddress(
+    ENV.get("SAFE_ADDRESS", "0xA03be496e67Ec29bC62F01a428683D7F9c204930")
+)
 INFURA_KEY = ENV.get("INFURA_KEY")
 NETWORK_STRING = ENV.get("NETWORK", "mainnet")
 NODE_URL = f"https://{NETWORK_STRING}.infura.io/v3/{INFURA_KEY}"
@@ -21,6 +24,19 @@ NETWORK = {
     "gnosis": EthereumNetwork.XDAI,
     "goerli": EthereumNetwork.GOERLI,
 }[NETWORK_STRING]
+SHORT_NAME = {
+    "mainnet": "eth",
+    "rinkeby": "rin",
+    "gnosis": "xdai",
+    "goerli": "gor",
+}[NETWORK_STRING]
+
+CSV_APP_HASH = "Qme49gESuwpSvwANmEqo34yfCkzyQehooJ5yL7aHmKJnpZ"
+AIRDROP_URL = (
+    f"https://gnosis-safe.io/app/eth:{SAFE_ADDRESS}"
+    f"/apps?appUrl=https://cloudflare-ipfs.com/ipfs/{CSV_APP_HASH}/"
+)
+SAFE_URL = f"https://gnosis-safe.io/app/{SHORT_NAME}:{SAFE_ADDRESS}/transactions/queue"
 
 # Things requiring dummy Web3 instance
 ERC20_ABI = json.loads(

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -395,10 +395,11 @@ def unusual_slippage_url(period: AccountingPeriod) -> str:
     return base + urllib.parse.quote_plus(query, safe="=&?")
 
 
-def summarize(transfers: list[Transfer]):
+def summary(transfers: list[Transfer]) -> str:
+    """Summarizes transfers with totals"""
     eth_total = sum(t.amount_wei for t in transfers if t.token_type == TokenType.NATIVE)
     cow_total = sum(t.amount_wei for t in transfers if t.token_type == TokenType.ERC20)
-    log_saver.print(
+    return (
         f"Total ETH Funds needed: {eth_total / 10 ** 18}\n"
         f"Total COW Funds needed: {cow_total / 10 ** 18}\n"
         f"Please cross check these results with the dashboard linked above.\n "
@@ -423,7 +424,7 @@ def manual_propose(dune: DuneAPI, period: AccountingPeriod) -> None:
         data_list=[CSVTransfer.from_transfer(t) for t in transfers],
         outfile=File(name=f"transfers-{period}.csv"),
     )
-    summarize(transfers)
+    print(summary(transfers))
 
 
 def auto_propose(dune: DuneAPI, period: AccountingPeriod) -> None:
@@ -439,7 +440,7 @@ def auto_propose(dune: DuneAPI, period: AccountingPeriod) -> None:
     network = NETWORK
 
     transfers = consolidate_transfers(get_transfers(dune, period))
-    summarize(transfers)
+    log_saver.print(summary(transfers))
     post_multisend(
         safe_address=COW_SAFE_ADDRESS,
         transfers=[t.as_multisend_tx() for t in transfers],

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -405,9 +405,6 @@ def summary(transfers: list[Transfer]) -> str:
     return (
         f"Total ETH Funds needed: {eth_total / 10 ** 18}\n"
         f"Total COW Funds needed: {cow_total / 10 ** 18}\n"
-        f"Please cross check these results with the dashboard linked above.\n "
-        f"For solver payouts, paste the transfer file CSV Airdrop at:\n"
-        f"{AIRDROP_URL}"
     )
 
 
@@ -426,6 +423,11 @@ def manual_propose(dune: DuneAPI, period: AccountingPeriod) -> None:
         outfile=File(name=f"transfers-{period}.csv"),
     )
     print(summary(transfers))
+    print(
+        f"Please cross check these results with the dashboard linked above.\n "
+        f"For solver payouts, paste the transfer file CSV Airdrop at:\n"
+        f"{AIRDROP_URL}"
+    )
 
 
 def post_to_slack(
@@ -448,6 +450,7 @@ def post_to_slack(
         text=sub_message,
         # According to https://api.slack.com/methods/conversations.replies
         thread_ts=response.get("ts"),
+        unfurl_media=False,
     )
     # return response.get("ts"), sub_response.get("ts")
 
@@ -483,7 +486,7 @@ def auto_propose(
             f"Solver Rewards transaction with nonce {nonce} pending signatures.\n"
             f"To sign and execute, visit:\n{SAFE_URL}\nMore details in thread"
         ),
-        sub_message=log_saver.get_value(),
+        sub_message="```" + log_saver.get_value() + "```",
     )
 
 

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -464,7 +464,6 @@ def post_to_slack(
             thread_ts=response.get("ts"),
             unfurl_media=False,
         )
-    # return response.get("ts"), sub_response.get("ts")
 
 
 def auto_propose(

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -447,6 +447,7 @@ def post_to_slack(
     # Post logs in thread.
     slack_client.chat_postMessage(
         channel=channel,
+        format="mrkdwn",
         text=sub_message,
         # According to https://api.slack.com/methods/conversations.replies
         thread_ts=response.get("ts"),
@@ -486,7 +487,7 @@ def auto_propose(
             f"Solver Rewards transaction with nonce {nonce} pending signatures.\n"
             f"To sign and execute, visit:\n{SAFE_URL}\nMore details in thread"
         ),
-        sub_message="```" + log_saver.get_value() + "```",
+        sub_message=log_saver.get_value(),
     )
 
 

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -39,7 +39,7 @@ def post_multisend(
     transfers: list[MultiSendTx],
     client: EthereumClient,
     signing_key: str,
-) -> None:
+) -> int:
     """Posts a MultiSend Transaction from a list of Transfers."""
     encoded_multisend = build_encoded_multisend(transactions=transfers, client=client)
     safe = Safe(address=safe_address, ethereum_client=client)
@@ -58,3 +58,4 @@ def post_multisend(
         f" {safe_tx.safe_tx_hash.hex()} to {safe.address}"
     )
     tx_service.post_transaction(safe_address=safe.address, safe_tx=safe_tx)
+    return int(safe_tx.safe_nonce)

--- a/src/utils/print_store.py
+++ b/src/utils/print_store.py
@@ -1,13 +1,19 @@
+"""
+Simple wrapper for print statements that saves all the messages chronologically in a list
+"""
 
 
 class PrintStore:
+    """Prints and saves messages in a list"""
 
-    def __init__(self):
-        self.store = []
+    def __init__(self) -> None:
+        self.store: list[str] = []
 
-    def print(self, message: str):
+    def print(self, message: str) -> None:
+        """Add message to store and print"""
         self.store.append(message)
         print(message)
 
     def get_value(self) -> str:
+        """Returns the print history"""
         return "\n".join(self.store)

--- a/src/utils/print_store.py
+++ b/src/utils/print_store.py
@@ -1,0 +1,13 @@
+
+
+class PrintStore:
+
+    def __init__(self):
+        self.store = []
+
+    def print(self, message: str):
+        self.store.append(message)
+        print(message)
+
+    def get_value(self) -> str:
+        return "\n".join(self.store)

--- a/src/utils/print_store.py
+++ b/src/utils/print_store.py
@@ -1,19 +1,35 @@
 """
 Simple wrapper for print statements that saves all the messages chronologically in a list
 """
+from collections import defaultdict
+from enum import Enum
+
+
+class Category(Enum):
+    """Known Categories for PrintStore"""
+
+    GENERAL = ""
+    TOTALS = "Totals"
+    OVERDRAFT = "Overdraft"
+    REDIRECT = "Redirect"
+    SLIPPAGE = "Slippage"
 
 
 class PrintStore:
     """Prints and saves messages in a list"""
 
     def __init__(self) -> None:
-        self.store: list[str] = []
+        self.store: dict[Category, list[str]] = defaultdict(list)
 
-    def print(self, message: str) -> None:
+    def print(self, message: str, category: Category) -> None:
         """Add message to store and print"""
-        self.store.append(message)
+        self.store[category].append(message)
         print(message)
 
-    def get_value(self) -> str:
+    def get_value(self, category: Category) -> str:
         """Returns the print history"""
-        return "\n".join(self.store)
+        return "\n".join(self.store[category])
+
+    def get_values(self) -> dict[str, str]:
+        """Returns partitioned dictionary of values per category"""
+        return {category.value: self.get_value(category) for category in self.store}

--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -13,6 +13,7 @@ class ScriptArgs:
     dune: DuneAPI
     period: AccountingPeriod
     post_tx: bool
+    dry_run: bool
 
 
 def generic_script_init(description: str) -> ScriptArgs:
@@ -32,9 +33,18 @@ def generic_script_init(description: str) -> ScriptArgs:
         "(requires valid env var `PROPOSER_PK`)",
         default=False,
     )
+    parser.add_argument(
+        "--dry-run",
+        type=bool,
+        help="Flag indicating whether script should not post alerts or transactions. "
+        "Only relevant in combination with --post-tx True"
+        "Primarily intended for deployment in staging environment.",
+        default=False,
+    )
     args = parser.parse_args()
     return ScriptArgs(
         dune=DuneAPI.new_from_environment(),
         period=AccountingPeriod(args.start),
         post_tx=args.post_tx,
+        dry_run=args.dry_run,
     )

--- a/tests/e2e/test_slack_post.py
+++ b/tests/e2e/test_slack_post.py
@@ -1,0 +1,45 @@
+import os
+import ssl
+import unittest
+
+import certifi
+from slack import WebClient
+from slack.errors import SlackApiError
+
+from src.fetch.transfer_file import post_to_slack
+
+
+class TestSlackPost(unittest.TestCase):
+    def test_post_to_slack(self):
+        # Test Results here:
+        # https://cowservices.slack.com/archives/C03PW4CR38A/p1658933310842469
+        bad_client = WebClient(
+            token="",  # Invalid Token,
+            ssl=ssl.create_default_context(cafile=certifi.where()),
+        )
+        good_client = WebClient(
+            token=os.environ["SLACK_TOKEN"],
+            ssl=ssl.create_default_context(cafile=certifi.where()),
+        )
+        with self.assertRaises(SlackApiError):
+            post_to_slack(
+                slack_client=bad_client,
+                channel=os.environ["SLACK_CHANNEL"],
+                message="Test Message",
+                sub_message="Test Reply in Thread",
+            )
+
+        # TODO - delete these posts (i.e. cleanup)
+        self.assertEqual(
+            post_to_slack(
+                slack_client=good_client,
+                channel=os.environ["SLACK_CHANNEL"],
+                message="Test Message",
+                sub_message="Test Reply in Thread",
+            ),
+            None,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_slack_post.py
+++ b/tests/e2e/test_slack_post.py
@@ -38,7 +38,6 @@ class TestSlackPost(unittest.TestCase):
                 sub_messages={
                     "Test Category1": "First Inner Message",
                     "Test Category 2": "Second Inner Message",
-                    "Example Code Block": "```Test Code Block```"
                 },
             ),
             None,

--- a/tests/e2e/test_slack_post.py
+++ b/tests/e2e/test_slack_post.py
@@ -25,8 +25,8 @@ class TestSlackPost(unittest.TestCase):
             post_to_slack(
                 slack_client=bad_client,
                 channel=os.environ["SLACK_CHANNEL"],
-                message="Test Message",
-                sub_message="Test Reply in Thread",
+                message="",
+                sub_messages={},
             )
 
         # TODO - delete these posts (i.e. cleanup)
@@ -35,7 +35,11 @@ class TestSlackPost(unittest.TestCase):
                 slack_client=good_client,
                 channel=os.environ["SLACK_CHANNEL"],
                 message="Test Message",
-                sub_message="```Test Reply in Thread```",
+                sub_messages={
+                    "Test Category1": "First Inner Message",
+                    "Test Category 2": "Second Inner Message",
+                    "Example Code Block": "```Test Code Block```"
+                },
             ),
             None,
         )

--- a/tests/e2e/test_slack_post.py
+++ b/tests/e2e/test_slack_post.py
@@ -35,7 +35,7 @@ class TestSlackPost(unittest.TestCase):
                 slack_client=good_client,
                 channel=os.environ["SLACK_CHANNEL"],
                 message="Test Message",
-                sub_message="Test Reply in Thread",
+                sub_message="```Test Reply in Thread```",
             ),
             None,
         )


### PR DESCRIPTION
Based on the discussion in slack: https://cowservices.slack.com/archives/C0361CDD1FZ/p1658843635716449

As the final step before automation of this process, we needed a way to alert the team that a transaction has been created. This PR introduces basic functionality required to alert on the posted transaction in the following way:

Once the transaction is posted to the safe, a message is sent to our internal #dev-multisig channel

```
Solver Rewards transaction with nonce {nonce} pending signatures.
To sign and execute, visit:
{SAFE_URL}
More details in thread
```

Inside the thread of this message, we also post the relevant logs. Specifically,

<details>

```sh
The data being aggregated here is available for visualization at
https://dune.com/gnosis.protocol/solver-rewards-accounting?StartTime=2022-07-10+00%3A00%3A00&EndTime=2022-07-17+00%3A00%3A00
Deducting slippage for solver 0x109BF9E0287Cc95cc623FBE7380dD841d4bdEb03by -0.01976 (barn-Otex)
Deducting slippage for solver 0x22DEE0935c77d32c7241362b14e76fc2D5eF657dby -0.00000 (barn-BalancerSOR)
Deducting slippage for solver 0x3Cee8C7d9B5C8F225A8c36E7d3514e1860309651by -0.00157 (prod-Baseline)
Deducting slippage for solver 0x5B0BFe439ab45A4F002C259b1654ED21c9a42D69by -0.01116 (barn-PLM)
Deducting slippage for solver 0x7A0A8890D71A4834285efDc1D18bb3828e765C6Aby -0.00067 (prod-Naive)
Deducting slippage for solver 0x8567351D6989d83513D3BC3ad951CcCe363941e3by -0.00175 (barn-Atlas)
Deducting slippage for solver 0xa0044c620Da7f2876dA7004719b8370eb7BE5e50by -0.00431 (barn-MIP)
Deducting slippage for solver 0xb20B86C4e6DEEB432A22D773a221898bBBD03036by -4.44768 (prod-1inch)
Deducting slippage for solver 0xc9ec550BEA1C64D779124b23A26292cc223327b6by -0.51984 (prod-Otex)
Deducting slippage for solver 0xda324c2f06d3544E7965767ce9ca536dcb67a660by -0.01314 (barn-QuasiModo)
Deducting slippage for solver 0xDe786877a10DBb7EBa25a4DA65aEcf47654F08abby -0.00683 (barn-0x)
Deducting slippage for solver 0xe18B5632DF2Ec339228DD65e4D9F004eF59653d3by -0.50232 (prod-Atlas)
Deducting slippage for solver 0xe33062a24149f7801a48B2675Ed5111d3278F0f5by -0.05856 (barn-1inch)
Slippage for 0xe33062a24149f7801a48B2675Ed5111d3278F0f5(barn-1inch) exceeds reimbursement: Invalid adjustment TransferETH(receiver=0xe33062a24149f7801a48B2675Ed5111d3278F0f5, amount_wei=0.0409522703268333) by -0.05856302842290827
Excluding payout and appending excess to overdraft
Deducting slippage for solver 0xE9aE2D792F981C53EA7f6493A17Abf5B2a45a86bby -1.94828 (prod-ParaSwap)
Deducting slippage for solver 0xF7995B6B051166eA52218c37b8d03A2A6bbeF3DAby -0.26270 (prod-BalancerSOR)
Redirecting solver 0x080a8b1E2f3695E179453c5e617b72A381BE44B9 COW tokens (480.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0x0d2584DA2F637805071f184bCFa1268eBAe8a24A COW tokens (170.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0x109BF9E0287Cc95cc623FBE7380dD841d4bdEb03 COW tokens (3570.0) to 0x84dbAE2549d67CaF00f65C355de3D6F4df59A32C
Redirecting solver 0x149d0f9282333681Ee41D30589824b2798E9fb47 COW tokens (82355.0) to 0xf7f9C5ecAFd159271fe55A8FEdEDa95d7fcD0DCc
Redirecting solver 0x22DEE0935c77d32c7241362b14e76fc2D5eF657d COW tokens (170.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0x3Cee8C7d9B5C8F225A8c36E7d3514e1860309651 COW tokens (7970.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0x5B0BFe439ab45A4F002C259b1654ED21c9a42D69 COW tokens (510.0) to 0xf7f9C5ecAFd159271fe55A8FEdEDa95d7fcD0DCc
Redirecting solver 0x6D1247b8ACf4dFD5Ff8cfD6C47077ddC43d4500E COW tokens (7850.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0x731a0A8ab2C6FcaD841e82D06668Af7f18e34970 COW tokens (34345.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0x7A0A8890D71A4834285efDc1D18bb3828e765C6A COW tokens (360.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0x8567351D6989d83513D3BC3ad951CcCe363941e3 COW tokens (595.0) to 0x28Dc5cd8785A31199211205124d140B57b054108
Redirecting solver 0xa0044c620Da7f2876dA7004719b8370eb7BE5e50 COW tokens (850.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0xb20B86C4e6DEEB432A22D773a221898bBBD03036 COW tokens (35040.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0xc9ec550BEA1C64D779124b23A26292cc223327b6 COW tokens (112875.0) to 0x84dbAE2549d67CaF00f65C355de3D6F4df59A32C
Redirecting solver 0xda324c2f06d3544E7965767ce9ca536dcb67a660 COW tokens (1455.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0xdA869Be4AdEA17AD39E1DFeCe1bC92c02491504f COW tokens (21375.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0xdAE69AffE582d36f330Ee1145995A53Fab670962 COW tokens (460.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0xDe786877a10DBb7EBa25a4DA65aEcf47654F08ab COW tokens (85.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0xe18B5632DF2Ec339228DD65e4D9F004eF59653d3 COW tokens (10480.0) to 0x28Dc5cd8785A31199211205124d140B57b054108
Deducting 224512758348341870592 COW from reward for 0xe33062a24149f7801a48B2675Ed5111d3278F0f5
Redirecting solver 0xe33062a24149f7801a48B2675Ed5111d3278F0f5 COW tokens (115.48724165165812) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0xE9aE2D792F981C53EA7f6493A17Abf5B2a45a86b COW tokens (18925.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Redirecting solver 0xF7995B6B051166eA52218c37b8d03A2A6bbeF3DA COW tokens (4320.0) to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
Total Slippage deducted (ETH): -7.699048214298761
Total ETH Funds needed: 38.71062626688295
Total COW Funds needed: 344355.48724165163
```

</details>

This was accomplished by introducing a `LogSaver` which stores a list of all "print" statements and has the ability to return them at will on demand (which is done for the slack message).

Additionally a few constants were updated.


# Test Plan:

An e2e test was introduced (that should not be run regularly - It actually posts messages to slack!)

You can see the results [here](https://cowservices.slack.com/archives/C03PW4CR38A/p1658934084927009) (It would be possible to delete these messages after the test if we want to go that way). 

<img width="461" alt="Screenshot 2022-07-27 at 10 46 27 PM" src="https://user-images.githubusercontent.com/11778116/181369055-40255e36-3058-429e-9a56-d0e5e02b0030.png">


[Here](https://cowservices.slack.com/archives/C03PW4CR38A/p1658953802134659) is a real test run posting to Rinkeby.


<img width="761" alt="Screenshot 2022-07-27 at 10 45 56 PM" src="https://user-images.githubusercontent.com/11778116/181368979-919f988d-cf48-421a-b689-4f9a3e8936eb.png">


along with the corresponding [proposed transactions](https://gnosis-safe.io/app/rin:0x8990c564ec303C7b26d3d5556ef0910E58Be08Ce/transactions/queue). Notice that running this script twice results in overwriting the unconfirmed transaction.



![Screenshot 2022-07-27 at 10 45 27 PM](https://user-images.githubusercontent.com/11778116/181368881-60a34838-f41d-43b1-b9c4-5936ca7d9b74.png)

