### PR TITLE
Bump Legacy Dune

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black==22.6.0
 certifi==2022.6.15
-duneapi==6.1.2
+duneapi==7.0.0
 dune-client==0.1.1
 mypy==0.982
 psycopg2-binary==2.9.3


### PR DESCRIPTION
Emergency version bump because of: https://github.com/bh2smith/duneapi/pull/72

This is a perfect example of why we need to have a develop branch.

Solver Payouts and order book sync will not run without this fix.

- I published a beta version of this branch so that order-book sync would continue to run.
- leaving this open so we can evaluate how to proceed with deployments.