### PR TITLE
Upsert Per Order Results

### DIFF
--- a/dashboards/solver-rewards-accounting/solver-totals.sql
+++ b/dashboards/solver-rewards-accounting/solver-totals.sql
@@ -55,7 +55,8 @@ select
     num_trades,
     coalesce(num_liquidity_orders, 0) as liquidity_orders,
     orderbook_trades,
-    1.0 * cow_reward / pow(10, 18) as cow_reward
+    1.0 * cow_reward / pow(10, 18) as cow_reward,
+    CONCAT('<a href="https://dune.com/queries/1468170?PeriodHash={{PeriodHash}}', '&SolverAddress=', solver_address, '" target="_blank">link</a>') as details
 from per_solver_results
 left outer join liquidity_orders lo
     on solver_address = lo.solver

--- a/queries/solver_per_order_rewards.sql
+++ b/queries/solver_per_order_rewards.sql
@@ -2,12 +2,7 @@
 select
   tx_hash,
   amount,
-  safe_liquidity,
-  case
-    when amount > 0
-    and safe_liquidity = True then 37.0
-    else amount
-  end as adjusted_amount
+  safe_liquidity
 from
   dune_user_generated.cow_per_order_rewards_{{PeriodHash}}
 where

--- a/queries/solver_per_order_rewards.sql
+++ b/queries/solver_per_order_rewards.sql
@@ -1,0 +1,14 @@
+-- https://dune.com/queries/1468170
+select
+  tx_hash,
+  amount,
+  safe_liquidity,
+  case
+    when amount > 0
+    and safe_liquidity = True then 37.0
+    else amount
+  end as adjusted_amount
+from
+  dune_user_generated.cow_per_order_rewards_{{PeriodHash}}
+where
+  solver = '{{SolverAddress}}'

--- a/queries/user_generated_per_order_rewards.sql
+++ b/queries/user_generated_per_order_rewards.sql
@@ -1,0 +1,9 @@
+DROP MATERIALIZED VIEW IF EXISTS dune_user_generated.cow_per_order_rewards_{{PeriodHash}} CASCADE;
+CREATE MATERIALIZED VIEW dune_user_generated.cow_per_order_rewards_{{PeriodHash}} (solver, tx_hash, amount, safe_liquidity) AS (
+  SELECT *
+  FROM (
+      VALUES
+{{SolverRewards}}
+    ) as _
+);
+SELECT * FROM dune_user_generated.cow_per_order_rewards_{{PeriodHash}}

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -405,7 +405,7 @@ def aggregate_orderbook_rewards(
     """
 
     unsafe_liquidity_batches = unsafe_batches(per_order_df)
-    per_order_df["adjusted_amount"] = per_order_df[
+    per_order_df["amount"] = per_order_df[
         ["amount", "tx_hash", "safe_liquidity"]
     ].apply(
         lambda x: map_reward(

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -40,7 +40,7 @@ from src.fetch.reward_targets import get_vouches, Vouch
 from src.fetch.risk_free_batches import get_risk_free_batches
 from src.models import AccountingPeriod, Token
 from src.multisend import post_multisend
-from src.update.orderbook_rewards import push_user_generated_view
+from src.update.orderbook_rewards import push_user_generated_view, RewardQuery
 from src.utils.dataset import index_by
 from src.utils.prices import eth_in_token, TokenId, token_in_eth
 from src.utils.print_store import PrintStore, Category
@@ -405,7 +405,7 @@ def aggregate_orderbook_rewards(
     """
 
     unsafe_liquidity_batches = unsafe_batches(per_order_df)
-    per_order_df["amount"] = per_order_df[
+    per_order_df["adjusted_amount"] = per_order_df[
         ["amount", "tx_hash", "safe_liquidity"]
     ].apply(
         lambda x: map_reward(
@@ -438,8 +438,11 @@ def get_cow_rewards(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:
     """
     start_block, end_block = period.get_block_interval(dune)
     print(f"Fetching CoW Rewards for block interval {start_block}, {end_block}")
+    per_order_df = get_orderbook_rewards(start_block, end_block)
+    # Pushing the pre-adjusted orderbook rewards (right from the DB)
+    push_user_generated_view(dune, period, per_order_df, RewardQuery.PER_ORDER)
     cow_rewards_df = aggregate_orderbook_rewards(
-        per_order_df=get_orderbook_rewards(start_block, end_block),
+        per_order_df,
         risk_free_transactions=get_risk_free_batches(dune, period),
     )
 
@@ -468,7 +471,9 @@ def get_cow_rewards(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:
     assert len(duplicates) == 0, f"solver sets disagree: {duplicates}"
 
     # Write this to Dune Database (as a user generated view).
-    push_user_generated_view(dune, period, data=cow_rewards_df)
+    push_user_generated_view(
+        dune, period, data=cow_rewards_df, data_type=RewardQuery.AGGREGATE
+    )
     return Transfer.from_dataframe(cow_rewards_df)
 
 

--- a/src/update/orderbook_rewards.py
+++ b/src/update/orderbook_rewards.py
@@ -55,6 +55,14 @@ class RewardQuery(Enum):
             .replace("{{SolverRewards}}", self.to_dune_list(data))
         )
 
+    def view_name(self) -> str:
+        """Returns Name of the user generated view Dune table"""
+        if self == RewardQuery.AGGREGATE:
+            return f"cow_rewards"
+        if self == RewardQuery.PER_ORDER:
+            return f"cow_per_order_rewards"
+
+        raise ValueError(f"Invalid enum variant {self}")
 
 def push_user_generated_view(
     dune: DuneAPI, period: AccountingPeriod, data: DataFrame, data_type: RewardQuery
@@ -70,4 +78,4 @@ def push_user_generated_view(
         )
     )
     assert len(data) == len(results)
-    print(f"Pushed User Generated view cow_rewards_{hash(period)}")
+    print(f"Pushed User Generated view {data_type.view_name()}_{hash(period)}")

--- a/src/update/orderbook_rewards.py
+++ b/src/update/orderbook_rewards.py
@@ -1,6 +1,8 @@
 """Pushes a new dune user generated view per Accounting Period
 with name dune_user_generated.cow_rewards_{{PeriodHash}}
 """
+from enum import Enum
+
 from duneapi.api import DuneAPI
 from duneapi.types import DuneQuery, Network
 from duneapi.util import open_query
@@ -9,40 +11,61 @@ from pandas import DataFrame, Series
 from src.models import AccountingPeriod
 
 
-def dune_repr(df_row: Series) -> str:
-    """
-    This is the per row format for inserting entries in a table of VALUES
-    Specific to a COW Reward Item
-    """
-    return (
-        f"('{df_row['receiver'].lower()}', {df_row['num_trades']}, {df_row['amount']})"
-    )
+class RewardQuery(Enum):
+    """different types of queries being pushed as user_generated_views"""
 
+    AGGREGATE = "Aggregated"
+    PER_ORDER = "Per Order"
 
-def rewards_df_to_dune_list(data: DataFrame) -> str:
-    """Joins a list of VALUES into the format for postgres VALUES list"""
-    return ",\n".join([dune_repr(row) for _, row in data.iterrows()])
+    def dune_repr(self, df_row: Series) -> str:
+        """
+        This is the per row format for inserting entries in a table of VALUES
+        Specific to a COW Reward Item
+        """
+        amount = df_row["amount"]
+        if self == RewardQuery.AGGREGATE:
+            return f"('{df_row['receiver'].lower()}', {df_row['num_trades']}, {amount})"
+        if self == RewardQuery.PER_ORDER:
+            solver, tx_hash = df_row["solver"].lower(), df_row["tx_hash"]
+            safe = df_row["safe_liquidity"]
+            safe = safe if safe is not None else "Null"
+            # See https://dune.com/queries/1456810 for Null Test Demonstration
+            return f"('{solver}', '{tx_hash}', {amount}, {safe})"
 
+        raise ValueError(f"Invalid enum variant {self}")
 
-def orderbook_rewards_query(period: AccountingPeriod, data: DataFrame) -> str:
-    """Returns query associated with the upsert of orderbook cow reward data"""
-    return (
-        open_query("./queries/user_generated_rewards.sql")
-        .replace("{{PeriodHash}}", str(hash(period)))
-        .replace("{{SolverRewards}}", rewards_df_to_dune_list(data))
-    )
+    def to_dune_list(self, data: DataFrame) -> str:
+        """Joins a list of VALUES into the format for postgres VALUES list for type"""
+        return ",\n".join([self.dune_repr(row) for _, row in data.iterrows()])
+
+    def query_file(self) -> str:
+        """Returns the file containing the RAW SQL for Dune Query"""
+        if self == RewardQuery.AGGREGATE:
+            return "./queries/user_generated_rewards.sql"
+        if self == RewardQuery.PER_ORDER:
+            return "./queries/user_generated_per_order_rewards.sql"
+
+        raise ValueError(f"Invalid enum variant {self}")
+
+    def dune_query(self, period: AccountingPeriod, data: DataFrame) -> str:
+        """Returns query associated with the upsert of orderbook cow reward data"""
+        return (
+            open_query(self.query_file())
+            .replace("{{PeriodHash}}", str(hash(period)))
+            .replace("{{SolverRewards}}", self.to_dune_list(data))
+        )
 
 
 def push_user_generated_view(
-    dune: DuneAPI, period: AccountingPeriod, data: DataFrame
+    dune: DuneAPI, period: AccountingPeriod, data: DataFrame, data_type: RewardQuery
 ) -> None:
     """
     Upsert SQL query constructing  a user generated view to Dune V1
     """
     results = dune.fetch(
         query=DuneQuery.from_environment(
-            raw_sql=orderbook_rewards_query(period, data),
-            name="Orderbook Rewards",
+            raw_sql=data_type.dune_query(period, data),
+            name=f"Orderbook {data_type} Rewards",
             network=Network.MAINNET,
         )
     )

--- a/src/update/orderbook_rewards.py
+++ b/src/update/orderbook_rewards.py
@@ -64,6 +64,7 @@ class RewardQuery(Enum):
 
         raise ValueError(f"Invalid enum variant {self}")
 
+
 def push_user_generated_view(
     dune: DuneAPI, period: AccountingPeriod, data: DataFrame, data_type: RewardQuery
 ) -> None:

--- a/src/update/orderbook_rewards.py
+++ b/src/update/orderbook_rewards.py
@@ -58,9 +58,9 @@ class RewardQuery(Enum):
     def view_name(self) -> str:
         """Returns Name of the user generated view Dune table"""
         if self == RewardQuery.AGGREGATE:
-            return f"cow_rewards"
+            return "cow_rewards"
         if self == RewardQuery.PER_ORDER:
-            return f"cow_per_order_rewards"
+            return "cow_per_order_rewards"
 
         raise ValueError(f"Invalid enum variant {self}")
 

--- a/tests/unit/test_orderbook_rewards.py
+++ b/tests/unit/test_orderbook_rewards.py
@@ -32,13 +32,23 @@ class TestCowRewardsUpsert(unittest.TestCase):
         print(self.aggregate_example)
 
     def test_dune_repr(self):
-        for i, (_, row) in enumerate(self.aggregate_example.iterrows()):
-            self.assertEqual(self.agg_expected[i], RewardQuery.AGGREGATE.dune_repr(row))
+        self.assertEqual(
+            self.agg_expected,
+            list(
+                self.aggregate_example.apply(
+                    lambda x: RewardQuery.AGGREGATE.dune_repr(x), axis=1
+                )
+            ),
+        )
 
-        for i, (_, row) in enumerate(self.per_order_example.iterrows()):
-            self.assertEqual(
-                self.per_order_expected[i], RewardQuery.PER_ORDER.dune_repr(row)
-            )
+        self.assertEqual(
+            self.per_order_expected,
+            list(
+                self.per_order_example.apply(
+                    lambda x: RewardQuery.PER_ORDER.dune_repr(x), axis=1
+                )
+            ),
+        )
 
     def test_rewards_df_to_dune_list(self):
         self.assertEqual(


### PR DESCRIPTION
We push the raw (merged) dataframe fetched from the orderbook database during the rewards script run to `dune_user_generated.cow_per_order_rewards_{{PeriodHash}}`

Follow up tasks:
1. we could also push the "amount", but it was more invasive to pass along Dune instance and other parameters into `aggregate_orderbook_rewards` function which is responsible for adjustments (we could separate this into adjust rewards and aggregate to add the additional column). Could also mimic the map_reward logic into the query and construct the adjusted reward (however then the logic would not be self contained). 

2. We would like to provide a link to a filtered version of this table (on the dashboard) so that solvers can "drill down" into their individual rewards.


closes #110 

## Test Plan

New Unit tests

AND 

You can believe that I have already done this and see that the table was created [here](https://dune.com/querie/1457040)

OR
You can run this script and see that the table is generated

```sh
python -m src.fetch.transfer_file --start '2022-10-18' --post-tx True --dry-run True
```

