### PR TITLE
Exclude TestSolvers From Payout

### DIFF
--- a/queries/period_transfers.sql
+++ b/queries/period_transfers.sql
@@ -1,13 +1,17 @@
 with
 -- For a configurable permanent version visit: https://dune.xyz/queries/469110
 relevant_batch_info as (
+    -- This subquery can be played with here: https://dune.com/queries/1297092
     select concat('0x', encode(solver_address, 'hex')) as solver,
            sum(gas_price_gwei * gas_used) * 10 ^ 9     as eth_spent,
            count(*) * '{{PerBatchReward}}'             as batch_reward,
            sum(num_trades) * '{{PerTradeReward}}'      as trade_reward
     from gnosis_protocol_v2.batches
+    join gnosis_protocol_v2.view_solvers
+        on solver_address = address
     where block_time >= '{{StartTime}}'
       and block_time < '{{EndTime}}'
+      and environment not in ('services', 'test')
     group by solver
 )
 


### PR DESCRIPTION
Test solvers are not bonded and we don't give them COW rewards.

We were already excluding these solvers from slippage calculation, but had forgotten to exclude them from the ETH spent and COW rewards query. This fixes that:

# TEST PLAN

Here is a PoC Query showing what it was like before in comparison with now (use the Excluded Environments parameter to see the difference). 

https://dune.com/queries/1297092

