### PR TITLE
[Automation] Default Start Date

### DIFF
--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -1,9 +1,17 @@
 """Common method for initializing setup for scripts"""
 import argparse
+from datetime import datetime, date, timedelta
 from dataclasses import dataclass
 
 from duneapi.api import DuneAPI
 from src.models import AccountingPeriod
+
+
+def previous_tuesday(day: date = date.today()) -> datetime.date:
+    week_day = day.weekday()
+    if week_day > 1:
+        return day - timedelta(days=week_day - 1)
+    return day - timedelta(days=6 + week_day)
 
 
 @dataclass
@@ -24,7 +32,10 @@ def generic_script_init(description: str) -> ScriptArgs:
     """
     parser = argparse.ArgumentParser(description)
     parser.add_argument(
-        "--start", type=str, help="Accounting Period Start", required=True
+        "--start",
+        type=str,
+        help="Accounting Period Start. Defaults to previous Tuesday",
+        default=str(previous_tuesday(date.today())),
     )
     parser.add_argument(
         "--post-tx",

--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -1,13 +1,17 @@
 """Common method for initializing setup for scripts"""
 import argparse
-from datetime import datetime, date, timedelta
+from datetime import date, timedelta
 from dataclasses import dataclass
 
 from duneapi.api import DuneAPI
 from src.models import AccountingPeriod
 
 
-def previous_tuesday(day: date = date.today()) -> datetime.date:
+def previous_tuesday(day: date = date.today()) -> date:
+    """
+    Returns the previous Tuesday for a given date (defaulting to today).
+    If the day is a Tuesday, then the previous Tuesday is the one before
+    """
     week_day = day.weekday()
     if week_day > 1:
         return day - timedelta(days=week_day - 1)

--- a/tests/unit/test_script_args.py
+++ b/tests/unit/test_script_args.py
@@ -24,4 +24,4 @@ class TestPreviousTuesday(unittest.TestCase):
                 previous_tuesday(some_tuesday + timedelta(days=i)), forward_expected
             )
 
-        self.assertEqual(str(some_tuesday), '2020-03-10')
+        self.assertEqual(str(some_tuesday), "2020-03-10")

--- a/tests/unit/test_script_args.py
+++ b/tests/unit/test_script_args.py
@@ -1,0 +1,27 @@
+from datetime import date, timedelta
+import unittest
+
+from src.utils.script_args import previous_tuesday
+
+
+class TestPreviousTuesday(unittest.TestCase):
+    def test_previous_tuesday(self):
+        some_tuesday = date(year=2020, month=3, day=10)
+        assert some_tuesday.weekday() == 1, "Tuesday week day is 1"
+        backwards_expected = some_tuesday - timedelta(days=7)
+
+        # going backward from tuesday (inclusive):
+        for i in range(7):
+            self.assertEqual(
+                backwards_expected,
+                previous_tuesday(some_tuesday - timedelta(days=i)),
+                f"Failed at index {i}",
+            )
+        # going forward from tuesday (exclusive):
+        forward_expected = some_tuesday
+        for i in range(1, 7):
+            self.assertEqual(
+                previous_tuesday(some_tuesday + timedelta(days=i)), forward_expected
+            )
+
+        self.assertEqual(str(some_tuesday), '2020-03-10')


### PR DESCRIPTION
Right now we manually pass in a start date parameter to this script. However, during automation it will be easier for the script to dynamically know the accounting period to run for. Thus, we make this argument default to the previous Tuesday. Since the job will run on Tuesdays, the deployed script will use rely on the default (previous Tuesday) as its Accounting Period Start.


Note: Additionally, that this change does not affect the current manual process as described in the README.

# Test Plan

New unit tests demonstrate that `previous_tuesday` works in all possible cases (going forwards and backwards).