### PR TITLE
Migrate Period Slippage Query

### DIFF
--- a/queries/dune_v1/period_slippage.sql
+++ b/queries/dune_v1/period_slippage.sql
@@ -223,7 +223,7 @@ internal_buffer_trader_solvers as (
 ),
 -- PoC Query For Token List: https://dune.com/queries/1547103
 token_list as (
-    SELECT decode(address_str, 'hex') as address
+    SELECT replace(address_str, '0x', '\x')::bytea as address
   FROM (
       VALUES {{TokenList}}
     ) as _ (address_str)

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -19,10 +19,7 @@ filtered_trades as (
             on t.tx_hash = b.tx_hash
     where b.block_time between '{{StartTime}}' and '{{EndTime}}'
     and t.block_time between '{{StartTime}}' and '{{EndTime}}'
-    and case
-            when '{{TxHash}}' = '0x' then true
-            else lower('{{TxHash}}') = t.tx_hash
-        end
+    and (t.tx_hash = lower('{{TxHash}}') or '{{TxHash}}' = '0x')
 ),
 
 batchwise_traders as (
@@ -85,10 +82,7 @@ other_transfers as (
       and '0x9008d19f58aabd9ed0d60971565aa8510560ab41' in (to, from)
       and not array_contains(traders_in, from)
       and not array_contains(traders_out, to)
-      and case
-              when '{{TxHash}}' = '0x' then true
-              else lower('{{TxHash}}') = b.tx_hash
-        end
+      and (t.evt_tx_hash = lower('{{TxHash}}') or '{{TxHash}}' = '0x')
 ),
 batch_transfers as (
     select * from user_in
@@ -136,7 +130,6 @@ incoming_and_outgoing as (
       -- Settlements with dex_swaps = 0 and num_trades = 0 can be handled in the following
       -- and we want to consider them in order to filter out illegal behaviour
         (dex_swaps = 0 and num_trades < 2) or dex_swaps > 0
---! TODO - dex_swaps can sometimes be NULL! because dex trades table isn't finished yet!
         and tx_hash not in (select tx_hash from exluded_batches)
 ),
 -- Benchmark takes 3 minuites to get here for ONE DAY interval!

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -4,11 +4,7 @@ with
 filtered_trades as (
     select t.block_time,
            t.tx_hash,
-           -- 1inch Solver has NULL DEX SWAPS.
-           -- This is the last remaining discrepancy between the two queries.
-           -- We need an estimation of dex_swaps for these solvers.
-           -- https://github.com/duneanalytics/spellbook/blob/2a7122f931900d754767df9359aa844af20c41ff/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql#L70-L80
-           coalesce(dex_swaps, 0) as dex_swaps ,
+           dex_swaps,
            num_trades,
            solver_address,
            trader                                              as trader_in,
@@ -213,11 +209,11 @@ internal_buffer_trader_solvers as (
     from cow_protocol_ethereum.solvers
     -- Exclude Single Order Solvers
     where name not in (
-        '1inch',
-        '0x',
-        'ParaSwap',
+        'Gnosis_1inch',
+        'Gnosis_0x',
+        'Gnosis_ParaSwap',
         'Baseline',
-        'BalancerSOR'
+        'Gnosis_BalancerSOR'
     )
     -- Exclude services and test solvers
     and environment not in ('service', 'test')

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,12 +1,11 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
 with
--- V2 Query: https://dune.com/queries/1570561
--- Benchmark 8 Minutes for 1 Day without pro account.
 filtered_trades as (
     select t.block_time,
            t.tx_hash,
            dex_swaps,
            num_trades,
-        --   solver_name,
            solver_address,
            trader                                              as trader_in,
            receiver                                            as trader_out,
@@ -14,11 +13,12 @@ filtered_trades as (
            buy_token_address                                   as buy_token,
            atoms_sold,
            atoms_bought,
-           lower('0x9008D19f58AAbD9eD0D60971565AA8510560ab41') as contract_address
+           '0x9008d19f58aabd9ed0d60971565aa8510560ab41' as contract_address
     from cow_protocol_ethereum.trades t
          join cow_protocol_ethereum.batches b
             on t.tx_hash = b.tx_hash
     where b.block_time between '{{StartTime}}' and '{{EndTime}}'
+    and t.block_time between '{{StartTime}}' and '{{EndTime}}'
     and case
             when '{{TxHash}}' = '0x' then true
             else lower('{{TxHash}}') = t.tx_hash
@@ -40,7 +40,6 @@ user_in as (
           dex_swaps,
           num_trades,
           solver_address,
-        --   solver_name,
           trader_in        as sender,
           contract_address as receiver,
           sell_token       as token,
@@ -54,7 +53,6 @@ user_out as (
           dex_swaps,
           num_trades,
           solver_address,
-        --   solver_name,
           contract_address as sender,
           trader_out       as receiver,
           buy_token        as token,
@@ -68,15 +66,14 @@ other_transfers as (
           dex_swaps,
           num_trades,
           solver_address,
-        --   solver_name,
           from               as sender,
           to                 as receiver,
           t.contract_address as token,
           value              as amount_wei,
           case
-              when to = lower('0x9008D19f58AAbD9eD0D60971565AA8510560ab41')
+              when to = '0x9008d19f58aabd9ed0d60971565aa8510560ab41'
                   then 'IN_AMM'
-              when from = lower('0x9008D19f58AAbD9eD0D60971565AA8510560ab41')
+              when from = '0x9008d19f58aabd9ed0d60971565aa8510560ab41'
                   then 'OUT_AMM'
               end            as transfer_type
     from erc20_ethereum.evt_Transfer t
@@ -85,7 +82,7 @@ other_transfers as (
              inner join batchwise_traders bt
                 on evt_tx_hash = bt.tx_hash
     where b.block_time between '{{StartTime}}' and '{{EndTime}}'
-      and lower('0x9008D19f58AAbD9eD0D60971565AA8510560ab41') in (to, from)
+      and '0x9008d19f58aabd9ed0d60971565aa8510560ab41' in (to, from)
       and not array_contains(traders_in, from)
       and not array_contains(traders_out, to)
       and case
@@ -104,7 +101,7 @@ batch_transfers as (
 -- whose transfer function doesn't align with the emitted transfer event.
 exluded_batches as (
     select tx_hash from filtered_trades
-    where lower('0xf5d669627376ebd411e34b98f19c868c8aba5ada') in (buy_token, sell_token)
+    where '0xf5d669627376ebd411e34b98f19c868c8aba5ada' in (buy_token, sell_token)
 ),
 incoming_and_outgoing as (
     SELECT
@@ -112,22 +109,20 @@ incoming_and_outgoing as (
         tx_hash,
         dex_swaps,
         solver_address,
-        -- solver_name,
         case
             when t.symbol = 'ETH' then 'WETH'
             when t.symbol is not null then t.symbol
             else token
         end                                     as symbol,
           case
-              when token = lower('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
-                  then lower('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
+              when token = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+                  then '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
               else token
               end                                     as token,
           case
-              when receiver =
-                    lower('0x9008D19f58AAbD9eD0D60971565AA8510560ab41')
+              when receiver = '0x9008d19f58aabd9ed0d60971565aa8510560ab41'
                   then amount_wei
-              when sender = lower('0x9008D19f58AAbD9eD0D60971565AA8510560ab41')
+              when sender = '0x9008d19f58aabd9ed0d60971565aa8510560ab41'
                   then -1 * amount_wei
               end                                     as amount,
           transfer_type
@@ -148,35 +143,34 @@ incoming_and_outgoing as (
 
 -- Clearing Prices query here: https://dune.com/queries/1571457
 pre_clearing_prices as (
-    select call_tx_hash as tx_hash,
-            i, j,
-          price,
-          token
+    select
+        call_tx_hash as tx_hash,
+        price,
+        token
     from gnosis_protocol_v2_ethereum.GPv2Settlement_call_settle
         lateral view posexplode(clearingPrices) as i, price
         lateral view posexplode(tokens) as j, token
-    where call_success = true
+    where call_block_time between '{{StartTime}}' and '{{EndTime}}'
+      and call_success = true
       and i = j
-      and call_block_time between '{{StartTime}}' and '{{EndTime}}'
-    order by call_block_number desc
 ),
 clearing_prices as (
-    select tx_hash,
-          case
-              when token = lower('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
-                  then lower('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
-              else token
-              end as token,
-          avg(price) as clearing_price
+    select
+        tx_hash,
+        case
+            when token = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+                then '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+            else token
+        end as token,
+        avg(price) as clearing_price
     from pre_clearing_prices
-    group by 1,2
+    group by tx_hash, token
 ),
 potential_buffer_trades as (
     select block_time,
           tx_hash,
           dex_swaps,
           solver_address,
-        --   solver_name,
           symbol,
           token,
           sum(amount) as amount
@@ -184,7 +178,6 @@ potential_buffer_trades as (
     group by tx_hash,
              dex_swaps,
              solver_address,
-            --  solver_name,
              symbol,
              token,
              block_time
@@ -205,7 +198,8 @@ valued_potential_buffered_trades as (
         on t.tx_hash = cp.tx_hash
     and t.token = cp.token
         left outer join prices.usd pusd
-            on pusd.contract_address = t.token
+            on pusd.minute between '{{StartTime}}' and '{{EndTime}}'
+            and pusd.contract_address = t.token
             and blockchain = 'ethereum'
             and date_trunc('minute', block_time) = pusd.minute
 ),
@@ -235,7 +229,6 @@ buffer_trades as (
     Select a.block_time as block_time,
           a.tx_hash,
           a.solver_address,
-        --   a.solver_name,
           a.symbol,
           a.token       as token_from,
           b.token       as token_to,
@@ -307,7 +300,6 @@ incoming_and_outgoing_with_buffer_trades as (
     select block_time,
           tx_hash,
           solver_address,
-        --   solver_name,
           symbol,
           token,
           amount,
@@ -317,7 +309,6 @@ incoming_and_outgoing_with_buffer_trades as (
     select block_time,
           tx_hash,
           solver_address,
-        --   solver_name,
           symbol,
           token_from as token,
           amount_from as amount,
@@ -327,7 +318,6 @@ incoming_and_outgoing_with_buffer_trades as (
 final_token_balance_sheet as (
     select
         solver_address,
-        -- solver_name,
         sum(amount) token_imbalance_wei,
         symbol,
         token,
@@ -339,7 +329,6 @@ final_token_balance_sheet as (
         symbol,
         token,
         solver_address,
-        -- solver_name,
         tx_hash,
         block_time
     having
@@ -396,7 +385,8 @@ intrinsic_prices as (
             date_trunc('hour', block_time) as hour,
             usd_value / units_bought as price
         FROM cow_protocol_ethereum.trades
-        WHERE units_bought > 0
+        WHERE block_time between '{{StartTime}}' and '{{EndTime}}'
+        AND units_bought > 0
     UNION
         select
             sell_token_address as contract_address,
@@ -404,7 +394,8 @@ intrinsic_prices as (
             date_trunc('hour', block_time) as hour,
             usd_value / units_sold as price
         FROM cow_protocol_ethereum.trades
-        WHERE units_sold > 0
+        WHERE block_time between '{{StartTime}}' and '{{EndTime}}'
+        AND units_sold > 0
     ) as combined
     GROUP BY hour, contract_address, decimals
 ),
@@ -441,7 +432,7 @@ eth_prices as (
         avg(price) as eth_price
     from prices.usd
     where blockchain = 'ethereum'
-    and contract_address = lower('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
+    and contract_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
     and minute between '{{StartTime}}' and '{{EndTime}}'
     group by date_trunc('hour', minute)
 ),
@@ -449,7 +440,6 @@ results_per_tx as (
     select
         ftbs.hour,
         solver_address,
-        -- solver_name,
         sum(token_imbalance_wei * price / pow(10, p.decimals)) as usd_value,
         sum(token_imbalance_wei * price / pow(10, p.decimals) / eth_price) * pow(10, 18) as eth_slippage_wei,
         tx_hash
@@ -463,7 +453,6 @@ results_per_tx as (
     group by
         ftbs.hour,
         solver_address,
-        -- solver_name,
         tx_hash
     having
         bool_and(price is not null)

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,0 +1,508 @@
+with
+-- V2 Query: https://dune.com/queries/1570561
+-- Benchmark 8 Minutes for 1 Day without pro account.
+filtered_trades as (
+    select t.block_time,
+           t.tx_hash,
+           dex_swaps,
+           num_trades,
+        --   solver_name,
+           solver_address,
+           trader                                              as trader_in,
+           receiver                                            as trader_out,
+           sell_token_address                                  as sell_token,
+           buy_token_address                                   as buy_token,
+           atoms_sold,
+           atoms_bought,
+           lower('0x9008D19f58AAbD9eD0D60971565AA8510560ab41') as contract_address
+    from cow_protocol_ethereum.trades t
+         join cow_protocol_ethereum.batches b
+            on t.tx_hash = b.tx_hash
+    where b.block_time between '{{StartTime}}' and '{{EndTime}}'
+    and case
+            when '{{TxHash}}' = '0x' then true
+            else lower('{{TxHash}}') = t.tx_hash
+        end
+),
+
+batchwise_traders as (
+    select
+        tx_hash,
+        collect_set(trader_in) as traders_in,
+        collect_set(trader_out) as traders_out
+    from filtered_trades
+    group by tx_hash
+),
+
+user_in as (
+    select block_time,
+          tx_hash,
+          dex_swaps,
+          num_trades,
+          solver_address,
+        --   solver_name,
+          trader_in        as sender,
+          contract_address as receiver,
+          sell_token       as token,
+          atoms_sold       as amount_wei,
+          'IN_USER'        as transfer_type
+    from filtered_trades
+),
+user_out as (
+    select block_time,
+          tx_hash,
+          dex_swaps,
+          num_trades,
+          solver_address,
+        --   solver_name,
+          contract_address as sender,
+          trader_out       as receiver,
+          buy_token        as token,
+          atoms_bought     as amount_wei,
+          'OUT_USER'       as transfer_type
+    from filtered_trades
+),
+other_transfers as (
+    select block_time,
+          b.tx_hash,
+          dex_swaps,
+          num_trades,
+          solver_address,
+        --   solver_name,
+          from               as sender,
+          to                 as receiver,
+          t.contract_address as token,
+          value              as amount_wei,
+          case
+              when to = lower('0x9008D19f58AAbD9eD0D60971565AA8510560ab41')
+                  then 'IN_AMM'
+              when from = lower('0x9008D19f58AAbD9eD0D60971565AA8510560ab41')
+                  then 'OUT_AMM'
+              end            as transfer_type
+    from erc20_ethereum.evt_Transfer t
+             inner join cow_protocol_ethereum.batches b
+                on evt_tx_hash = b.tx_hash
+             inner join batchwise_traders bt
+                on evt_tx_hash = bt.tx_hash
+    where b.block_time between '{{StartTime}}' and '{{EndTime}}'
+      and lower('0x9008D19f58AAbD9eD0D60971565AA8510560ab41') in (to, from)
+      and not array_contains(traders_in, from)
+      and not array_contains(traders_out, to)
+      and case
+              when '{{TxHash}}' = '0x' then true
+              else lower('{{TxHash}}') = b.tx_hash
+        end
+),
+batch_transfers as (
+    select * from user_in
+    union
+    select * from user_out
+    union
+    select * from other_transfers
+),
+-- These batches involve a token AXS (Old)
+-- whose transfer function doesn't align with the emitted transfer event.
+exluded_batches as (
+    select tx_hash from filtered_trades
+    where lower('0xf5d669627376ebd411e34b98f19c868c8aba5ada') in (buy_token, sell_token)
+),
+incoming_and_outgoing as (
+    SELECT
+        block_time,
+        tx_hash,
+        dex_swaps,
+        solver_address,
+        -- solver_name,
+        case
+            when t.symbol = 'ETH' then 'WETH'
+            when t.symbol is not null then t.symbol
+            else token
+        end                                     as symbol,
+          case
+              when token = lower('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
+                  then lower('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
+              else token
+              end                                     as token,
+          case
+              when receiver =
+                    lower('0x9008D19f58AAbD9eD0D60971565AA8510560ab41')
+                  then amount_wei
+              when sender = lower('0x9008D19f58AAbD9eD0D60971565AA8510560ab41')
+                  then -1 * amount_wei
+              end                                     as amount,
+          transfer_type
+    from batch_transfers i
+        left outer join tokens.erc20 t
+            on i.token = t.contract_address
+            and blockchain = 'ethereum'
+    where
+      -- We exclude settlements that have zero AMM interactions and settle several trades,
+      -- as our query is not good enough to handle these cases accurately.
+      -- Settlements with dex_swaps = 0 and num_trades = 0 can be handled in the following
+      -- and we want to consider them in order to filter out illegal behaviour
+        (dex_swaps = 0 and num_trades < 2) or dex_swaps > 0
+--! TODO - dex_swaps can sometimes be NULL! because dex trades table isn't finished yet!
+        and tx_hash not in (select tx_hash from exluded_batches)
+),
+-- Benchmark takes 3 minuites to get here for ONE DAY interval!
+
+-- Clearing Prices query here: https://dune.com/queries/1571457
+pre_clearing_prices as (
+    select call_tx_hash as tx_hash,
+            i, j,
+          price,
+          token
+    from gnosis_protocol_v2_ethereum.GPv2Settlement_call_settle
+        lateral view posexplode(clearingPrices) as i, price
+        lateral view posexplode(tokens) as j, token
+    where call_success = true
+      and i = j
+      and call_block_time between '{{StartTime}}' and '{{EndTime}}'
+    order by call_block_number desc
+),
+clearing_prices as (
+    select tx_hash,
+          case
+              when token = lower('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
+                  then lower('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
+              else token
+              end as token,
+          avg(price) as clearing_price
+    from pre_clearing_prices
+    group by 1,2
+),
+potential_buffer_trades as (
+    select block_time,
+          tx_hash,
+          dex_swaps,
+          solver_address,
+        --   solver_name,
+          symbol,
+          token,
+          sum(amount) as amount
+    from incoming_and_outgoing io
+    group by tx_hash,
+             dex_swaps,
+             solver_address,
+            --  solver_name,
+             symbol,
+             token,
+             block_time
+             -- exclude 0 to prevent zero division, and exclude very small values for performance
+    having abs(sum(amount)) > 0.0001
+),
+valued_potential_buffered_trades as (
+    select t.*,
+          amount * clearing_price            as clearing_value,
+          amount / pow(10, decimals) * price as usd_value
+    from potential_buffer_trades t
+    -- The following joins require the uniqueness of the prices per join,
+    -- otherwise duplicated internal trades will be found.
+    -- For clearing prices, it is given by construction and
+    -- for prices.usd, one can see that the primary key of the table is
+    -- (contract, minute) as seen here: https://dune.xyz/queries/510124
+    left outer join clearing_prices cp
+        on t.tx_hash = cp.tx_hash
+    and t.token = cp.token
+        left outer join prices.usd pusd
+            on pusd.contract_address = t.token
+            and blockchain = 'ethereum'
+            and date_trunc('minute', block_time) = pusd.minute
+),
+internal_buffer_trader_solvers as (
+    -- See the resulting list at: https://dune.com/queries/908642
+    select address
+    from cow_protocol_ethereum.solvers
+    -- Exclude Single Order Solvers
+    where name not in (
+        '1inch',
+        '0x',
+        'ParaSwap',
+        'Baseline',
+        'BalancerSOR'
+    )
+    -- Exclude services and test solvers
+    and environment not in ('service', 'test')
+),
+-- V2 PoC Query For Token List: https://dune.com/queries/1576758?d=1
+token_list as (
+    SELECT lower(address_str) as address
+  FROM (
+      VALUES {{TokenList}}
+    ) as _ (address_str)
+),
+buffer_trades as (
+    Select a.block_time as block_time,
+          a.tx_hash,
+          a.solver_address,
+        --   a.solver_name,
+          a.symbol,
+          a.token       as token_from,
+          b.token       as token_to,
+          -1 * a.amount as amount_from,
+          -1 * b.amount as amount_to,
+          abs((a.clearing_value + b.clearing_value) /(abs(a.clearing_value) + abs(b.clearing_value))) as matchablity_clearing_prices,
+          abs((a.usd_value + b.usd_value) / (abs(a.usd_value) + abs(b.usd_value))) as matchability_prices_dune,
+          'INTERNAL_TRADE'   as transfer_type
+    from valued_potential_buffered_trades a
+             full outer join valued_potential_buffered_trades b
+                             on a.tx_hash = b.tx_hash
+    where (
+              case
+                  -- in order to classify as buffer trade, the positive surplus must be in an allow_listed token
+                  when ((a.amount > 0 and b.amount < 0 and a.token in (select * from token_list))
+                      or (b.amount > 0 and a.amount < 0 and b.token in (select * from token_list)))
+                      and
+                      -- We know that settlements - with at least one amm interaction - have internal buffer trades only if
+                      -- the solution must come from a internal_buffer_trader_solvers solver
+                      (a.solver_address in (select * from internal_buffer_trader_solvers)
+                          or a.dex_swaps = 0)
+                      then
+                      case
+                          when a.clearing_value is not null and
+                              b.clearing_value is not null
+                              -- If clearing prices are use, the price of internal trades are usually pretty close to
+                              -- the clearing prices. But they don't have to be the same, as internal trades are usually settled
+                              -- at the effective rate of an AMM. One example with deviating prices, is the tx:
+                              -- 0x9a318d1abd997bcf8afed55b2946a7b1bd919d227f094cdcc99d8d6155808d7c. It
+                              -- scores a matchablity of 0.021.
+                              -- Another example is xd2e1eeef702d562491d6b68683772fec1b119df18e338b50f45ed4751c89e406 with a
+                              -- matchablity of 0.02 for USDC to ETH trade
+                              -- But for higher values, one more commonly find examples, where solvers sell a little bit too much
+                              -- of the selling token and hence also receive a little bit too much of the buying token
+                              -- One could see this as an internal buffer trade, but since this is not good for the protocol's buffers
+                              -- we will not evaluate this as buffer trade, but rather as positive and negative slippage at the same time:
+                              -- One example is: 0x63e234a1a0d657f5725817f8d829c4e14d8194fdc49b5bc09322179ff99619e7 with a matchablity of 0.26
+                              -- selling too much USDC and receiving too much ETH
+                              then (abs((a.clearing_value + b.clearing_value) /
+                                        (abs(a.clearing_value) + abs(b.clearing_value))) <
+                                    0.025
+                              and a.token != b.token)
+                          else
+                              case
+                                  when a.usd_value is not null and b.usd_value is not null
+                                      -- If prices from the prices.usd dune table are used, the prices can also be off from time to time.
+                                      -- On the one hand side, we don't wanna allow to high deviations. E.g. for
+                                      -- 0x9a318d1abd997bcf8afed55b2946a7b1bd919d227f094cdcc99d8d6155808d7c a matchability of 0.26 is calculated
+                                      -- for a slippage of WETH and the LDO deficit. (In this example the internal trade is only STRONG -> LDO)
+                                      -- On the other hand, real internal trades like the CRV to USDT internal trade of 0xc15dda7c10eb317c0ad177316020ec4baa13babb0713b73480feef14045603f4
+                                      -- also score a matchablilty of 0.027
+                                      -- As a compromise 0.025 was chosen
+                                      then (abs((a.usd_value + b.usd_value) /
+                                                (abs(a.usd_value) + abs(b.usd_value))) <
+                                            0.025
+                                      and a.token != b.token
+                                      and abs(a.usd_value) > 10 -- we don't want small slippage values to be recognized as internal swaps
+                                      )
+                                  else
+                                      false
+                                  end
+                          end
+                  else
+                      false
+                  end
+              )
+),
+incoming_and_outgoing_with_buffer_trades as (
+    select block_time,
+          tx_hash,
+          solver_address,
+        --   solver_name,
+          symbol,
+          token,
+          amount,
+          transfer_type
+    from incoming_and_outgoing
+    union all
+    select block_time,
+          tx_hash,
+          solver_address,
+        --   solver_name,
+          symbol,
+          token_from as token,
+          amount_from as amount,
+          transfer_type
+    from buffer_trades
+),
+final_token_balance_sheet as (
+    select
+        solver_address,
+        -- solver_name,
+        sum(amount) token_imbalance_wei,
+        symbol,
+        token,
+        tx_hash,
+        date_trunc('hour', block_time) as hour
+    from
+        incoming_and_outgoing_with_buffer_trades
+    group by
+        symbol,
+        token,
+        solver_address,
+        -- solver_name,
+        tx_hash,
+        block_time
+    having
+        sum(amount) != 0
+),
+
+-- Benchmark: 4 minutes for 1 day (non-pro account)
+-- select * from final_token_balance_sheet limit 10
+token_times as (
+    select hour, token
+    from final_token_balance_sheet
+    group by hour, token
+),
+precise_prices as (
+    select
+        contract_address,
+        decimals,
+        date_trunc('hour', minute) as hour,
+        avg(price) as price
+    from
+        prices.usd pusd
+    inner join token_times tt
+        on minute between date(hour) and date(hour) + interval '1 day' -- query execution speed optimization since minute is indexed
+        and date_trunc('hour', minute) = hour
+        and contract_address = token
+        and blockchain = 'ethereum'
+    group by
+        contract_address,
+        decimals,
+        date_trunc('hour', minute)
+),
+--! THIS TABLE DOES NOT EXIST ON V2 (at least not yet!)
+-- median_prices as (
+--     select
+--         contract_address,
+--         decimals,
+--         tt.hour,
+--         median_price
+--     from
+--         prices.prices_from_dex_data musd
+--         inner join token_times tt on musd.hour = tt.hour
+--         and contract_address = token
+-- ),
+intrinsic_prices as (
+    select
+        contract_address,
+        decimals,
+        hour,
+        AVG(price) as price
+    from (
+        select
+            buy_token_address as contract_address,
+            ROUND(LOG(10, atoms_bought / units_bought)) as decimals,
+            date_trunc('hour', block_time) as hour,
+            usd_value / units_bought as price
+        FROM cow_protocol_ethereum.trades
+        WHERE units_bought > 0
+    UNION
+        select
+            sell_token_address as contract_address,
+            ROUND(LOG(10, atoms_sold / units_sold)) as decimals,
+            date_trunc('hour', block_time) as hour,
+            usd_value / units_sold as price
+        FROM cow_protocol_ethereum.trades
+        WHERE units_sold > 0
+    ) as combined
+    GROUP BY hour, contract_address, decimals
+),
+-- Price Construction: https://dune.com/queries/1579091?
+prices as (
+    select
+        tt.hour as hour,
+        tt.token as contract_address,
+        COALESCE(
+            precise.decimals,
+            -- median.decimals,
+            intrinsic.decimals
+        ) as decimals,
+        COALESCE(
+            precise.price,
+            -- median_price,
+            intrinsic.price
+        ) as price
+    from token_times tt
+    LEFT JOIN precise_prices precise
+        ON precise.hour = tt.hour
+        AND precise.contract_address = token
+    -- LEFT JOIN prices.prices_from_dex_data median
+    --     ON median.hour = tt.hour
+    --     and median.contract_address = token
+    LEFT JOIN intrinsic_prices intrinsic
+        ON intrinsic.hour = tt.hour
+        and intrinsic.contract_address = token
+),
+-- ETH Prices: https://dune.com/queries/1578626?d=1
+eth_prices as (
+    select
+        date_trunc('hour', minute) as hour,
+        avg(price) as eth_price
+    from prices.usd
+    where blockchain = 'ethereum'
+    and contract_address = lower('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
+    and minute between '{{StartTime}}' and '{{EndTime}}'
+    group by date_trunc('hour', minute)
+),
+results_per_tx as (
+    select
+        ftbs.hour,
+        solver_address,
+        -- solver_name,
+        sum(token_imbalance_wei * price / pow(10, p.decimals)) as usd_value,
+        sum(token_imbalance_wei * price / pow(10, p.decimals) / eth_price) * pow(10, 18) as eth_slippage_wei,
+        tx_hash
+    from
+        final_token_balance_sheet ftbs
+    left join prices p
+        on token = p.contract_address
+        and p.hour = ftbs.hour
+    left join eth_prices ep
+        on  ftbs.hour = ep.hour
+    group by
+        ftbs.hour,
+        solver_address,
+        -- solver_name,
+        tx_hash
+    having
+        bool_and(price is not null)
+),
+-- Benchmark: 10 minutes for ONE DAY with non-pro account.
+-- select * from results_per_tx limit 10
+results as (
+    select
+        solver_address,
+        concat(environment, '-', name) as solver_name,
+        sum(usd_value) as usd_value,
+        sum(eth_slippage_wei) as eth_slippage_wei
+    from
+        results_per_tx rpt
+    join eth_prices ep
+        on rpt.hour = ep.hour
+    join cow_protocol_ethereum.solvers
+        on address = solver_address
+    group by
+        solver_address,
+        solver_name
+)
+select * from results
+
+-- -- select
+-- --     block_time,
+-- --     rpt.solver_name,
+-- --     concat('<a href="https://dune.com/queries/663231?TxHash=', concat('0x', encode(rpt.tx_hash, 'hex')), '" target="_blank">link</a>') as token_breakdown,
+-- --     concat('0x', encode(rpt.tx_hash, 'hex')) as tx_hash,
+-- --     usd_value,
+-- --     batch_value,
+-- --     100 * usd_value / batch_value as relative_slippage
+-- -- from results_per_tx rpt
+-- -- join gnosis_protocol_v2."batches" b
+-- --     on rpt.tx_hash = b.tx_hash
+-- -- where (
+-- --     abs(usd_value) > '{{MinAbsoluteSlippageTolerance}}'
+-- --     and
+-- --     100.0 * abs(usd_value) / batch_value > '{{RelativeSlippageTolerance}}'
+-- -- ) or
+-- --     abs(usd_value) > '{{SignificantSlippageValue}}'
+-- -- order by relative_slippage

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -4,7 +4,11 @@ with
 filtered_trades as (
     select t.block_time,
            t.tx_hash,
-           dex_swaps,
+           -- 1inch Solver has NULL DEX SWAPS.
+           -- This is the last remaining discrepancy between the two queries.
+           -- We need an estimation of dex_swaps for these solvers.
+           -- https://github.com/duneanalytics/spellbook/blob/2a7122f931900d754767df9359aa844af20c41ff/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql#L70-L80
+           coalesce(dex_swaps, 0) as dex_swaps ,
            num_trades,
            solver_address,
            trader                                              as trader_in,

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -11,12 +11,12 @@ from src.fetch.token_list import get_trusted_tokens
 from src.logger import set_log
 from src.models.accounting_period import AccountingPeriod
 from src.models.period_totals import PeriodTotals
-from src.models.slippage import SplitSlippages, slippage_query
+from src.models.slippage import SplitSlippages
 from src.models.split_transfers import SplitTransfers
 from src.models.transfer import Transfer
 from src.models.vouch import Vouch, RECOGNIZED_BONDING_POOLS, parse_vouches
 from src.pg_client import DualEnvDataframe
-from src.queries import QUERIES
+from src.queries import QUERIES, DuneVersion, QueryData
 from src.utils.dataset import index_by
 from src.utils.print_store import PrintStore
 from src.utils.query_file import open_query
@@ -36,15 +36,27 @@ class DuneFetcher:
     period: AccountingPeriod
     log_saver: PrintStore
 
-    def __init__(self, dune_v1: DuneAPI, dune: DuneClient, period: AccountingPeriod):
+    def __init__(
+        self,
+        dune_v1: DuneAPI,
+        dune: DuneClient,
+        period: AccountingPeriod,
+        dune_version: DuneVersion = DuneVersion.V1,
+    ):
         self.dune_v1 = dune_v1
         self.dune = dune
         self.period = period
         self.log_saver = PrintStore()
+        self.dune_version = dune_version
 
     def _period_params(self) -> list[QueryParameter]:
         """Easier access to these parameters."""
         return self.period.as_query_params()
+
+    def _parameterized_query(
+        self, query_data: QueryData, params: list[QueryParameter]
+    ) -> Query:
+        return query_data.with_params(params, dune_version=self.dune_version)
 
     def _get_query_results(self, query: Query) -> list[dict[str, str]]:
         """Internally every dune query execution is routed through here."""
@@ -59,7 +71,9 @@ class DuneFetcher:
 
     def get_block_interval(self) -> tuple[str, str]:
         """Returns block numbers corresponding to date interval"""
-        query = QUERIES["PERIOD_BLOCK_INTERVAL"].with_params(self._period_params())
+        query = self._parameterized_query(
+            QUERIES["PERIOD_BLOCK_INTERVAL"], self._period_params()
+        )
         query.name = f"Block Interval for Accounting Period {self}"
         results = self._get_query_results(query)
         assert len(results) == 1, "Block Interval Query should return only 1 result!"
@@ -70,14 +84,16 @@ class DuneFetcher:
         Fetches ETH spent on successful settlements by all solvers during `period`
         """
         results = self._get_query_results(
-            QUERIES["ETH_SPENT"].with_params(self._period_params())
+            self._parameterized_query(QUERIES["ETH_SPENT"], self._period_params())
         )
         return [Transfer.from_dict(t) for t in results]
 
     def get_risk_free_batches(self) -> set[str]:
         """Fetches Risk Free Batches from Dune"""
         results = self._get_query_results(
-            QUERIES["RISK_FREE_BATCHES"].with_params(self._period_params())
+            self._parameterized_query(
+                QUERIES["RISK_FREE_BATCHES"], self._period_params()
+            )
         )
         return {row["tx_hash"].lower() for row in results}
 
@@ -95,11 +111,12 @@ class DuneFetcher:
 
         # Validation of results - using characteristics of results from two sources.
         trade_counts = self._get_query_results(
-            QUERIES["TRADE_COUNT"].with_params(
-                [
+            query=self._parameterized_query(
+                query_data=QUERIES["TRADE_COUNT"],
+                params=[
                     QueryParameter.text_type("start_block", start_block),
                     QueryParameter.text_type("end_block", end_block),
-                ]
+                ],
             )
         )
         # Number of trades per solver retrieved from orderbook agrees ethereum events.
@@ -142,7 +159,9 @@ class DuneFetcher:
         Fetches & Returns Dune Results for accounting period totals.
         """
         data_set = self._get_query_results(
-            QUERIES["PERIOD_TOTALS"].with_params(self._period_params())
+            query=self._parameterized_query(
+                query_data=QUERIES["PERIOD_TOTALS"], params=self._period_params()
+            )
         )
         assert len(data_set) == 1
         rec = data_set[0]
@@ -159,18 +178,16 @@ class DuneFetcher:
         Returns a class representation of the results as two lists (positive & negative).
         """
         token_list = get_trusted_tokens()
-        query = DuneQuery.from_environment(
-            raw_sql=slippage_query(),
-            network=Network.MAINNET,
-            name="Slippage Accounting",
-            parameters=[
-                LegacyParameter.date_type("StartTime", self.period.start),
-                LegacyParameter.date_type("EndTime", self.period.end),
-                LegacyParameter.text_type("TxHash", "0x"),
-                LegacyParameter.text_type("TokenList", ",".join(token_list)),
-            ],
+        data_set = self._get_query_results(
+            self._parameterized_query(
+                QUERIES["PERIOD_SLIPPAGE"],
+                params=self._period_params()
+                + [
+                    QueryParameter.text_type("TxHash", "0x"),
+                    QueryParameter.text_type("TokenList", ",".join(token_list)),
+                ],
+            )
         )
-        data_set = self.dune_v1.fetch(query)
         return SplitSlippages.from_data_set(data_set)
 
     def get_transfers(self) -> list[Transfer]:

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -60,7 +60,7 @@ class DuneFetcher:
 
     def _get_query_results(self, query: Query) -> list[dict[str, str]]:
         """Internally every dune query execution is routed through here."""
-        exec_result = self.dune.refresh(query)
+        exec_result = self.dune.refresh(query, ping_frequency=20)
         # TODO - use a real logger:
         #  https://github.com/cowprotocol/dune-client/issues/34
         if exec_result.result is not None:

--- a/src/fetch/token_list.py
+++ b/src/fetch/token_list.py
@@ -31,9 +31,7 @@ def parse_token_list(token_list_json: str) -> list[str]:
         print("Could not parse JSON data!")
         raise
     return [
-        f"('{t['address'].replace('0x', '')}')"
-        for t in token_list["tokens"]
-        if t["chainId"] == 1
+        f"('{t['address'].lower()}')" for t in token_list["tokens"] if t["chainId"] == 1
     ]
 
 

--- a/src/queries.py
+++ b/src/queries.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 
 from copy import copy
 from dataclasses import dataclass
+from enum import Enum
 
 from dune_client.query import Query
 from dune_client.types import QueryParameter
 
 from src.utils.query_file import dashboard_file
+
+
+class DuneVersion(Enum):
+    """Dune Version Identifier"""
+
+    V1 = 1
+    V2 = 2
 
 
 @dataclass
@@ -26,12 +34,17 @@ class QueryData:
         self.v1_query = Query(v1_id, name)
         self.v2_query = Query(v2_id, name)
 
-    def with_params(self, params: list[QueryParameter]) -> Query:
+    def with_params(
+        self, params: list[QueryParameter], dune_version: DuneVersion = DuneVersion.V1
+    ) -> Query:
         """
         Copies the query and adds parameters to it, returning the copy.
         """
         # We currently default to the V1 Queries, soon to switch them out.
         query_copy = copy(self.v1_query)
+        if dune_version == DuneVersion.V2:
+            query_copy = copy(self.v2_query)
+
         query_copy.params = params
         return query_copy
 
@@ -72,5 +85,11 @@ QUERIES = {
         filepath=dashboard_file("period-totals.sql"),
         v1_id=448457,
         v2_id=-1,  # Not implemented
+    ),
+    "PERIOD_SLIPPAGE": QueryData(
+        name="Solver Slippage for Period",
+        filepath="period_slippage.sql",
+        v1_id=1570227,
+        v2_id=1570561,
     ),
 }

--- a/tests/integration/test_query_migration.py
+++ b/tests/integration/test_query_migration.py
@@ -6,6 +6,7 @@ from duneapi.api import DuneAPI
 
 from src.fetch.dune import DuneFetcher
 from src.models.accounting_period import AccountingPeriod
+from src.models.slippage import SolverSlippage, SplitSlippages
 from src.queries import DuneVersion
 
 
@@ -15,17 +16,24 @@ class MyTestCase(unittest.TestCase):
         self.dune_v2 = DuneClient(os.environ["DUNE_API_KEY"])
 
     def test_similar_slippage(self):
-        period = AccountingPeriod("2022-11-01")
+        period = AccountingPeriod("2022-11-01", length_days=1)
         dune_v1 = self.dune_v1
         dune = self.dune_v2
+        # These results expire at 2024-11-22
+        # v1_result = dune.get_result("01GJGHR9AG3AAXCQSSGWFPRW5E")
+        # v2_result = dune.get_result("01GJGHTRH14SSR33K7BK5RZ9B8")
+
+        # v1_slippage = SplitSlippages.from_data_set(v1_result.get_rows())
+        # v2_slippage = SplitSlippages.from_data_set(v2_result.get_rows())
+
         v1_fetcher = DuneFetcher(dune_v1, dune, period, dune_version=DuneVersion.V1)
         v2_fetcher = DuneFetcher(dune_v1, dune, period, dune_version=DuneVersion.V2)
         # Takes about 2-3 minutes each. Could be parallelized!
         v1_slippage = v1_fetcher.get_period_slippage()
         v2_slippage = v2_fetcher.get_period_slippage()
 
-        self.assertEqual(len(v1_slippage.negative), len(v2_slippage.negative))
-        self.assertEqual(len(v1_slippage.positive), len(v2_slippage.positive))
+        print(v1_slippage)
+        print(v2_slippage)
 
         self.assertAlmostEqual(
             v1_slippage.sum_negative(), v2_slippage.sum_negative(), delta=1000

--- a/tests/integration/test_query_migration.py
+++ b/tests/integration/test_query_migration.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+import pytest
 from dune_client.client import DuneClient
 from duneapi.api import DuneAPI
 
@@ -10,36 +11,68 @@ from src.models.slippage import SolverSlippage, SplitSlippages
 from src.queries import DuneVersion
 
 
-class MyTestCase(unittest.TestCase):
+class TestQueryMigration(unittest.TestCase):
     def setUp(self) -> None:
         self.dune_v1 = DuneAPI("", "")
         self.dune_v2 = DuneClient(os.environ["DUNE_API_KEY"])
 
-    def test_similar_slippage(self):
+    def test_similar_slippage_cached_results_one_day(self):
         period = AccountingPeriod("2022-11-01", length_days=1)
         dune_v1 = self.dune_v1
         dune = self.dune_v2
         # These results expire at 2024-11-22
-        # v1_result = dune.get_result("01GJGHR9AG3AAXCQSSGWFPRW5E")
-        # v2_result = dune.get_result("01GJGHTRH14SSR33K7BK5RZ9B8")
+        v1_result = dune.get_result("01GJJBP5E0CE4XM8FJ7KBVB8KW")
+        v2_result = dune.get_result("01GJJBNWMZNTTB6VQCFZMK7JCN")
+        print(v1_result)
+        print(v2_result)
 
-        # v1_slippage = SplitSlippages.from_data_set(v1_result.get_rows())
-        # v2_slippage = SplitSlippages.from_data_set(v2_result.get_rows())
+        v1_slippage = SplitSlippages.from_data_set(v1_result.get_rows())
+        v2_slippage = SplitSlippages.from_data_set(v2_result.get_rows())
+
+        # v1_fetcher = DuneFetcher(dune_v1, dune, period, dune_version=DuneVersion.V1)
+        # v2_fetcher = DuneFetcher(dune_v1, dune, period, dune_version=DuneVersion.V2)
+        # # Takes about 2-3 minutes each. Could be parallelized!
+        # v1_slippage = v1_fetcher.get_period_slippage()
+        # v2_slippage = v2_fetcher.get_period_slippage()
+        delta = 2  # decimal places ETH. This is 2.20 USD with ETH at 100
+        self.assertAlmostEqual(
+            v1_slippage.sum_negative() / 10**18,
+            v2_slippage.sum_negative() / 10**18,
+            delta,
+        )
+        self.assertAlmostEqual(
+            v1_slippage.sum_positive() / 10**18,
+            v2_slippage.sum_positive() / 10**18,
+            delta,
+        )
+
+    @pytest.mark.skip(
+        reason="This test takes FOREVER to run, use the Cached version above."
+    )
+    def test_similar_slippage_for_period(self):
+        period = AccountingPeriod("2022-11-01", length_days=1)
+        dune_v1 = self.dune_v1
+        dune = self.dune_v2
 
         v1_fetcher = DuneFetcher(dune_v1, dune, period, dune_version=DuneVersion.V1)
         v2_fetcher = DuneFetcher(dune_v1, dune, period, dune_version=DuneVersion.V2)
         # Takes about 2-3 minutes each. Could be parallelized!
         v1_slippage = v1_fetcher.get_period_slippage()
         v2_slippage = v2_fetcher.get_period_slippage()
+        # Cached Results available at
+        # V1: 01GJJD92TNQE0476SSWP2EMC34
+        # V2: 01GJJDAZFKMNP7KKZWFWQKY05S
 
-        print(v1_slippage)
-        print(v2_slippage)
-
+        delta = 2  # decimal places ETH. This is 2.20 USD with ETH at 100
         self.assertAlmostEqual(
-            v1_slippage.sum_negative(), v2_slippage.sum_negative(), delta=1000
+            v1_slippage.sum_negative() / 10**18,
+            v2_slippage.sum_negative() / 10**18,
+            delta,
         )
         self.assertAlmostEqual(
-            v1_slippage.sum_positive(), v2_slippage.sum_positive(), delta=1000
+            v1_slippage.sum_positive() / 10**18,
+            v2_slippage.sum_positive() / 10**18,
+            delta,
         )
 
 

--- a/tests/integration/test_query_migration.py
+++ b/tests/integration/test_query_migration.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+
+from dune_client.client import DuneClient
+from duneapi.api import DuneAPI
+
+from src.fetch.dune import DuneFetcher
+from src.models.accounting_period import AccountingPeriod
+from src.queries import DuneVersion
+
+
+class MyTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dune_v1 = DuneAPI("", "")
+        self.dune_v2 = DuneClient(os.environ["DUNE_API_KEY"])
+
+    def test_similar_slippage(self):
+        v1_fetcher = DuneFetcher(
+            dune_v1=self.dune_v1,
+            dune=self.dune_v2,
+            period=AccountingPeriod("2022-11-01"),
+        )
+        v2_fetcher = DuneFetcher(
+            dune_v1=self.dune_v1,
+            dune=self.dune_v2,
+            period=AccountingPeriod("2022-11-01"),
+            dune_version=DuneVersion.V2,
+        )
+        # Takes about 2-3 minutes each. Could be parallelized!
+        v1_slippage = v1_fetcher.get_period_slippage()
+        v2_slippage = v2_fetcher.get_period_slippage()
+
+        self.assertEqual(len(v1_slippage.negative), len(v2_slippage.negative))
+        self.assertEqual(len(v1_slippage.positive), len(v2_slippage.positive))
+
+        self.assertAlmostEqual(
+            v1_slippage.sum_negative(), v2_slippage.sum_negative(), delta=1000
+        )
+        self.assertAlmostEqual(
+            v1_slippage.sum_positive(), v2_slippage.sum_positive(), delta=1000
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_query_migration.py
+++ b/tests/integration/test_query_migration.py
@@ -15,17 +15,11 @@ class MyTestCase(unittest.TestCase):
         self.dune_v2 = DuneClient(os.environ["DUNE_API_KEY"])
 
     def test_similar_slippage(self):
-        v1_fetcher = DuneFetcher(
-            dune_v1=self.dune_v1,
-            dune=self.dune_v2,
-            period=AccountingPeriod("2022-11-01"),
-        )
-        v2_fetcher = DuneFetcher(
-            dune_v1=self.dune_v1,
-            dune=self.dune_v2,
-            period=AccountingPeriod("2022-11-01"),
-            dune_version=DuneVersion.V2,
-        )
+        period = AccountingPeriod("2022-11-01")
+        dune_v1 = self.dune_v1
+        dune = self.dune_v2
+        v1_fetcher = DuneFetcher(dune_v1, dune, period, dune_version=DuneVersion.V1)
+        v2_fetcher = DuneFetcher(dune_v1, dune, period, dune_version=DuneVersion.V2)
         # Takes about 2-3 minutes each. Could be parallelized!
         v1_slippage = v1_fetcher.get_period_slippage()
         v2_slippage = v2_fetcher.get_period_slippage()

--- a/tests/integration/test_query_migration.py
+++ b/tests/integration/test_query_migration.py
@@ -47,7 +47,7 @@ class TestQueryMigration(unittest.TestCase):
         )
 
     @pytest.mark.skip(
-        reason="This test takes FOREVER to run, use the Cached version above."
+        reason="This test takes FOREVER (~8m) to run, use the Cached version above."
     )
     def test_similar_slippage_for_period(self):
         period = AccountingPeriod("2022-11-01", length_days=1)

--- a/tests/unit/test_multisend.py
+++ b/tests/unit/test_multisend.py
@@ -3,7 +3,6 @@ import unittest
 from dune_client.types import Address
 from eth_typing import URI
 from gnosis.eth import EthereumClient
-from gnosis.safe.multi_send import MultiSendTx
 from web3 import Web3
 
 from src.abis.load import weth9


### PR DESCRIPTION
Translating `period_slippage.sql` from pSQL to HiveSQL.

- Working PoC Query [here](https://dune.com/queries/1570561)

### Benchmarks
- without pro account is 8 minute runtime for a single Day [**THIS IS NOT GREAT**]
- **with pro account for full  accounting period**  - 13 Minutes.- for comparison, the v1 query takes 2 minutes. 


<img width="1005" alt="Screenshot 2022-11-10 at 4 07 24 PM" src="https://user-images.githubusercontent.com/11778116/201131673-7aeada23-39d9-4cd7-afef-5df70144cfb7.png">

### Prices

We no longer have access to "median_prices" (this part of the query has been commented out). However, I have made some [calculation of our token price availability](https://dune.com/queries/1579091?d=1) and these are the results (for a one week time period):

![Screenshot 2022-11-10 at 3 37 08 PM](https://user-images.githubusercontent.com/11778116/201119926-cc72c481-c471-4dd6-b4a4-2cfd6a306340.png)


This could be improved but it is not bad at all.
- only missing prices for 6 / 398 tokens (1.5%)
- and we have 100% price availability for (398  - 12 / 398) of all tokens (97%)


 