### PR TITLE
[OrderbookDB] Different Reward Tables per Environment

### DIFF
--- a/queries/orderbook/order_rewards.sql
+++ b/queries/orderbook/order_rewards.sql
@@ -31,6 +31,6 @@ select concat('0x', encode(trade_hashes.order_uid, 'hex')) as order_uid,
            when reward is null and fee_amount = 0 then False
            end                              as safe_liquidity
 from trade_hashes
-         left outer join order_rewards
-                         on trade_hashes.order_uid = order_rewards.order_uid
-                             and trade_hashes.auction_id = order_rewards.auction_id;
+         left outer join {{reward_table}} o
+                         on trade_hashes.order_uid = o.order_uid
+                             and trade_hashes.auction_id = o.auction_id;


### PR DESCRIPTION
The backend is changing the DB schema here https://github.com/cowprotocol/services/pull/828#discussion_r1029059800

and for the next week - the order rewards table will have two different names across environments. After deployment of this feature to production, we can revert/adapt this change to use only the new table name.

The most challenging part of this change will only be coordination of deployments.

cc @vkgnosis 


## Test Plan

Existing CI. Note that our tests wont pass until the Barn DB schema has been updated.