### PR TITLE
HotFix: AMM Transfer Categorization

### DIFF
--- a/queries/period_slippage.sql
+++ b/queries/period_slippage.sql
@@ -77,10 +77,12 @@ other_transfers as (
       and "from" not in (
         select trader_in
         from filtered_trades
+        where evt_tx_hash = tx_hash
     )
       and "to" not in (
         select trader_out
         from filtered_trades
+        where evt_tx_hash = tx_hash
     )
       and case
               when '{{TxHash}}' = '0x' then true

--- a/tests/e2e/test_token_details.py
+++ b/tests/e2e/test_token_details.py
@@ -18,9 +18,9 @@ class TestTokenDecimals(unittest.TestCase):
         self.assertEqual(get_token_decimals(duneapi.types.Address(self.cow)), 18)
 
     def test_token_decimals_cache(self):
-        new_token = "0x10245515d35BC525e3C0977412322BFF32382EF1"
+        NEW_TOKEN = "0x10245515d35BC525e3C0977412322BFF32382EF1"
         with self.assertLogs("src.utils.token_details", level="INFO"):
-            get_token_decimals(new_token)
+            get_token_decimals(NEW_TOKEN)
 
         with self.assertNoLogs("src.utils.token_details", level="INFO"):
             get_token_decimals(new_token)


### PR DESCRIPTION
Recently Accounts have started implementing themselves as private liquidity sources as in this batch:

[EtherScan](https://etherscan.io/tx/0x0e9ef8eceb8467c24d6f991149e3cd569685e14a63659fb71c27bcd57de02c5c)

The account: 0x7eba631d7dc85cb1296d9900dca3ce9f6edf8ac5 (a Gnosis Safe) has approved solvers to draw funds (as a source of liquidity to be supplied for batch settlement). However these transfer are not trade events and should be categorized as "other transfers" in our slippage query.

The problem is that this particular [account has used CoWSwap](https://etherscan.io/address/0x7eba631d7dc85cb1296d9900dca3ce9f6edf8ac5#tokentxns) as well and so appears in the trader list which use for filtering "other transfers"

This hot fix add a restriction that the to and from must not be in the traders list for the transaction in which the transfer happened. 

UNFORTUNATELY - this makes our **query run time much longer**.


Updated Query has been running here now for 8 minutes already (and is not yet complete)

https://dune.com/queries/645559

We may have to attempt to improve this.