### PR TITLE
[Easy] Fix relative imports across project

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -11,8 +11,11 @@ from web3 import Web3
 
 COW_TOKEN_ADDRESS = Address("0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB")
 
+PROJECT_ROOT = Path(__file__).parent.parent
+LOG_CONFIG_FILE = PROJECT_ROOT / Path("logging.conf")
+QUERY_PATH = PROJECT_ROOT / Path("queries")
+DASHBOARD_PATH = PROJECT_ROOT / Path("dashboards/solver-rewards-accounting")
 
-LOG_CONFIG_FILE = Path(__file__).parent.parent / Path("logging.conf")
 # Things requiring network
 load_dotenv()
 ENV = os.environ

--- a/src/fetch/orderbook_rewards.py
+++ b/src/fetch/orderbook_rewards.py
@@ -1,15 +1,17 @@
 """Fetching Per Order Rewards from Production and Staging Database"""
+
 import pandas as pd
 from duneapi.util import open_query
 from pandas import DataFrame
 
 from src.pg_client import pg_engine, OrderbookEnv
+from src.utils.query_file import query_file
 
 
 def get_orderbook_rewards(start_block: str, end_block: str) -> DataFrame:
     """Fetches and validates Orderbook Reward DataFrame as concatenation from Prod and Staging DB"""
     cow_reward_query = (
-        open_query("./queries/cow_rewards.sql")
+        open_query(query_file("cow_rewards.sql"))
         .replace("{{start_block}}", start_block)
         .replace("{{end_block}}", end_block)
     )

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -14,6 +14,7 @@ from src.constants import LOG_CONFIG_FILE
 from src.models import AccountingPeriod
 from src.token_list import fetch_trusted_tokens
 from src.update.token_list import update_token_list
+from src.utils.query_file import dashboard_file, query_file
 from src.utils.script_args import generic_script_init
 
 log = logging.getLogger(__name__)
@@ -40,9 +41,7 @@ class QueryType(Enum):
         if self in (QueryType.PER_TX, QueryType.TOTAL):
             return f"select * from {self}"
         if self == QueryType.UNUSUAL:
-            return open_query(
-                "./dashboards/solver-rewards-accounting/unusual-slippage.sql"
-            )
+            return open_query(dashboard_file("unusual-slippage.sql"))
         # Can only happen if types are added to the enum and not accounted for.
         raise ValueError(f"Invalid Query Type! {self}")
 
@@ -54,7 +53,10 @@ def slippage_query(query_type: QueryType = QueryType.TOTAL) -> str:
     per transaction results for testing
     """
     return "\n".join(
-        [open_query("./queries/period_slippage.sql"), query_type.select_statement()]
+        [
+            open_query(query_file("period_slippage.sql")),
+            query_type.select_statement(),
+        ]
     )
 
 

--- a/src/fetch/period_totals.py
+++ b/src/fetch/period_totals.py
@@ -9,6 +9,7 @@ from duneapi.types import QueryParameter, DuneQuery, Network
 from duneapi.util import open_query
 
 from src.models import AccountingPeriod
+from src.utils.query_file import dashboard_file
 from src.utils.script_args import generic_script_init
 
 
@@ -27,7 +28,7 @@ def get_period_totals(dune: DuneAPI, period: AccountingPeriod) -> PeriodTotals:
     Fetches & Returns Dune Results for accounting period totals.
     """
     query = DuneQuery.from_environment(
-        raw_sql=open_query("./dashboards/solver-rewards-accounting/period-totals.sql"),
+        raw_sql=open_query(dashboard_file("period-totals.sql")),
         network=Network.MAINNET,
         name="Accounting Period Totals",
         parameters=[

--- a/src/fetch/reward_targets.py
+++ b/src/fetch/reward_targets.py
@@ -9,6 +9,7 @@ from duneapi.types import DuneQuery, Network, QueryParameter, Address
 from duneapi.util import open_query
 
 from src.utils.dataset import index_by
+from src.utils.query_file import query_file
 from src.utils.script_args import generic_script_init
 
 # pylint: disable=line-too-long
@@ -48,7 +49,10 @@ def get_vouches(dune: DuneAPI, end_time: datetime) -> dict[Address, Vouch]:
     pool_values = ",\n           ".join(RECOGNIZED_BONDING_POOLS)
     query = DuneQuery.from_environment(
         raw_sql="\n".join(
-            [open_query("./queries/vouch_registry.sql"), "select * from valid_vouches"]
+            [
+                open_query(query_file("vouch_registry.sql")),
+                "select * from valid_vouches",
+            ]
         ),
         network=Network.MAINNET,
         name="Solver Reward Targets",

--- a/src/fetch/risk_free_batches.py
+++ b/src/fetch/risk_free_batches.py
@@ -1,16 +1,18 @@
 """Fetching Risk-Free Batches from Dune Analytics"""
+
 from duneapi.api import DuneAPI
 from duneapi.types import DuneQuery, Network, QueryParameter
 from duneapi.util import open_query
 
 from src.models import AccountingPeriod
+from src.utils.query_file import query_file
 
 
 def get_risk_free_batches(dune: DuneAPI, period: AccountingPeriod) -> set[str]:
     """Fetches Risk Free Batches from Dune"""
     results = dune.fetch(
         query=DuneQuery.from_environment(
-            raw_sql=open_query("./queries/risk_free_batches.sql"),
+            raw_sql=open_query(query_file("risk_free_batches.sql")),
             network=Network.MAINNET,
             name="Risk Free Batches",
             parameters=[

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -44,6 +44,7 @@ from src.update.orderbook_rewards import push_user_generated_view, RewardQuery
 from src.utils.dataset import index_by
 from src.utils.prices import eth_in_token, TokenId, token_in_eth
 from src.utils.print_store import PrintStore, Category
+from src.utils.query_file import query_file
 from src.utils.script_args import generic_script_init
 
 log_saver = PrintStore()
@@ -449,7 +450,7 @@ def get_cow_rewards(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:
     # Validation of results - using characteristics of results from two sources.
     dune_trade_counts = dune.fetch(
         query=DuneQuery.from_environment(
-            raw_sql=open_query("./queries/dune_trade_counts.sql"),
+            raw_sql=open_query(query_file("dune_trade_counts.sql")),
             network=Network.MAINNET,
             name="Trade Counts",
             parameters=[
@@ -482,7 +483,7 @@ def get_eth_spent(dune: DuneAPI, period: AccountingPeriod) -> list[Transfer]:
     Fetches ETH spent on successful settlements by all solvers during `period`
     """
     query = DuneQuery.from_environment(
-        raw_sql=open_query("./queries/eth_spent.sql"),
+        raw_sql=open_query(query_file("eth_spent.sql")),
         network=Network.MAINNET,
         name="ETH Reimbursement",
         parameters=[

--- a/src/models.py
+++ b/src/models.py
@@ -13,6 +13,7 @@ from duneapi.types import Address, DuneQuery, Network, QueryParameter
 from duneapi.util import open_query
 
 from src.constants import COW_TOKEN_ADDRESS, w3
+from src.utils.query_file import query_file
 from src.utils.token_details import get_token_decimals
 
 
@@ -38,7 +39,7 @@ class AccountingPeriod:
         """Returns block numbers corresponding to date interval"""
         results = dune.fetch(
             query=DuneQuery.from_environment(
-                raw_sql=open_query("./queries/period_block_interval.sql"),
+                raw_sql=open_query(query_file("period_block_interval.sql")),
                 name=f"Block Interval for Accounting Period {self}",
                 network=Network.MAINNET,
                 parameters=[

--- a/src/update/orderbook_rewards.py
+++ b/src/update/orderbook_rewards.py
@@ -9,6 +9,7 @@ from duneapi.util import open_query
 from pandas import DataFrame, Series
 
 from src.models import AccountingPeriod
+from src.utils.query_file import query_file
 
 
 class RewardQuery(Enum):
@@ -41,9 +42,9 @@ class RewardQuery(Enum):
     def query_file(self) -> str:
         """Returns the file containing the RAW SQL for Dune Query"""
         if self == RewardQuery.AGGREGATE:
-            return "./queries/user_generated_rewards.sql"
+            return query_file("user_generated_rewards.sql")
         if self == RewardQuery.PER_ORDER:
-            return "./queries/user_generated_per_order_rewards.sql"
+            return query_file("user_generated_per_order_rewards.sql")
 
         raise ValueError(f"Invalid enum variant {self}")
 

--- a/src/update/token_list.py
+++ b/src/update/token_list.py
@@ -12,6 +12,7 @@ from duneapi.util import open_query
 
 from src.constants import LOG_CONFIG_FILE
 from src.token_list import fetch_trusted_tokens
+from src.utils.query_file import query_file
 from src.utils.script_args import generic_script_init
 
 log = logging.getLogger(__name__)
@@ -24,9 +25,9 @@ def update_token_list(dune: DuneAPI, token_list: list[str]) -> list[dict[str, st
     """Fetches current trusted token list and builds a user generated view from it"""
     if not token_list:
         raise ValueError("Can't update and empty token list")
-    raw_sql = open_query("./queries/token_list.sql").replace(
+    raw_sql = open_query(query_file("token_list.sql")).replace(
         "'{{TokenList}}'",
-        ",\n             ".join(token_list),
+        ",\n".join(token_list),
     )
     query = DuneQuery.from_environment(
         raw_sql=raw_sql, name="Updated Token List", network=Network.MAINNET

--- a/src/utils/query_file.py
+++ b/src/utils/query_file.py
@@ -1,0 +1,18 @@
+"""
+Relative imports are generally bad to include in a project.
+It causes problems when people are not necessarily running the scripts from the project root
+These utilities eliminate the need to use relative paths.
+"""
+import os
+
+from src.constants import QUERY_PATH, DASHBOARD_PATH
+
+
+def query_file(filename: str) -> str:
+    """Returns proper path for filename in QUERY_PATH"""
+    return os.path.join(QUERY_PATH, filename)
+
+
+def dashboard_file(filename: str) -> str:
+    """Returns proper path for filename in DASHBOARD_PATH"""
+    return os.path.join(DASHBOARD_PATH, filename)

--- a/tests/queries/test_internal_trades.py
+++ b/tests/queries/test_internal_trades.py
@@ -8,6 +8,7 @@ from duneapi.types import DuneQuery, QueryParameter, Network, Address
 from duneapi.util import open_query
 
 from src.models import AccountingPeriod
+from src.utils.query_file import query_file
 from tests.db.pg_client import ConnectionType, DBRouter
 
 
@@ -91,7 +92,7 @@ class TestInternalTrades(unittest.TestCase):
     def get_internal_transfers(self, tx_hash: str) -> list[InternalTransfer]:
         raw_sql = "\n".join(
             [
-                open_query("./queries/period_slippage.sql"),
+                open_query(query_file("period_slippage.sql")),
                 SELECT_INTERNAL_TRANSFERS,
             ]
         )

--- a/tests/queries/test_vouch_registry.py
+++ b/tests/queries/test_vouch_registry.py
@@ -5,6 +5,7 @@ from duneapi.types import DuneQuery, Network, QueryParameter, Address
 from duneapi.util import open_query
 
 from src.fetch.reward_targets import Vouch, parse_vouches, RECOGNIZED_BONDING_POOLS
+from src.utils.query_file import query_file
 from tests.db.pg_client import (
     ConnectionType,
     DBRouter,
@@ -88,7 +89,10 @@ def invalidate_vouch(
 def query_for(date_str: str, bonding_pools: list[str]) -> DuneQuery:
     return DuneQuery(
         raw_sql="\n".join(
-            [open_query("./queries/vouch_registry.sql"), "select * from valid_vouches"]
+            [
+                open_query(query_file("vouch_registry.sql")),
+                "select * from valid_vouches",
+            ]
         ),
         network=Network.MAINNET,
         name="Solver Reward Targets",


### PR DESCRIPTION
We had been using relative imports to open query files. This issue only really affects PyCharm users, but also its not good practice to have relative imports in a project.

closes #111 

# Test Plan

Existing CI should have enough query files being opened to prove that this still works.