### PR TITLE
[Easy] Link Slippage to Tokenwise Breakdown

### DIFF
--- a/dashboards/solver-rewards-accounting/unusual-slippage.sql
+++ b/dashboards/solver-rewards-accounting/unusual-slippage.sql
@@ -1,6 +1,7 @@
 select
     block_time,
     rpt.solver_name,
+    concat('<a href="https://dune.com/queries/663231?TxHash=', concat('0x', encode(rpt.tx_hash, 'hex')), '" target="_blank">link</a>') as token_breakdown,
     concat('0x', encode(rpt.tx_hash, 'hex')) as tx_hash,
     usd_value,
     batch_value,

--- a/tests/e2e/test_slack_post.py
+++ b/tests/e2e/test_slack_post.py
@@ -36,7 +36,7 @@ class TestSlackPost(unittest.TestCase):
                 channel=os.environ["SLACK_CHANNEL"],
                 message="Test Message",
                 sub_messages={
-                    "Test Category1": "First Inner Message",
+                    "Test Category 1": "First Inner Message",
                     "Test Category 2": "Second Inner Message",
                 },
             ),


### PR DESCRIPTION
For investigating unusual slippage batches, it helps to know what token is causing the accounting imbalance (easier than etherscan).

<img width="1135" alt="Screenshot 2022-10-11 at 1 00 56 PM" src="https://user-images.githubusercontent.com/11778116/195073631-0a90003c-06c6-4f1e-bb00-8f6556e0b6d5.png">


This PR adds a column with a "link" to the token_breakdown in the unusual slippage query. From there, we see there are also links to the etherscan tx.

cc @c3rnst 


# Test Plan:

Check out this query and follow the link...

https://dune.com/queries/645559/1200795?EndTime_d83555=2022-10-11+00%3A00%3A00&StartTime_d83555=2022-10-04+00%3A00%3A00