### PR TITLE
[Workflow] Update Actions

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.1.3-beta
+        uses: contributor-assistant/github-action@v2.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN : ${{ secrets.ORG_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,22 +13,22 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
           labels: |
             org.opencontainers.image.licenses=MIT OR Apache-2.0
 
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/postgres.yaml
+++ b/.github/workflows/postgres.yaml
@@ -21,9 +21,9 @@ jobs:
         volumes:
           - ${{ github.workspace }}:/repo
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.10'
       - name: Install Requirements

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,9 +7,9 @@ jobs:
   python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.10'
       - name: Install Requirements


### PR DESCRIPTION
We have been seeing a lot of deprecation warnings in our github actions:

- [pull-request](https://github.com/cowprotocol/solver-rewards/actions/runs/3340274512)
- [deploy](https://github.com/cowprotocol/solver-rewards/actions/runs/3338557640)
- [postgres](https://github.com/cowprotocol/solver-rewards/actions/runs/3340274234)
- [cla](https://github.com/cowprotocol/solver-rewards/actions/runs/3340274339)

This should fix them - I have tested this already for all but CLA [here](https://github.com/bh2smith/subsafe-commander/pull/14)

# Test Plan

see github actions with no warnings! 