### PR TITLE
[Idea] Update ETH Spent Query

### DIFF
--- a/queries/eth_spent.sql
+++ b/queries/eth_spent.sql
@@ -1,21 +1,29 @@
--- V1: https://dune.com/queries/1320169
-select concat('0x', encode(solver_address, 'hex')) as receiver,
-       sum(gas_price_gwei * gas_used) * 10 ^ 9     as amount
-from gnosis_protocol_v2.batches
-join gnosis_protocol_v2.view_solvers
-    on solver_address = address
-where block_time between '{{StartTime}}' and '{{EndTime}}'
-  and environment not in ('services', 'test')
-group by receiver
-order by amount desc
+-- V1: https://dune.com/queries/1403457
+select concat('0x', encode(address, 'hex')) as solver,
+       sum(gas_price * gas_used) as eth_spent,
+       count(*) as num_transactions
+from gnosis_protocol_v2.view_solvers
+inner join ethereum.transactions
+    on "from" = address
+    and "to" = '\x9008d19f58aabd9ed0d60971565aa8510560ab41'
+    and position('\x13d79a0b' in data) > 0 --! settle method ID
+    and block_time between '{{StartTime}}' and '{{EndTime}}'
+    and success = true
+    and environment not in ('services', 'test')
+group by solver
+order by eth_spent desc
 
--- --! They do not seem to agree!
--- -- V2: https://dune.com/queries/1320174
--- select solver_address as receiver,
---        cast(sum(gas_price * gas_used) as decimal(38,0))::string     as eth_spent
--- from cow_protocol_ethereum.batches
--- join cow_protocol_ethereum.solvers
---     on solver_address = address
--- where block_time between '{{StartTime}}' and '{{EndTime}}'
---   and environment not in ('services', 'test')
--- group by receiver
+-- -- V2: https://dune.com/queries/1403493
+-- select address as solver,
+--        sum(gas_price * gas_used) / pow(10, 18) as eth_spent,
+--        count(*) as num_transactions
+-- from cow_protocol_ethereum.solvers
+-- inner join ethereum.transactions
+--     on from = address
+--     and block_time between '{{StartTime}}' and '{{EndTime}}'
+--     and to = '0x9008d19f58aabd9ed0d60971565aa8510560ab41'
+--     and position('0x13d79a0b' in data) > 0 --! settle method ID
+--     and success = true
+--     and environment not in ('services', 'test')
+-- group by solver
+-- order by eth_spent desc


### PR DESCRIPTION
Since the batches table (created as a dune abstraction) explicitly excludes batches containing ZERO trades, it was mentioned that we may want to consider reimbursing other successful transactions (such as approvals). 

This draft PR, intended for discussion, implements an alternate query for "ETH Spent" used to reimburse solvers. 

Explicitly it calculates all eth spent on successful transactions to the settle method of the settlement contract (regardless of whether there are trades contained in the batch). Furthermore, this remains restricted to all whose environment is not 'test' or 'service'.