### PR TITLE
Add Fixed Python Version to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.10.8
 COPY . .
 RUN pip install -r requirements.txt
 ENTRYPOINT [ "python3", "-m" , "src.fetch.transfer_file"]


### PR DESCRIPTION
python:latest was recently updated https://hub.docker.com/_/python/tags and broke our build.



Notice that we have not changed the requirements or docker file since the most recent (successful) build (4 days ago and today): 

- See Previous success and recent failure: https://github.com/cowprotocol/solver-rewards/actions/workflows/deploy.yaml
- See the recent build errors [here](https://github.com/cowprotocol/solver-rewards/actions/runs/3320477778)

also here:

```
#8 48.29   Building wheel for pysha3 (setup.py): started
#8 48.59   Building wheel for pysha3 (setup.py): finished with status 'error'
#8 48.60   error: subprocess-exited-with-error
#8 48.60   
#8 48.60   × python setup.py bdist_wheel did not run successfully.
#8 48.60   │ exit code: 1
#8 48.60   ╰─> [18 lines of output]
#8 48.60       running bdist_wheel
#8 48.60       running build
#8 48.60       running build_py
#8 48.60       creating build
#8 48.60       creating build/lib.linux-x86_64-cpython-311
#8 48.60       copying sha3.py -> build/lib.linux-x86_64-cpython-311
#8 48.60       running build_ext
#8 48.60       building '_pysha3' extension
#8 48.60       creating build/temp.linux-x86_64-cpython-311
#8 48.60       creating build/temp.linux-x86_64-cpython-311/Modules
#8 48.60       creating build/temp.linux-x86_64-cpython-311/Modules/_sha3
#8 48.60       gcc -pthread -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPY_WITH_KECCAK=1 -I/usr/local/include/python3.11 -c Modules/_sha3/sha3module.c -o build/temp.linux-x86_64-cpython-311/Modules/_sha3/sha3module.o
#8 48.60       In file included from Modules/_sha3/sha3module.c:20:
#8 48.60       Modules/_sha3/backport.inc:78:10: fatal error: pystrhex.h: No such file or directory
#8 48.60          78 | #include "pystrhex.h"
#8 48.60             |          ^~~~~~~~~~~~
#8 48.60       compilation terminated.
#8 48.60       error: command '/usr/bin/gcc' failed with exit code 1
#8 48.60       [end of output]
```

This fixes it:

## Test Plan
Try this on main and here (see that this branch works and other doesn't)
```
docker build . -t test-solver-rewards  
```


I tried a fixed python version 