### PR TITLE
[HotFix] Fix Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,4 @@
-FROM python:alpine
-RUN apk add --update gcc libc-dev linux-headers postgresql-dev
-
-WORKDIR /app
-
-COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
-
+FROM python
 COPY . .
-
+RUN pip install -r requirements.txt
 ENTRYPOINT [ "python3", "-m" , "src.fetch.transfer_file"]


### PR DESCRIPTION
Since the recent introduction of pandas the alpine image we were using didn't suffice. This uses a python docker image (and greatly simplifies the dockerfile).

Observe our failing build: https://github.com/cowprotocol/solver-rewards/actions/runs/3173564523/jobs/5169321471

Issues: There are several links (search "install pandas docker alpine")

- https://gist.github.com/orenitamar/f29fb15db3b0d13178c1c4dd611adce2
- https://stackoverflow.com/questions/54890328/installing-pandas-in-docker-alpine


# Test Plan

```sh
docker build . test-solver-rewards
```

Run as in the README (also cross check with readme)

```sh
docker run -it --rm --env-file .env -v $PWD:/out test-solver-rewards --start 2022-09-20 --dry-run True --post-tx False
```