### PR TITLE
Update e2e tests & psycopg2 Dependency

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,7 +12,7 @@ PROPOSER_PK=
 
 # Slack Bot Credentials
 SLACK_TOKEN=
-SLACK_ALERT_CHANNEL=
+SLACK_CHANNEL=
 
 # Orderbook DB Credentials
 PROD_ORDERBOOK_HOST=

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ black==22.6.0
 certifi==2022.6.15
 duneapi==6.0.0
 mypy==0.961
-psycopg2==2.9.3
+psycopg2-binary==2.9.3
 pylint==2.14.4
 pytest==7.1.2
 python-dotenv>=0.20.0

--- a/tests/e2e/test_token_details.py
+++ b/tests/e2e/test_token_details.py
@@ -6,24 +6,19 @@ from src.utils.token_details import get_token_decimals
 
 
 class TestTokenDecimals(unittest.TestCase):
-    def setUp(self) -> None:
-        self.cow = "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB"
-        self.usdc = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-
     def test_token_decimals(self):
-        self.assertEqual(get_token_decimals(self.cow), 18)
-        self.assertEqual(get_token_decimals(self.usdc), 6)
-
-        self.assertEqual(get_token_decimals(duneapi.types.Address(self.usdc)), 6)
-        self.assertEqual(get_token_decimals(duneapi.types.Address(self.cow)), 18)
+        # Goerli doesn't seem to have tokens with anything other than 18 decimals.
+        cow = "0x3430d04E42a722c5Ae52C5Bffbf1F230C2677600"
+        self.assertEqual(get_token_decimals(cow), 18)
+        self.assertEqual(get_token_decimals(duneapi.types.Address(cow)), 18)
 
     def test_token_decimals_cache(self):
-        new_token = "0x10245515d35BC525e3C0977412322BFF32382EF1"
+        usdc = "0x5ffbac75efc9547fbc822166fed19b05cd5890bb"
         with self.assertLogs("src.utils.token_details", level="INFO"):
-            get_token_decimals(new_token)
+            get_token_decimals(usdc)
 
         with self.assertNoLogs("src.utils.token_details", level="INFO"):
-            get_token_decimals(new_token)
+            get_token_decimals(usdc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Recently (since the introduction of `psycopg2` dependency) it has been impossible to run e2e tests from within a virtual environment (on a Mac). This is - I suspect - because of the path where homebrew puts postgres: 

The error starts off looking like this:

```
$ python -m pytest tests/e2e

E   ImportError: dlopen(/solver-rewards/venv/lib/python3.10/site-packages/psycopg2/_psycopg.cpython-310-darwin.so, 0x0002): Library not loaded: '/opt/homebrew/opt/postgresql/lib/libpq.5.dylib'
E     Referenced from: '/solver-rewards/venv/lib/python3.10/site-packages/psycopg2/_psycopg.cpython-310-darwin.so'
E     Reason: tried: '/opt/homebrew/opt/postgresql/lib/libpq.5.dylib' (no such file), '/usr/local/lib/libpq.5.dylib' (no such file), '/usr/lib/libpq.5.dylib' (no such file), '/opt/homebrew/Cellar/postgresql@14/14.5_5/lib/libpq.5.dylib' (no such file), '/usr/local/lib/libpq.5.dylib' (no such file), '/usr/lib/libpq.5.dylib' (no such file)
```

talking about libpq and dylib. Even if you manage to get past this you will also eventually run into something that looks like missing postgres path (and its a nightmare and you can try making a bunch of symlinks and it will never work). Anyway, its been a long rabbit hole and yesterday I was chatting with @kalatabe over some beers who told me that all this baloney would magically disappear if we used `psycopg2-binary` instead! Tried it out and was immediately satisfied!

Also there were a few broken e2e tests (since the deprecation of Rinkeby Test). Had to change the token addresses for some token tests. Furthermore, I can no longer find any tokens that do not have 18 decimal places and the ERC20 token standard has changed so that 18 is the default ([see here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.7.3/contracts/token/ERC20/ERC20.sol)). Instead of deploying my own special token with 6 decimals I just decided to remove that check from the test.


# Test Plan

For any one on a mac

1. check out main
2. From within a venv try this:

```sh
$ (venv) python -m pytest tests/e2e/test_get_transfers.py
```
and observe the hideous error (shown above)

3. Change the dependency (or checkout this branch and install requirements)

```sh
pip uninstall psycopg2 && pip install psycopg2-binary
```
4. Run the e2e test again and watch it magically work like a charm.

