### PR TITLE
Unwrap WETH when needed

### DIFF
--- a/src/abis/erc20.json
+++ b/src/abis/erc20.json
@@ -1,0 +1,40 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/abis/load.py
+++ b/src/abis/load.py
@@ -1,0 +1,61 @@
+"""Basic Contract ABI loader (from json files)"""
+import json
+import os
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+from eth_typing import ChecksumAddress
+from typing_extensions import Type
+from web3 import Web3
+from web3.contract import Contract
+
+from src.constants import PROJECT_ROOT
+
+ABI_PATH = PROJECT_ROOT / Path("src/abis")
+
+WETH9_ADDRESS = Web3().toChecksumAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+
+
+class IndexedContract(Enum):
+    """Contracts with abis contained in project"""
+
+    ERC20 = "erc20"
+    WETH9 = "weth9"
+
+    def filename(self) -> str:
+        return str(self.value)
+
+
+def load_contract_abi(abi_name: str) -> Any:
+    """Loads a contract abi from json file"""
+    with open(
+        os.path.join(ABI_PATH, f"{abi_name}.json"), "r", encoding="utf-8"
+    ) as file:
+        return json.load(file)
+
+
+# web3.eth.contract returns this ugly type,
+# probably for backwards compatibility with old python versions
+ContractInterface = Type[Contract] | Contract
+
+
+def get_contract(
+    address: Optional[ChecksumAddress], c_type: IndexedContract
+) -> ContractInterface:
+    abi = load_contract_abi(c_type.filename())
+    if address:
+        return Web3().eth.contract(address, abi=abi)
+    return Web3().eth.contract(abi=abi)
+
+
+# The following methods are merely convenience methods so that users
+# don't have to import a bunch of stuff to get the contract then want
+
+
+def weth9() -> ContractInterface:
+    return get_contract(WETH9_ADDRESS, IndexedContract.WETH9)
+
+
+def erc20(address: Optional[ChecksumAddress] = None) -> ContractInterface:
+    return get_contract(address, IndexedContract.ERC20)

--- a/src/abis/load.py
+++ b/src/abis/load.py
@@ -5,16 +5,22 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
 
-from eth_typing import ChecksumAddress
+from eth_typing.evm import ChecksumAddress
 from typing_extensions import Type
 from web3 import Web3
 from web3.contract import Contract
 
 from src.constants import PROJECT_ROOT
+from src.logger import set_log
 
 ABI_PATH = PROJECT_ROOT / Path("src/abis")
 
 WETH9_ADDRESS = Web3().toChecksumAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+# web3.eth.contract returns this ugly type,
+# probably for backwards compatibility with old python versions
+ContractInterface = Type[Contract] | Contract
+
+log = set_log(__name__)
 
 
 class IndexedContract(Enum):
@@ -24,38 +30,48 @@ class IndexedContract(Enum):
     WETH9 = "weth9"
 
     def filename(self) -> str:
-        return str(self.value)
+        """The abi filename"""
+        return f"{self.value}.json"
 
+    def filepath(self) -> str:
+        """Absolute path to abi file"""
+        return os.path.join(ABI_PATH, self.filename())
 
-def load_contract_abi(abi_name: str) -> Any:
-    """Loads a contract abi from json file"""
-    with open(
-        os.path.join(ABI_PATH, f"{abi_name}.json"), "r", encoding="utf-8"
-    ) as file:
-        return json.load(file)
+    def load_contract_abi(self) -> Any:
+        """Loads a contract abi from json file"""
+        with open(self.filepath(), "r", encoding="utf-8") as file:
+            return json.load(file)
 
-
-# web3.eth.contract returns this ugly type,
-# probably for backwards compatibility with old python versions
-ContractInterface = Type[Contract] | Contract
-
-
-def get_contract(
-    address: Optional[ChecksumAddress], c_type: IndexedContract
-) -> ContractInterface:
-    abi = load_contract_abi(c_type.filename())
-    if address:
-        return Web3().eth.contract(address, abi=abi)
-    return Web3().eth.contract(abi=abi)
+    def get_contract(
+        self, web3: Optional[Web3], address: Optional[ChecksumAddress]
+    ) -> ContractInterface:
+        """Loads ContractInterface instance from abi and optional"""
+        abi = self.load_contract_abi()
+        if not web3:
+            # Use dummy web3
+            log.warning(
+                "Using a fallback (dummy) web3 instance with no actual connection!"
+            )
+            web3 = Web3()
+        if address:
+            return web3.eth.contract(address, abi=abi)
+        return web3.eth.contract(abi=abi)
 
 
 # The following methods are merely convenience methods so that users
 # don't have to import a bunch of stuff to get the contract then want
 
 
-def weth9() -> ContractInterface:
-    return get_contract(WETH9_ADDRESS, IndexedContract.WETH9)
+def weth9(web3: Optional[Web3] = None) -> ContractInterface:
+    """Returns an instance of WETH9 Contract"""
+    return IndexedContract.WETH9.get_contract(web3, WETH9_ADDRESS)
 
 
-def erc20(address: Optional[ChecksumAddress] = None) -> ContractInterface:
-    return get_contract(address, IndexedContract.ERC20)
+def erc20(
+    web3: Optional[Web3] = None, address: Optional[ChecksumAddress] = None
+) -> ContractInterface:
+    """
+    Returns an instance of the ERC20 Contract when address provided
+    Generic ERC20Interface otherwise.
+    """
+    return IndexedContract.ERC20.get_contract(web3, address)

--- a/src/abis/weth9.json
+++ b/src/abis/weth9.json
@@ -1,0 +1,279 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "guy",
+        "type": "address"
+      },
+      {
+        "name": "wad",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "src",
+        "type": "address"
+      },
+      {
+        "name": "dst",
+        "type": "address"
+      },
+      {
+        "name": "wad",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "wad",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "dst",
+        "type": "address"
+      },
+      {
+        "name": "wad",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "deposit",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "address"
+      },
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "src",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "guy",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "wad",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "src",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "dst",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "wad",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "dst",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "wad",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "src",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "wad",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdrawal",
+    "type": "event"
+  }
+]

--- a/src/constants.py
+++ b/src/constants.py
@@ -45,4 +45,4 @@ AIRDROP_URL = (
 SAFE_URL = f"https://gnosis-safe.io/app/{SHORT_NAME}:{SAFE_ADDRESS}/transactions/queue"
 
 # Real Web3 Instance
-w3 = Web3(Web3.HTTPProvider(NODE_URL))
+web3 = Web3(Web3.HTTPProvider(NODE_URL))

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,5 +1,4 @@
 """Project Global Constants. """
-import json
 import os
 from pathlib import Path
 
@@ -45,36 +44,5 @@ AIRDROP_URL = (
 )
 SAFE_URL = f"https://gnosis-safe.io/app/{SHORT_NAME}:{SAFE_ADDRESS}/transactions/queue"
 
-# Things requiring dummy Web3 instance
-ERC20_ABI = json.loads(
-    """[
-    {
-        "inputs": [
-            {"internalType": "address", "name": "recipient", "type": "address"},
-            {"internalType": "uint256", "name": "amount", "type": "uint256"}
-        ],
-        "name": "transfer",
-        "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "decimals",
-        "outputs": [
-          {
-            "name": "",
-            "type": "uint8"
-          }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-  }
-]
-"""
-)
-ERC20_TOKEN = Web3().eth.contract(abi=ERC20_ABI)
 # Real Web3 Instance
 w3 = Web3(Web3.HTTPProvider(NODE_URL))

--- a/src/models/token.py
+++ b/src/models/token.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from dune_client.types import Address
 
-from src.constants import COW_TOKEN_ADDRESS, w3
+from src.constants import COW_TOKEN_ADDRESS, web3
 from src.utils.token_details import get_token_decimals
 
 
@@ -52,7 +52,7 @@ class Token:
             decimals = 18
 
         self.decimals = (
-            decimals if decimals is not None else get_token_decimals(w3, address)
+            decimals if decimals is not None else get_token_decimals(web3, address)
         )
 
     def __eq__(self, other: object) -> bool:

--- a/src/models/transfer.py
+++ b/src/models/transfer.py
@@ -11,9 +11,7 @@ from dune_client.types import Address
 from eth_typing.encoding import HexStr
 from gnosis.safe.multi_send import MultiSendOperation, MultiSendTx
 
-from src.constants import (
-    ERC20_TOKEN,
-)
+from src.abis.load import erc20
 from src.models.slippage import SolverSlippage
 from src.models.token import TokenType, Token
 from src.utils.print_store import Category, PrintStore
@@ -171,7 +169,7 @@ class Transfer:
                 operation=MultiSendOperation.CALL,
                 to=str(self.token.address),
                 value=0,
-                data=ERC20_TOKEN.encodeABI(
+                data=erc20().encodeABI(
                     fn_name="transfer", args=[self.receiver.address, self.amount_wei]
                 ),
             )

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -79,12 +79,11 @@ def prepend_unwrap_if_necessary(
 def post_multisend(
     safe_address: ChecksumAddress,
     network: EthereumNetwork,
-    transfers: list[MultiSendTx],
+    transactions: list[MultiSendTx],
     client: EthereumClient,
     signing_key: str,
 ) -> int:
     """Posts a MultiSend Transaction from a list of Transfers."""
-    transactions = prepend_unwrap_if_necessary(client, safe_address, transfers)
 
     encoded_multisend = build_encoded_multisend(transactions, client=client)
     safe = Safe(address=safe_address, ethereum_client=client)

--- a/src/utils/token_details.py
+++ b/src/utils/token_details.py
@@ -7,7 +7,8 @@ import logging.config
 from dune_client.types import Address
 from web3 import Web3
 
-from src.constants import ERC20_ABI, LOG_CONFIG_FILE
+from src.abis.load import erc20
+from src.constants import LOG_CONFIG_FILE
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ def get_token_decimals(web3: Web3, address: str | Address) -> int:
         checksum_address = web3.toChecksumAddress(address.address)
     else:
         checksum_address = web3.toChecksumAddress(address)
-    token_info = web3.eth.contract(address=checksum_address, abi=ERC20_ABI)
+    token = erc20(checksum_address)
     # This "trick" is because of the unknown type returned from the contract call.
-    token_decimals: int = token_info.functions.decimals().call()
+    token_decimals: int = token.functions.decimals().call()
     return token_decimals

--- a/src/utils/token_details.py
+++ b/src/utils/token_details.py
@@ -26,7 +26,7 @@ def get_token_decimals(web3: Web3, address: str | Address) -> int:
         checksum_address = web3.toChecksumAddress(address.address)
     else:
         checksum_address = web3.toChecksumAddress(address)
-    token = erc20(checksum_address)
+    token = erc20(web3, checksum_address)
     # This "trick" is because of the unknown type returned from the contract call.
     token_decimals: int = token.functions.decimals().call()
     return token_decimals

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -5,7 +5,8 @@ from dune_client.types import Address
 from eth_typing import HexStr
 from gnosis.safe.multi_send import MultiSendTx, MultiSendOperation
 
-from src.constants import COW_TOKEN_ADDRESS, ERC20_TOKEN
+from src.abis.load import erc20
+from src.constants import COW_TOKEN_ADDRESS
 from src.models.slippage import SolverSlippage
 from src.fetch.transfer_file import Transfer
 from src.models.accounting_period import AccountingPeriod
@@ -340,9 +341,7 @@ class TestTransfer(unittest.TestCase):
                 operation=MultiSendOperation.CALL,
                 to=COW_TOKEN_ADDRESS.address,
                 value=0,
-                data=ERC20_TOKEN.encodeABI(
-                    fn_name="transfer", args=[receiver.address, 15]
-                ),
+                data=erc20().encodeABI(fn_name="transfer", args=[receiver.address, 15]),
             ),
         )
 


### PR DESCRIPTION
Closes #137 

The program now checks fore sufficient eth balance to propose payout transaction and unwraps WETH balance if the ETH balance is insufficient. Raises a value error (by default) if (WETH + ETH) balance is still insufficient.

We also moved our contract vendoring into a module of its own "abi".


# Test Plan

New tests for the new method "prepend_weth_unwrap_if_necessary".