### PR TITLE
Fix path for log config

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,9 +1,10 @@
 """Project Global Constants. """
 import json
 import os
+from pathlib import Path
 
-from duneapi.types import Address
 from dotenv import load_dotenv
+from duneapi.types import Address
 from gnosis.eth.ethereum_network import EthereumNetwork
 from web3 import Web3
 
@@ -12,6 +13,8 @@ COW_TOKEN_ADDRESS = Address("0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB")
 COW_PER_BATCH = 50
 COW_PER_TRADE = 35
 
+
+LOG_CONFIG_FILE = Path(__file__).parent.parent / Path("logging.conf")
 # Things requiring network
 load_dotenv()
 ENV = os.environ

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -10,7 +10,7 @@ from duneapi.api import DuneAPI
 from duneapi.types import QueryParameter, DuneQuery, Network, Address, DuneRecord
 from duneapi.util import open_query
 
-from constants import LOG_CONFIG_FILE
+from src.constants import LOG_CONFIG_FILE
 from src.models import AccountingPeriod
 from src.token_list import fetch_trusted_tokens
 from src.update.token_list import update_token_list

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -10,13 +10,16 @@ from duneapi.api import DuneAPI
 from duneapi.types import QueryParameter, DuneQuery, Network, Address, DuneRecord
 from duneapi.util import open_query
 
+from constants import LOG_CONFIG_FILE
 from src.models import AccountingPeriod
 from src.token_list import fetch_trusted_tokens
 from src.update.token_list import update_token_list
 from src.utils.script_args import generic_script_init
 
 log = logging.getLogger(__name__)
-logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=False)
+logging.config.fileConfig(
+    fname=LOG_CONFIG_FILE.absolute(), disable_existing_loggers=False
+)
 
 
 class QueryType(Enum):

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -9,6 +9,7 @@ from gnosis.eth.ethereum_client import EthereumClient
 from gnosis.eth.ethereum_network import EthereumNetwork
 from gnosis.safe.multi_send import MultiSend, MultiSendOperation, MultiSendTx
 from gnosis.safe.safe import Safe
+
 # This dependency can be removed once this issue is resolved:
 # https://github.com/safe-global/safe-eth-py/issues/284
 from safe_cli.api.transaction_service_api import TransactionServiceApi

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -7,15 +7,18 @@ import logging.config
 from eth_typing.evm import ChecksumAddress
 from gnosis.eth.ethereum_client import EthereumClient
 from gnosis.eth.ethereum_network import EthereumNetwork
-from gnosis.safe.safe import Safe
 from gnosis.safe.multi_send import MultiSend, MultiSendOperation, MultiSendTx
-
+from gnosis.safe.safe import Safe
 # This dependency can be removed once this issue is resolved:
 # https://github.com/safe-global/safe-eth-py/issues/284
 from safe_cli.api.transaction_service_api import TransactionServiceApi
 
+from constants import LOG_CONFIG_FILE
+
 log = logging.getLogger(__name__)
-logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=False)
+logging.config.fileConfig(
+    fname=LOG_CONFIG_FILE.absolute(), disable_existing_loggers=False
+)
 
 # This contract address can be removed once this issue is resolved:
 # https://github.com/safe-global/safe-eth-py/issues/283

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -13,7 +13,7 @@ from gnosis.safe.safe import Safe
 # https://github.com/safe-global/safe-eth-py/issues/284
 from safe_cli.api.transaction_service_api import TransactionServiceApi
 
-from constants import LOG_CONFIG_FILE
+from src.constants import LOG_CONFIG_FILE
 
 log = logging.getLogger(__name__)
 logging.config.fileConfig(

--- a/src/update/token_list.py
+++ b/src/update/token_list.py
@@ -10,11 +10,14 @@ from duneapi.api import DuneAPI
 from duneapi.types import DuneQuery, Network
 from duneapi.util import open_query
 
+from constants import LOG_CONFIG_FILE
 from src.token_list import fetch_trusted_tokens
 from src.utils.script_args import generic_script_init
 
 log = logging.getLogger(__name__)
-logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=False)
+logging.config.fileConfig(
+    fname=LOG_CONFIG_FILE.absolute(), disable_existing_loggers=False
+)
 
 
 def update_token_list(dune: DuneAPI, token_list: list[str]) -> list[dict[str, str]]:

--- a/src/update/token_list.py
+++ b/src/update/token_list.py
@@ -10,7 +10,7 @@ from duneapi.api import DuneAPI
 from duneapi.types import DuneQuery, Network
 from duneapi.util import open_query
 
-from constants import LOG_CONFIG_FILE
+from src.constants import LOG_CONFIG_FILE
 from src.token_list import fetch_trusted_tokens
 from src.utils.script_args import generic_script_init
 

--- a/src/utils/prices.py
+++ b/src/utils/prices.py
@@ -9,7 +9,7 @@ from enum import Enum
 
 from coinpaprika import client as cp
 
-from constants import LOG_CONFIG_FILE
+from src.constants import LOG_CONFIG_FILE
 
 log = logging.getLogger(__name__)
 logging.config.fileConfig(

--- a/src/utils/prices.py
+++ b/src/utils/prices.py
@@ -4,13 +4,17 @@ Currently, only price feed is CoinPaprika's Free tier API.
 """
 import functools
 import logging.config
-from enum import Enum
 from datetime import datetime
+from enum import Enum
 
 from coinpaprika import client as cp
 
+from constants import LOG_CONFIG_FILE
+
 log = logging.getLogger(__name__)
-logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=False)
+logging.config.fileConfig(
+    fname=LOG_CONFIG_FILE.absolute(), disable_existing_loggers=False
+)
 
 client = cp.Client()
 

--- a/src/utils/token_details.py
+++ b/src/utils/token_details.py
@@ -3,12 +3,16 @@ Very basic Token Info Fetcher that gets token decimals
 """
 import functools
 import logging.config
+
 from duneapi.types import Address
 
-from src.constants import w3, ERC20_ABI
+from src.constants import w3, ERC20_ABI, LOG_CONFIG_FILE
 
 log = logging.getLogger(__name__)
-logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=False)
+
+logging.config.fileConfig(
+    fname=LOG_CONFIG_FILE.absolute(), disable_existing_loggers=False
+)
 
 
 @functools.cache


### PR DESCRIPTION
When using pycharm, if trying to run the test via the play buttons, we were always failing because of the working directory. This lead me to realize that the way logging config was imported was incorrect.

We probably also need to change the relative paths when opening query files. Unfortunately this needs to be fixed deep inside duneapi project's `open_query` method.