### PR TITLE
Risk Free Reward Adjustments

### DIFF
--- a/queries/cow_rewards.sql
+++ b/queries/cow_rewards.sql
@@ -21,6 +21,8 @@ with trade_hashes as (SELECT solver,
 select concat('0x', encode(solver, 'hex'))  as solver,
        concat('0x', encode(tx_hash, 'hex')) as tx_hash,
        coalesce(reward, 0.0)                as amount,
+       -- An order is a liquidity order if and only if reward is null.
+       -- A liquidity order is safe if and only if its fee_amount is > 0
        case
            when reward is null and fee_amount > 0 then True
            when reward is null and fee_amount = 0 then False

--- a/queries/cow_rewards.sql
+++ b/queries/cow_rewards.sql
@@ -19,7 +19,6 @@ with trade_hashes as (SELECT solver,
 
 select concat('0x', encode(solver, 'hex'))                as solver,
        concat('0x', encode(tx_hash, 'hex'))               as tx_hash,
---        concat('0x', encode(trade_hashes.order_uid, 'hex')) as order_uid,
        coalesce(reward, 0.0) as amount
 from trade_hashes
          -- Inner join because both prod and staging DB index trades and settlements,

--- a/queries/cow_rewards.sql
+++ b/queries/cow_rewards.sql
@@ -1,5 +1,6 @@
 with trade_hashes as (SELECT solver,
                              order_uid,
+                             fee_amount,
                              settlement.tx_hash,
                              solver_competitions.id as auction_id
                       FROM trades t
@@ -11,18 +12,20 @@ with trade_hashes as (SELECT solver,
                           ORDER BY s.log_index ASC
                           LIMIT 1
                           ) AS settlement ON true
-                      join solver_competitions
+                               join solver_competitions
                           -- This join also eliminates overlapping
                           -- trades & settlements between barn and prod DB
-                          on settlement.tx_hash = solver_competitions.tx_hash
+                                    on settlement.tx_hash = solver_competitions.tx_hash
                       where block_number between {{start_block}} and {{end_block}})
 
-select concat('0x', encode(solver, 'hex'))                as solver,
-       concat('0x', encode(tx_hash, 'hex'))               as tx_hash,
-       coalesce(reward, 0.0) as amount
+select concat('0x', encode(solver, 'hex'))  as solver,
+       concat('0x', encode(tx_hash, 'hex')) as tx_hash,
+       coalesce(reward, 0.0)                as amount,
+       case
+           when reward is null and fee_amount > 0 then True
+           when reward is null and fee_amount = 0 then False
+           end                              as safe_liquidity
 from trade_hashes
-         -- Inner join because both prod and staging DB index trades and settlements,
--- but the rewards for each environment are contained only in respective databases.
          left outer join order_rewards
                          on trade_hashes.order_uid = order_rewards.order_uid
                              and trade_hashes.auction_id = order_rewards.auction_id;

--- a/queries/risk_free_batches.sql
+++ b/queries/risk_free_batches.sql
@@ -1,0 +1,42 @@
+with interactions as (select selector,
+                             target,
+                             case
+                                 when selector in (
+                                                   '\x095ea7b3', -- approve
+                                                   '\x2e1a7d4d', -- withdraw
+                                                   '\xa9059cbb', -- transfer
+                                                   '\x23b872dd' -- transferFrom
+                                     ) then true
+                                 else false
+                                 end as risk_free
+                      from gnosis_protocol_v2."GPv2Settlement_evt_Interaction"
+                      where evt_block_time between '{{StartTime}}' and '{{EndTime}}'),
+
+     no_interactions as (select evt_tx_hash
+                         from gnosis_protocol_v2."GPv2Settlement_evt_Settlement"
+                         where evt_block_time between '{{StartTime}}' and '{{EndTime}}'
+                           and evt_tx_hash not in (select evt_tx_hash
+                                                   from gnosis_protocol_v2."GPv2Settlement_evt_Interaction"
+                                                   where evt_block_time between '{{StartTime}}' and '{{EndTime}}')),
+
+     batch_interaction_counts as (select s.evt_tx_hash,
+                                         count(*)                                          as num_interactions,
+                                         sum(case when risk_free = true then 1 else 0 end) as risk_free
+                                  from gnosis_protocol_v2."GPv2Settlement_evt_Settlement" s
+                                           inner join gnosis_protocol_v2."GPv2Settlement_evt_Interaction" i
+                                                      on s.evt_tx_hash = i.evt_tx_hash
+                                           inner join interactions i2
+                                                      on i.selector = i2.selector
+                                                          and i.target = i2.target
+                                  where s.evt_block_time between '{{StartTime}}' and '{{EndTime}}'
+                                  group by s.evt_tx_hash),
+
+     combined_results as (select *
+                          from batch_interaction_counts
+                          where num_interactions = risk_free
+                          union
+                          select *, 0 as num_interactions, 0 as risk_free
+                          from no_interactions)
+
+select concat('0x', encode(evt_tx_hash, 'hex')) as tx_hash
+from combined_results

--- a/src/fetch/orderbook_rewards.py
+++ b/src/fetch/orderbook_rewards.py
@@ -1,0 +1,28 @@
+"""Fetching Per Order Rewards from Production and Staging Database"""
+import pandas as pd
+from duneapi.util import open_query
+from pandas import DataFrame
+
+from src.pg_client import pg_engine, OrderbookEnv
+
+
+def get_orderbook_rewards(start_block: str, end_block: str) -> DataFrame:
+    """Fetches and validates Orderbook Reward DataFrame as concatenation from Prod and Staging DB"""
+    cow_reward_query = (
+        open_query("./queries/cow_rewards.sql")
+        .replace("{{start_block}}", start_block)
+        .replace("{{end_block}}", end_block)
+    )
+
+    # Need to fetch results from both order-books (prod and barn)
+    prod_df: DataFrame = pd.read_sql(
+        sql=cow_reward_query, con=pg_engine(OrderbookEnv.PROD)
+    )
+    print(f"got {prod_df} from production DB")
+    barn_df: DataFrame = pd.read_sql(
+        sql=cow_reward_query, con=pg_engine(OrderbookEnv.BARN)
+    )
+    print(f"got {barn_df} from staging DB")
+    # Solvers do not appear in both environments!
+    assert set(prod_df.solver).isdisjoint(set(barn_df.solver)), "receiver overlap!"
+    return pd.concat([prod_df, barn_df])

--- a/src/fetch/risk_free_batches.py
+++ b/src/fetch/risk_free_batches.py
@@ -1,0 +1,22 @@
+"""Fetching Risk-Free Batches from Dune Analytics"""
+from duneapi.api import DuneAPI
+from duneapi.types import DuneQuery, Network, QueryParameter
+from duneapi.util import open_query
+
+from src.models import AccountingPeriod
+
+
+def get_risk_free_batches(dune: DuneAPI, period: AccountingPeriod) -> set[str]:
+    """Fetches Risk Free Batches from Dune"""
+    results = dune.fetch(
+        query=DuneQuery.from_environment(
+            raw_sql=open_query("./queries/risk_free_batches.sql"),
+            network=Network.MAINNET,
+            name="Risk Free Batches",
+            parameters=[
+                QueryParameter.date_type("StartTime", period.start),
+                QueryParameter.date_type("EndTime", period.end),
+            ],
+        )
+    )
+    return {row["tx_hash"].lower() for row in results}

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -386,13 +386,7 @@ def unsafe_batches(order_df: DataFrame) -> set[str]:
     """
     liquidity = order_df.loc[order_df["amount"] == 0]
     liquidity = liquidity.astype({"safe_liquidity": "boolean"})
-    # Pandas doesn't seem to work with boolean types:
-    # when using "is False" we get
-    # KeyError: 'False: boolean label can not be used without a boolean index'
-    # When using == False we get pylint error
-    unsafe_liquidity = liquidity.loc[
-        liquidity["safe_liquidity"] == False  # pylint: disable=singleton-comparison
-    ]
+    unsafe_liquidity = liquidity.loc[~liquidity["safe_liquidity"]]
     return set(unsafe_liquidity["tx_hash"])
 
 

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -375,6 +375,10 @@ def map_reward(amount: float, risk_free: bool, tx_contains_jit_order: bool) -> f
 
 
 def liquidity_order_batches(order_df: DataFrame) -> set[str]:
+    """
+    Fetches the set of transaction hashes containing a
+    liquidity order as the unique tx_hash where reward `amount = 0`
+    """
     return set(order_df.loc[order_df["amount"] == 0]["tx_hash"].unique())
 
 

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -390,8 +390,8 @@ def liquidity_order_batches(order_df: DataFrame) -> set[str]:
     # KeyError: 'False: boolean label can not be used without a boolean index'
     # When using == False we get pylint error
     unsafe_liquidity = liquidity.loc[
-        liquidity["safe_liquidity"] == False
-    ]  # pylint: disable=singleton-comparison
+        liquidity["safe_liquidity"] == False  # pylint: disable=singleton-comparison
+    ]
     return set(unsafe_liquidity["tx_hash"].unique())
 
 

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -363,11 +363,11 @@ class Overdraft:
         )
 
 
-def map_reward(amount: float, tx_hash: str, risk_free: set[str]) -> float:
+def map_reward(amount: float, risk_free: bool) -> float:
     """
     Converts orderbook rewards based on additional knowledge of "risk_free" transactions
     """
-    if amount > 0 and tx_hash in risk_free:
+    if amount > 0 and risk_free:
         # Risk Free Orders that are not liquidity orders get 37 COW tokens.
         return 37.0
     return amount
@@ -382,9 +382,9 @@ def aggregate_orderbook_rewards(
     the results are aggregated by solver as a sum of amounts and additional
     "transfer" related metadata is appended. The aggregated dataframe is returned.
     """
-    # TODO - passing large set in to function multiple times!
     per_order_df["amount"] = per_order_df[["amount", "tx_hash"]].apply(
-        lambda x: map_reward(x.amount, x.tx_hash, risk_free=risk_free_transactions), axis=1
+        lambda x: map_reward(x.amount, risk_free=x.tx_hash in risk_free_transactions),
+        axis=1,
     )
     result_agg = (
         per_order_df.groupby("solver")["amount"].agg(["count", "sum"]).reset_index()

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -370,10 +370,14 @@ def map_reward(
     batch_contains_unsafe_liquidity: bool,
 ) -> float:
     """
-    Converts orderbook rewards based on additional knowledge of "risk_free" transactions
+    Converts orderbook rewards based on additional information of
+    "risk_free" batches and (un)safe liquidity orders.
+    - risk-free are batches contain only user and liquidity orders (i.e. no AMM interactions),
+    - liquidity orders are further classified as being safe or unsafe;
+        Examples: (unsafe) 0x and just in time orders which carry some revert risk
     """
     if amount > 0 and risk_free and not batch_contains_unsafe_liquidity:
-        # Risk Free Orders that are not liquidity orders get 37 COW tokens.
+        # Risk Free User Orders that are not contained in unsafe batches 37 COW tokens.
         return 37.0
     return amount
 

--- a/tests/e2e/test_get_transfers.py
+++ b/tests/e2e/test_get_transfers.py
@@ -11,17 +11,6 @@ from src.fetch.transfer_file import (
 from src.models import AccountingPeriod
 
 
-def reward_for_tx(
-    df: pd.DataFrame, tx_hash: str, risk_free: bool, jit_batch: bool
-) -> tuple[int, float]:
-    batch_subset = df.loc[df["tx_hash"] == tx_hash]
-    order_rewards = batch_subset[["amount"]].apply(
-        lambda x: map_reward(x.amount, risk_free, jit_batch),
-        axis=1,
-    )
-    return order_rewards.size, order_rewards.sum()
-
-
 class MyTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.dune = DuneAPI.new_from_environment()
@@ -35,7 +24,7 @@ class MyTestCase(unittest.TestCase):
         )
 
     def test_get_cow_rewards(self):
-        period = AccountingPeriod("2022-10-18", length_days=2)
+        period = AccountingPeriod("2022-10-18", length_days=7)
         print(f"Check out results at: {dashboard_url(period)}")
         try:
             get_cow_rewards(self.dune, period)

--- a/tests/e2e/test_get_transfers.py
+++ b/tests/e2e/test_get_transfers.py
@@ -2,8 +2,6 @@ import unittest
 import pandas as pd
 from duneapi.api import DuneAPI
 
-from src.fetch.orderbook_rewards import get_orderbook_rewards
-from src.fetch.risk_free_batches import get_risk_free_batches
 from src.fetch.transfer_file import (
     get_cow_rewards,
     get_eth_spent,
@@ -13,10 +11,12 @@ from src.fetch.transfer_file import (
 from src.models import AccountingPeriod
 
 
-def reward_for_tx(df: pd.DataFrame, tx_hash: str, risk_free: bool) -> tuple[int, float]:
+def reward_for_tx(
+    df: pd.DataFrame, tx_hash: str, risk_free: bool, jit_batch: bool
+) -> tuple[int, float]:
     batch_subset = df.loc[df["tx_hash"] == tx_hash]
     order_rewards = batch_subset[["amount"]].apply(
-        lambda x: map_reward(x.amount, risk_free),
+        lambda x: map_reward(x.amount, risk_free, jit_batch),
         axis=1,
     )
     return order_rewards.size, order_rewards.sum()
@@ -41,47 +41,6 @@ class MyTestCase(unittest.TestCase):
             get_cow_rewards(self.dune, period)
         except AssertionError as err:
             self.fail(f"get_cow_rewards failed with {err}")
-
-    def test_per_order_rewards(self):
-        period = AccountingPeriod("2022-10-18")
-        start_block, end_block = period.get_block_interval(self.dune)
-        rewards_df = get_orderbook_rewards(start_block, end_block)
-        risk_free_batches = get_risk_free_batches(self.dune, period)
-        # Transactions:
-        # 0x6b6181e95ae837376dd15adbe7801bffffee639dbc8f18b918ace9645a5c1be2 -> 37
-        # 0x72e4c54e9c9dc2ee2a09dd242bf80abc39d122af0813ff4d570d3ce04eea8468 -> 37
-        # 0x82318dd23592f7ccba72fcad43c452c4c426d9e02c7cf3b1f9e7823a0c9a9fc0 -> 74
-        # 0x43bfe76d590966c7539f1ea0bb7989edc1289f989eaf8d84589c3508c5066c2c ->
-        # https://explorer.cow.fi/tx/0x43bfe76d590966c7539f1ea0bb7989edc1289f989eaf8d84589c3508c5066c2c?tab=orders
-        buffer_tx = "0x6b6181e95ae837376dd15adbe7801bffffee639dbc8f18b918ace9645a5c1be2"
-        self.assertEqual(
-            reward_for_tx(rewards_df, buffer_tx, buffer_tx in risk_free_batches),
-            (1, 37.0),
-        )
-
-        perfect_cow_native_liquidity = (
-            "0x72e4c54e9c9dc2ee2a09dd242bf80abc39d122af0813ff4d570d3ce04eea8468"
-        )
-        self.assertEqual(
-            reward_for_tx(
-                rewards_df,
-                perfect_cow_native_liquidity,
-                perfect_cow_native_liquidity in risk_free_batches,
-            ),
-            (2, 37.0),
-        )
-
-        perfect_cow_foreign_liquidity = (
-            "0x43bfe76d590966c7539f1ea0bb7989edc1289f989eaf8d84589c3508c5066c2c"
-        )
-        self.assertEqual(
-            reward_for_tx(
-                rewards_df,
-                perfect_cow_foreign_liquidity,
-                perfect_cow_foreign_liquidity in risk_free_batches,
-            ),
-            (2, 37.0),
-        )
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_get_transfers.py
+++ b/tests/e2e/test_get_transfers.py
@@ -22,7 +22,7 @@ class MyTestCase(unittest.TestCase):
         )
 
     def test_get_cow_rewards(self):
-        period = AccountingPeriod("2022-10-18", length_days=7)
+        period = AccountingPeriod("2022-10-18", length_days=5)
         print(f"Check out results at: {dashboard_url(period)}")
         try:
             get_cow_rewards(self.dune, period)

--- a/tests/e2e/test_get_transfers.py
+++ b/tests/e2e/test_get_transfers.py
@@ -1,11 +1,8 @@
 import unittest
+
 from duneapi.api import DuneAPI
 
-from src.fetch.transfer_file import (
-    get_cow_rewards,
-    get_eth_spent,
-    dashboard_url,
-)
+from src.fetch.transfer_file import get_cow_rewards, get_eth_spent, dashboard_url
 from src.models import AccountingPeriod
 
 

--- a/tests/e2e/test_get_transfers.py
+++ b/tests/e2e/test_get_transfers.py
@@ -1,8 +1,25 @@
 import unittest
-
+import pandas as pd
 from duneapi.api import DuneAPI
-from src.fetch.transfer_file import get_cow_rewards, get_eth_spent, dashboard_url
+
+from src.fetch.orderbook_rewards import get_orderbook_rewards
+from src.fetch.risk_free_batches import get_risk_free_batches
+from src.fetch.transfer_file import (
+    get_cow_rewards,
+    get_eth_spent,
+    dashboard_url,
+    map_reward,
+)
 from src.models import AccountingPeriod
+
+
+def reward_for_tx(df: pd.DataFrame, tx_hash: str, risk_free: bool) -> tuple[int, float]:
+    batch_subset = df.loc[df["tx_hash"] == tx_hash]
+    order_rewards = batch_subset[["amount"]].apply(
+        lambda x: map_reward(x.amount, risk_free),
+        axis=1,
+    )
+    return order_rewards.size, order_rewards.sum()
 
 
 class MyTestCase(unittest.TestCase):
@@ -24,6 +41,47 @@ class MyTestCase(unittest.TestCase):
             get_cow_rewards(self.dune, period)
         except AssertionError as err:
             self.fail(f"get_cow_rewards failed with {err}")
+
+    def test_per_order_rewards(self):
+        period = AccountingPeriod("2022-10-18")
+        start_block, end_block = period.get_block_interval(self.dune)
+        rewards_df = get_orderbook_rewards(start_block, end_block)
+        risk_free_batches = get_risk_free_batches(self.dune, period)
+        # Transactions:
+        # 0x6b6181e95ae837376dd15adbe7801bffffee639dbc8f18b918ace9645a5c1be2 -> 37
+        # 0x72e4c54e9c9dc2ee2a09dd242bf80abc39d122af0813ff4d570d3ce04eea8468 -> 37
+        # 0x82318dd23592f7ccba72fcad43c452c4c426d9e02c7cf3b1f9e7823a0c9a9fc0 -> 74
+        # 0x43bfe76d590966c7539f1ea0bb7989edc1289f989eaf8d84589c3508c5066c2c ->
+        # https://explorer.cow.fi/tx/0x43bfe76d590966c7539f1ea0bb7989edc1289f989eaf8d84589c3508c5066c2c?tab=orders
+        buffer_tx = "0x6b6181e95ae837376dd15adbe7801bffffee639dbc8f18b918ace9645a5c1be2"
+        self.assertEqual(
+            reward_for_tx(rewards_df, buffer_tx, buffer_tx in risk_free_batches),
+            (1, 37.0),
+        )
+
+        perfect_cow_native_liquidity = (
+            "0x72e4c54e9c9dc2ee2a09dd242bf80abc39d122af0813ff4d570d3ce04eea8468"
+        )
+        self.assertEqual(
+            reward_for_tx(
+                rewards_df,
+                perfect_cow_native_liquidity,
+                perfect_cow_native_liquidity in risk_free_batches,
+            ),
+            (2, 37.0),
+        )
+
+        perfect_cow_foreign_liquidity = (
+            "0x43bfe76d590966c7539f1ea0bb7989edc1289f989eaf8d84589c3508c5066c2c"
+        )
+        self.assertEqual(
+            reward_for_tx(
+                rewards_df,
+                perfect_cow_foreign_liquidity,
+                perfect_cow_foreign_liquidity in risk_free_batches,
+            ),
+            (2, 37.0),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_get_transfers.py
+++ b/tests/e2e/test_get_transfers.py
@@ -1,12 +1,10 @@
 import unittest
-import pandas as pd
 from duneapi.api import DuneAPI
 
 from src.fetch.transfer_file import (
     get_cow_rewards,
     get_eth_spent,
     dashboard_url,
-    map_reward,
 )
 from src.models import AccountingPeriod
 

--- a/tests/e2e/test_per_batch_rewards.py
+++ b/tests/e2e/test_per_batch_rewards.py
@@ -6,7 +6,7 @@ from src.fetch.orderbook_rewards import get_orderbook_rewards
 from src.fetch.risk_free_batches import get_risk_free_batches
 from src.fetch.transfer_file import (
     map_reward,
-    liquidity_order_batches,
+    unsafe_batches,
 )
 from src.models import AccountingPeriod
 
@@ -37,7 +37,7 @@ class TestPerBatchRewards(unittest.TestCase):
 
         self.rewards_df = get_orderbook_rewards(start_block, end_block)
         self.risk_free_batches = get_risk_free_batches(dune, period)
-        self.jit_batches = liquidity_order_batches(self.rewards_df)
+        self.jit_batches = unsafe_batches(self.rewards_df)
 
     def test_buffer_trade(self):
         tx_hash = "0x6b6181e95ae837376dd15adbe7801bffffee639dbc8f18b918ace9645a5c1be2"

--- a/tests/e2e/test_per_batch_rewards.py
+++ b/tests/e2e/test_per_batch_rewards.py
@@ -66,9 +66,8 @@ class TestPerBatchRewards(unittest.TestCase):
                 tx_hash in self.risk_free_batches,
                 tx_hash in self.jit_batches,
             ),
-            (2, 37.0),
+            (2, 39.51661869443983),
         )
-        self.assertEqual(1, 0)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_per_batch_rewards.py
+++ b/tests/e2e/test_per_batch_rewards.py
@@ -29,6 +29,7 @@ class TestPerBatchRewards(unittest.TestCase):
     tests/unit/test_reward_aggregation.py
     cf: https://github.com/cowprotocol/solver-rewards/pull/107#issuecomment-1288566854
     """
+
     def setUp(self) -> None:
         dune = DuneAPI.new_from_environment()
         period = AccountingPeriod("2022-10-18")

--- a/tests/e2e/test_per_batch_rewards.py
+++ b/tests/e2e/test_per_batch_rewards.py
@@ -24,6 +24,11 @@ def reward_for_tx(
 
 
 class TestPerBatchRewards(unittest.TestCase):
+    """
+    These tests aren't actually necessary because their logic is captured by a unit test
+    tests/unit/test_reward_aggregation.py
+    cf: https://github.com/cowprotocol/solver-rewards/pull/107#issuecomment-1288566854
+    """
     def setUp(self) -> None:
         dune = DuneAPI.new_from_environment()
         period = AccountingPeriod("2022-10-18")

--- a/tests/e2e/test_per_batch_rewards.py
+++ b/tests/e2e/test_per_batch_rewards.py
@@ -1,0 +1,75 @@
+import unittest
+import pandas as pd
+from duneapi.api import DuneAPI
+
+from src.fetch.orderbook_rewards import get_orderbook_rewards
+from src.fetch.risk_free_batches import get_risk_free_batches
+from src.fetch.transfer_file import (
+    map_reward,
+    liquidity_order_batches,
+)
+from src.models import AccountingPeriod
+
+
+def reward_for_tx(
+    df: pd.DataFrame, tx_hash: str, risk_free: bool, jit_batch: bool
+) -> tuple[int, float]:
+    print(df, tx_hash, risk_free, jit_batch)
+    batch_subset = df.loc[df["tx_hash"] == tx_hash]
+    order_rewards = batch_subset[["amount"]].apply(
+        lambda x: map_reward(x.amount, risk_free, jit_batch),
+        axis=1,
+    )
+    return order_rewards.size, order_rewards.sum()
+
+
+class TestPerBatchRewards(unittest.TestCase):
+    def setUp(self) -> None:
+        dune = DuneAPI.new_from_environment()
+        period = AccountingPeriod("2022-10-18")
+        start_block, end_block = period.get_block_interval(dune)
+
+        self.rewards_df = get_orderbook_rewards(start_block, end_block)
+        self.risk_free_batches = get_risk_free_batches(dune, period)
+        self.jit_batches = liquidity_order_batches(self.rewards_df)
+
+    def test_buffer_trade(self):
+        tx_hash = "0x6b6181e95ae837376dd15adbe7801bffffee639dbc8f18b918ace9645a5c1be2"
+        self.assertEqual(
+            reward_for_tx(
+                self.rewards_df,
+                tx_hash,
+                tx_hash in self.risk_free_batches,
+                tx_hash in self.jit_batches,
+            ),
+            (1, 37.0),
+        )
+
+    def test_perfect_cow_with_native_liquidity(self):
+        tx_hash = "0x72e4c54e9c9dc2ee2a09dd242bf80abc39d122af0813ff4d570d3ce04eea8468"
+        self.assertEqual(
+            reward_for_tx(
+                self.rewards_df,
+                tx_hash,
+                tx_hash in self.risk_free_batches,
+                tx_hash in self.jit_batches,
+            ),
+            (2, 37.0),
+        )
+
+    def test_perfect_cow_with_foreign_liquidity(self):
+        tx_hash = "0x43bfe76d590966c7539f1ea0bb7989edc1289f989eaf8d84589c3508c5066c2c"
+        self.assertEqual(
+            reward_for_tx(
+                self.rewards_df,
+                tx_hash,
+                tx_hash in self.risk_free_batches,
+                tx_hash in self.jit_batches,
+            ),
+            (2, 37.0),
+        )
+        self.assertEqual(1, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_orderbook_rewards.py
+++ b/tests/unit/test_orderbook_rewards.py
@@ -1,7 +1,5 @@
 import unittest
 
-from duneapi.util import open_query
-
 from src.models import AccountingPeriod
 from src.update.orderbook_rewards import (
     dune_repr,

--- a/tests/unit/test_reward_aggregation.py
+++ b/tests/unit/test_reward_aggregation.py
@@ -11,6 +11,11 @@ def to_wei(t) -> int:
 
 
 class MyTestCase(unittest.TestCase):
+    """
+    This test is a mock dataset capturing the real data from
+    cf: https://github.com/cowprotocol/solver-rewards/pull/107#issuecomment-1288566854
+    """
+    # TODO - add this: 0x82318dd23592f7ccba72fcad43c452c4c426d9e02c7cf3b1f9e7823a0c9a9fc0
     def test_aggregate_orderbook_rewards(self):
         # Tx 0x001 is 0x72e4c54e9c9dc2ee2a09dd242bf80abc39d122af0813ff4d570d3ce04eea8468
         # Tx 0x002 is 0x43bfe76d590966c7539f1ea0bb7989edc1289f989eaf8d84589c3508c5066c2c

--- a/tests/unit/test_reward_aggregation.py
+++ b/tests/unit/test_reward_aggregation.py
@@ -1,0 +1,41 @@
+import unittest
+
+import pandas.testing
+from web3 import Web3
+
+from src.fetch.transfer_file import aggregate_orderbook_rewards, map_reward
+import pandas as pd
+
+
+class MyTestCase(unittest.TestCase):
+    def test_aggregate_orderbook_rewards(self):
+        solvers = ["0x1", "0x2", "0x2"]
+        tx_hashes = ["0x001", "0x002", "0x003"]
+        amounts = [0, 55, 47]
+        orderbook_rewards = pd.DataFrame(
+            {
+                "solver": solvers,
+                "tx_hash": tx_hashes,
+                "amount": amounts,
+            }
+        )
+        results = aggregate_orderbook_rewards(
+            orderbook_rewards, risk_free_transactions={tx_hashes[1]}
+        )
+        expected = pd.DataFrame(
+            {
+                "receiver": ["0x1", "0x2"],
+                "num_trades": [1, 2],
+                "amount": [0, Web3().toWei(84, 'ether')],
+                "token_address": [
+                    "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+                    "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+                ],
+            }
+        )
+
+        self.assertIsNone(pd.testing.assert_frame_equal(expected, results))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_reward_aggregation.py
+++ b/tests/unit/test_reward_aggregation.py
@@ -108,10 +108,10 @@ class MyTestCase(unittest.TestCase):
     def test_unsafe_batches(self):
         orderbook_rewards = pd.DataFrame(
             {
-                "solver": [""] * 6,
-                "tx_hash": ["t1", "t2", "t3", "t3", "t4", "t4"],
-                "amount": [0] * 6,
-                "safe_liquidity": [True, False, False, True, False, False],
+                "solver": [""] * 7,
+                "tx_hash": ["t1", "t2", "t3", "t3", "t4", "t4", "t5"],
+                "amount": [0] * 7,
+                "safe_liquidity": [True, False, False, True, False, False, None],
             }
         )
 

--- a/tests/unit/test_reward_aggregation.py
+++ b/tests/unit/test_reward_aggregation.py
@@ -1,6 +1,5 @@
 import unittest
 
-import pandas.testing
 from web3 import Web3
 
 from src.fetch.transfer_file import aggregate_orderbook_rewards, map_reward
@@ -26,7 +25,7 @@ class MyTestCase(unittest.TestCase):
             {
                 "receiver": ["0x1", "0x2"],
                 "num_trades": [1, 2],
-                "amount": [0, Web3().toWei(84, 'ether')],
+                "amount": [0, Web3().toWei(84, "ether")],
                 "token_address": [
                     "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
                     "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
@@ -35,6 +34,14 @@ class MyTestCase(unittest.TestCase):
         )
 
         self.assertIsNone(pd.testing.assert_frame_equal(expected, results))
+
+    def test_map_reward(self):
+        self.assertEqual(map_reward(0, True), 0)
+        self.assertEqual(map_reward(0, False), 0)
+        self.assertEqual(
+            map_reward(1, True), 37, "Risk-free non-zero amount must be 37!"
+        )
+        self.assertEqual(map_reward(1, False), 1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_reward_aggregation.py
+++ b/tests/unit/test_reward_aggregation.py
@@ -16,24 +16,51 @@ class MyTestCase(unittest.TestCase):
     cf: https://github.com/cowprotocol/solver-rewards/pull/107#issuecomment-1288566854
     """
 
-    # TODO - add this: 0x82318dd23592f7ccba72fcad43c452c4c426d9e02c7cf3b1f9e7823a0c9a9fc0
     def test_aggregate_orderbook_rewards(self):
-        # Tx 0x001 is 0x72e4c54e9c9dc2ee2a09dd242bf80abc39d122af0813ff4d570d3ce04eea8468
-        # Tx 0x002 is 0x43bfe76d590966c7539f1ea0bb7989edc1289f989eaf8d84589c3508c5066c2c
-        # Tx 0x003 is 0x6b6181e95ae837376dd15adbe7801bffffee639dbc8f18b918ace9645a5c1be2
-        solvers = ["0x1", "0x1", "0x2", "0x2", "0x3", "0x1", "0x2", "0x3"]
+        solvers = [
+            "0x1",
+            "0x1",
+            "0x2",
+            "0x2",
+            "0x3",
+            "0x1",
+            "0x2",
+            "0x3",
+            "0x4",
+            "0x4",
+            "0x4",
+        ]
         tx_hashes = [
+            # Tx 0x001 is 0x72e4c54e9c9dc2ee2a09dd242bf80abc39d122af0813ff4d570d3ce04eea8468
             "0x001",
             "0x001",
+            # Tx 0x002 is 0x43bfe76d590966c7539f1ea0bb7989edc1289f989eaf8d84589c3508c5066c2c
             "0x002",
             "0x002",
+            # Tx 0x003 is 0x6b6181e95ae837376dd15adbe7801bffffee639dbc8f18b918ace9645a5c1be2
             "0x003",
             "0x004",
             "0x005",
             "0x006",
+            # Tx 0x007 0x82318dd23592f7ccba72fcad43c452c4c426d9e02c7cf3b1f9e7823a0c9a9fc0
+            "0x007",
+            "0x007",
+            "0x007",
         ]
-        amounts = [39, 0, 40, 0, 41, 50, 60, 70]
-        safe_liquidity = [None, True, None, False, None, None, None, None]
+        amounts = [39, 0, 40, 0, 41, 50, 60, 70, 40, 50, 0]
+        safe_liquidity = [
+            None,
+            True,
+            None,
+            False,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            True,
+        ]
         orderbook_rewards = pd.DataFrame(
             {
                 "solver": solvers,
@@ -43,20 +70,24 @@ class MyTestCase(unittest.TestCase):
             }
         )
         results = aggregate_orderbook_rewards(
-            orderbook_rewards, risk_free_transactions={"0x001", "0x002", "0x003"}
+            orderbook_rewards,
+            risk_free_transactions={"0x001", "0x002", "0x003", "0x007"},
         )
         expected = pd.DataFrame(
             {
-                "receiver": ["0x1", "0x2", "0x3"],
-                "num_trades": [3, 3, 2],
-                "amount": [to_wei(87), to_wei(100), to_wei(107)],
+                "receiver": ["0x1", "0x2", "0x3", "0x4"],
+                "num_trades": [3, 3, 2, 3],
+                "amount": [to_wei(87), to_wei(100), to_wei(107), to_wei(74)],
                 "token_address": [
+                    "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
                     "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
                     "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
                     "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
                 ],
             }
         )
+        print(expected)
+        print(results)
         self.assertIsNone(pd.testing.assert_frame_equal(expected, results))
 
     def test_map_reward(self):

--- a/tests/unit/test_reward_aggregation.py
+++ b/tests/unit/test_reward_aggregation.py
@@ -6,42 +6,63 @@ from src.fetch.transfer_file import aggregate_orderbook_rewards, map_reward
 import pandas as pd
 
 
+def to_wei(t) -> int:
+    return Web3().toWei(t, "ether")
+
+
 class MyTestCase(unittest.TestCase):
     def test_aggregate_orderbook_rewards(self):
-        solvers = ["0x1", "0x2", "0x2"]
-        tx_hashes = ["0x001", "0x002", "0x003"]
-        amounts = [0, 55, 47]
+        # Tx 0x001 is 0x72e4c54e9c9dc2ee2a09dd242bf80abc39d122af0813ff4d570d3ce04eea8468
+        # Tx 0x002 is 0x43bfe76d590966c7539f1ea0bb7989edc1289f989eaf8d84589c3508c5066c2c
+        # Tx 0x003 is 0x6b6181e95ae837376dd15adbe7801bffffee639dbc8f18b918ace9645a5c1be2
+        solvers = ["0x1", "0x1", "0x2", "0x2", "0x3", "0x1", "0x2", "0x3"]
+        tx_hashes = [
+            "0x001",
+            "0x001",
+            "0x002",
+            "0x002",
+            "0x003",
+            "0x004",
+            "0x005",
+            "0x006",
+        ]
+        amounts = [39, 0, 40, 0, 41, 50, 60, 70]
+        safe_liquidity = [None, True, None, False, None, None, None, None]
         orderbook_rewards = pd.DataFrame(
             {
                 "solver": solvers,
                 "tx_hash": tx_hashes,
                 "amount": amounts,
+                "safe_liquidity": safe_liquidity,
             }
         )
         results = aggregate_orderbook_rewards(
-            orderbook_rewards, risk_free_transactions={tx_hashes[1]}
+            orderbook_rewards, risk_free_transactions={"0x001", "0x002", "0x003"}
         )
         expected = pd.DataFrame(
             {
-                "receiver": ["0x1", "0x2"],
-                "num_trades": [1, 2],
-                "amount": [0, Web3().toWei(84, "ether")],
+                "receiver": ["0x1", "0x2", "0x3"],
+                "num_trades": [3, 3, 2],
+                "amount": [to_wei(87), to_wei(100), to_wei(107)],
                 "token_address": [
+                    "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
                     "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
                     "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
                 ],
             }
         )
-
         self.assertIsNone(pd.testing.assert_frame_equal(expected, results))
 
     def test_map_reward(self):
-        self.assertEqual(map_reward(0, True), 0)
-        self.assertEqual(map_reward(0, False), 0)
-        self.assertEqual(
-            map_reward(1, True), 37, "Risk-free non-zero amount must be 37!"
-        )
-        self.assertEqual(map_reward(1, False), 1)
+        self.assertEqual(map_reward(0, True, True), 0)
+        self.assertEqual(map_reward(0, True, False), 0)
+        self.assertEqual(map_reward(0, False, True), 0)
+        self.assertEqual(map_reward(0, False, False), 0)
+
+        self.assertEqual(map_reward(1, True, False), 37)
+        self.assertEqual(map_reward(1, True, True), 1)
+        self.assertEqual(map_reward(1, False, True), 1)
+        self.assertEqual(map_reward(1, False, False), 1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_reward_aggregation.py
+++ b/tests/unit/test_reward_aggregation.py
@@ -2,7 +2,11 @@ import unittest
 
 from web3 import Web3
 
-from src.fetch.transfer_file import aggregate_orderbook_rewards, map_reward
+from src.fetch.transfer_file import (
+    aggregate_orderbook_rewards,
+    map_reward,
+    unsafe_batches,
+)
 import pandas as pd
 
 
@@ -100,6 +104,18 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(map_reward(1, True, True), 1)
         self.assertEqual(map_reward(1, False, True), 1)
         self.assertEqual(map_reward(1, False, False), 1)
+
+    def test_unsafe_batches(self):
+        orderbook_rewards = pd.DataFrame(
+            {
+                "solver": [""] * 6,
+                "tx_hash": ["t1", "t2", "t3", "t3", "t4", "t4"],
+                "amount": [0] * 6,
+                "safe_liquidity": [True, False, False, True, False, False],
+            }
+        )
+
+        self.assertEqual(unsafe_batches(orderbook_rewards), {"t2", "t3", "t4"})
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_reward_aggregation.py
+++ b/tests/unit/test_reward_aggregation.py
@@ -15,6 +15,7 @@ class MyTestCase(unittest.TestCase):
     This test is a mock dataset capturing the real data from
     cf: https://github.com/cowprotocol/solver-rewards/pull/107#issuecomment-1288566854
     """
+
     # TODO - add this: 0x82318dd23592f7ccba72fcad43c452c4c426d9e02c7cf3b1f9e7823a0c9a9fc0
     def test_aggregate_orderbook_rewards(self):
         # Tx 0x001 is 0x72e4c54e9c9dc2ee2a09dd242bf80abc39d122af0813ff4d570d3ce04eea8468


### PR DESCRIPTION
Based on the logic that orders contained in _risk-free batches_ (i.e. those classified as having only zero risk interactions) should receive 37 tokens (instead of the amount quoted at the time of order placement) if they are NOT liquidity orders, we adapt this program to do just that.

Before we were aggregating solver sums directly from the orderbook. However, the orderbook does not contain sufficient information to identify risk free batches so we fetch them from Dune. 

Now we collect the per order rewards order the order book and adjust them based on the set of risk free transaction hashes.

This involved a bit of data manipulation via pandas (captured in the newly introduced `aggregate_orderbook_rewards` and `map_reward` functions. 


# Test Plan Exsiting CI 

Unit tests for two new introduced methods.


and specifically the e2e test `get_cow_rewards` which makes use of this new functionality

```
python -m pytest tests/e2e/test_get_transfers.py
```

(Note this requires some credentials be set as env vars - many)