### PR TITLE
Migrate Reward Targets (aka Vouch Registry)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git/
 .github/
 .mypy_cache/
 .pytest_cache/

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ test-db:
 	python -m pytest tests/db
 	python -m pytest tests/queries
 
+test-integration:
+	python -m pytest tests/integration
+
 test-all:
 	make test-unit
 	make test-e2e

--- a/queries/dune_v1/vouch_registry.sql
+++ b/queries/dune_v1/vouch_registry.sql
@@ -3,9 +3,13 @@ with
 -- Contract events queried here are from the VouchRegister verified at
 -- https://etherscan.io/address/0xb422f2520b0b7fd86f7da61b32cc631a59ed7e8f#code
 bonding_pools (pool, name, initial_funder) as (
-  select * from (
+  select
+    replace(pool, '0x', '\x')::bytea,
+    name,
+    replace(funder, '0x', '\x')::bytea
+  from (
     values {{BondingPoolData}}
-  ) as _
+  ) as _ (pool, name, funder)
 ),
 
 last_block_before_timestamp as (

--- a/queries/dune_v1/vouch_registry.sql
+++ b/queries/dune_v1/vouch_registry.sql
@@ -85,4 +85,19 @@ valid_vouches as (
     pool
   from current_active_vouches
   where time_rank = 1
+),
+complete_results as (
+    select
+     concat('0x', encode(solver, 'hex')) as solver,
+     concat(environment, '-', s.name) as solver_name,
+     concat('0x', encode(reward_target, 'hex')) as reward_target,
+     concat('0x', encode(vv.pool, 'hex')) as bonding_pool,
+     bp.name as pool_name
+    from valid_vouches vv
+    join gnosis_protocol_v2."view_solvers" s
+        on address = solver
+    join bonding_pools bp
+        on vv.pool = bp.pool
 )
+
+select * from {{VOUCH_CTE_NAME}}

--- a/queries/dune_v2/vouch_registry.sql
+++ b/queries/dune_v2/vouch_registry.sql
@@ -79,16 +79,20 @@ valid_vouches as (
     pool
   from current_active_vouches
   where time_rank = 1
+),
+complete_results as (
+    select
+        solver,
+        concat(environment, '-', s.name) as solver_name,
+        reward_target,
+        vv.pool as bonding_pool,
+        bp.name as pool_name
+    from valid_vouches vv
+    join cow_protocol_ethereum.solvers s
+        on address = solver
+    join bonding_pools bp
+        on vv.pool = bp.pool
 )
 
-select
- solver,
- concat(environment, '-', s.name) as solver_name,
- reward_target,
- vv.pool as bonding_pool,
- bp.name as pool_name
-from valid_vouches vv
-join cow_protocol_ethereum.solvers s
-    on address = solver
-join bonding_pools bp
-    on vv.pool = bp.pool
+select * from {{VOUCH_CTE_NAME}}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black==22.6.0
 certifi==2022.6.15
 duneapi==7.0.0
-dune-client==0.1.1
+dune-client==0.2.2
 mypy==0.982
 psycopg2-binary==2.9.3
 pylint==2.14.4

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -4,7 +4,6 @@ from dune_client.client import DuneClient
 from dune_client.query import Query
 from dune_client.types import QueryParameter, Address
 from duneapi.api import DuneAPI
-from duneapi.types import DuneQuery, QueryParameter as LegacyParameter, Network
 
 from src.fetch.cow_rewards import aggregate_orderbook_rewards
 from src.fetch.token_list import get_trusted_tokens
@@ -19,7 +18,6 @@ from src.pg_client import DualEnvDataframe
 from src.queries import QUERIES, DuneVersion, QueryData
 from src.utils.dataset import index_by
 from src.utils.print_store import PrintStore
-from src.utils.query_file import open_query
 
 log = set_log(__name__)
 

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -60,6 +60,7 @@ class DuneFetcher:
 
     def _get_query_results(self, query: Query) -> list[dict[str, str]]:
         """Internally every dune query execution is routed through here."""
+        log.info(f"Fetching {query.name} from query: {query}")
         exec_result = self.dune.refresh(query, ping_frequency=10)
         # TODO - use a real logger:
         #  https://github.com/cowprotocol/dune-client/issues/34
@@ -71,11 +72,11 @@ class DuneFetcher:
 
     def get_block_interval(self) -> tuple[str, str]:
         """Returns block numbers corresponding to date interval"""
-        query = self._parameterized_query(
-            QUERIES["PERIOD_BLOCK_INTERVAL"], self._period_params()
+        results = self._get_query_results(
+            self._parameterized_query(
+                QUERIES["PERIOD_BLOCK_INTERVAL"], self._period_params()
+            )
         )
-        query.name = f"Block Interval for Accounting Period {self}"
-        results = self._get_query_results(query)
         assert len(results) == 1, "Block Interval Query should return only 1 result!"
         return str(results[0]["start_block"]), str(results[0]["end_block"])
 
@@ -136,23 +137,18 @@ class DuneFetcher:
         """
         Fetches & Returns Parsed Results for VouchRegistry query.
         """
-
-        pool_values = ",\n           ".join(RECOGNIZED_BONDING_POOLS)
-        query = DuneQuery.from_environment(
-            raw_sql="\n".join(
-                [
-                    open_query("dune_v1/vouch_registry.sql"),
-                    "select * from valid_vouches",
-                ]
-            ),
-            network=Network.MAINNET,
-            name="Solver Reward Targets",
-            parameters=[
-                LegacyParameter.date_type("EndTime", self.period.end),
-                LegacyParameter.text_type("BondingPoolData", pool_values),
-            ],
+        pool_values = ",\n".join(RECOGNIZED_BONDING_POOLS)
+        data_set = self._get_query_results(
+            query=self._parameterized_query(
+                query_data=QUERIES["VOUCH_REGISTRY"],
+                params=[
+                    QueryParameter.date_type("EndTime", self.period.end),
+                    QueryParameter.text_type("BondingPoolData", pool_values),
+                    QueryParameter.enum_type("VOUCH_CTE_NAME", "valid_vouches"),
+                ],
+            )
         )
-        return parse_vouches(self.dune_v1.fetch(query))
+        return parse_vouches(data_set)
 
     def get_period_totals(self) -> PeriodTotals:
         """

--- a/src/models/vouch.py
+++ b/src/models/vouch.py
@@ -8,10 +8,8 @@ from dune_client.types import Address
 from src.utils.dataset import index_by
 
 RECOGNIZED_BONDING_POOLS = [
-    "('\\x8353713b6D2F728Ed763a04B886B16aAD2b16eBD'::bytea, 'Gnosis', "
-    "'\\x6c642cafcbd9d8383250bb25f67ae409147f78b2'::bytea)",
-    "('\\x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6'::bytea, 'CoW Services', "
-    "'\\x423cec87f19f0778f549846e0801ee267a917935'::bytea)",
+    "('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD', 'Gnosis', '0x6c642cafcbd9d8383250bb25f67ae409147f78b2')",
+    "('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6', 'CoW Services', '0x423cec87f19f0778f549846e0801ee267a917935')",
 ]
 
 

--- a/src/models/vouch.py
+++ b/src/models/vouch.py
@@ -8,8 +8,10 @@ from dune_client.types import Address
 from src.utils.dataset import index_by
 
 RECOGNIZED_BONDING_POOLS = [
-    "('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD', 'Gnosis', '0x6c642cafcbd9d8383250bb25f67ae409147f78b2')",
-    "('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6', 'CoW Services', '0x423cec87f19f0778f549846e0801ee267a917935')",
+    "('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD', 'Gnosis', "
+    "'0x6c642cafcbd9d8383250bb25f67ae409147f78b2')",
+    "('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6', 'CoW Services', "
+    "'0x423cec87f19f0778f549846e0801ee267a917935')",
 ]
 
 

--- a/tests/integration/test_query_migration.py
+++ b/tests/integration/test_query_migration.py
@@ -13,16 +13,20 @@ from src.queries import DuneVersion
 
 class TestQueryMigration(unittest.TestCase):
     def setUp(self) -> None:
-        self.dune_v1 = DuneAPI("", "")
-        self.dune_v2 = DuneClient(os.environ["DUNE_API_KEY"])
+        dune_v1 = DuneAPI("", "")
+        self.dune = DuneClient(os.environ["DUNE_API_KEY"])
+        period = AccountingPeriod("2022-11-01", length_days=7)
+        self.v1_fetcher = DuneFetcher(
+            dune_v1, dune=self.dune, period=period, dune_version=DuneVersion.V1
+        )
+        self.v2_fetcher = DuneFetcher(
+            dune_v1, dune=self.dune, period=period, dune_version=DuneVersion.V2
+        )
 
     def test_similar_slippage_cached_results_one_day(self):
-        period = AccountingPeriod("2022-11-01", length_days=1)
-        dune_v1 = self.dune_v1
-        dune = self.dune_v2
         # These results expire at 2024-11-22
-        v1_result = dune.get_result("01GJJBP5E0CE4XM8FJ7KBVB8KW")
-        v2_result = dune.get_result("01GJJBNWMZNTTB6VQCFZMK7JCN")
+        v1_result = self.dune.get_result("01GJJBP5E0CE4XM8FJ7KBVB8KW")
+        v2_result = self.dune.get_result("01GJJBNWMZNTTB6VQCFZMK7JCN")
         print(v1_result)
         print(v2_result)
 
@@ -50,15 +54,9 @@ class TestQueryMigration(unittest.TestCase):
         reason="This test takes FOREVER (~8m) to run, use the Cached version above."
     )
     def test_similar_slippage_for_period(self):
-        period = AccountingPeriod("2022-11-01", length_days=1)
-        dune_v1 = self.dune_v1
-        dune = self.dune_v2
-
-        v1_fetcher = DuneFetcher(dune_v1, dune, period, dune_version=DuneVersion.V1)
-        v2_fetcher = DuneFetcher(dune_v1, dune, period, dune_version=DuneVersion.V2)
         # Takes about 2-3 minutes each. Could be parallelized!
-        v1_slippage = v1_fetcher.get_period_slippage()
-        v2_slippage = v2_fetcher.get_period_slippage()
+        v1_slippage = self.v1_fetcher.get_period_slippage()
+        v2_slippage = self.v2_fetcher.get_period_slippage()
         # Cached Results available at
         # V1: 01GJJD92TNQE0476SSWP2EMC34
         # V2: 01GJJDAZFKMNP7KKZWFWQKY05S
@@ -74,6 +72,12 @@ class TestQueryMigration(unittest.TestCase):
             v2_slippage.sum_positive() / 10**18,
             delta,
         )
+
+    def test_identical_vouch_registry(self):
+        v1_vouches = self.v1_fetcher.get_vouches()
+        v2_vouches = self.v2_fetcher.get_vouches()
+
+        self.assertEqual(v1_vouches, v2_vouches)
 
 
 if __name__ == "__main__":

--- a/tests/queries/test_vouch_registry.py
+++ b/tests/queries/test_vouch_registry.py
@@ -15,17 +15,14 @@ from tests.db.pg_client import (
 
 
 def pool_from(num: int) -> str:
-    return f"0xb{num}"
+    return f"\\xb{num}"
 
 
 def sender_from(num: int) -> str:
-    return f"0xf{num}"
+    return f"\\xf{num}"
 
 
-TEST_BONDING_POOLS = [
-    f"('{pool_from(i)}'::bytea, 'Pool {i}', '{sender_from(i)}'::bytea)"
-    for i in range(5)
-]
+TEST_BONDING_POOLS = [f"('0xb{i}', 'Pool {i}', '0xf{i}')" for i in range(5)]
 
 
 @dataclass
@@ -95,7 +92,7 @@ def query_for(date_str: str, bonding_pools: list[str]) -> DuneQuery:
         parameters=[
             QueryParameter.date_type("EndTime", date_str),
             QueryParameter.text_type("BondingPoolData", ",".join(bonding_pools)),
-            QueryParameter.text_type("VOUCH_CTE_NAME", "valid_vouches")
+            QueryParameter.text_type("VOUCH_CTE_NAME", "valid_vouches"),
         ],
         query_id=-1,
         description="",

--- a/tests/queries/test_vouch_registry.py
+++ b/tests/queries/test_vouch_registry.py
@@ -15,11 +15,11 @@ from tests.db.pg_client import (
 
 
 def pool_from(num: int) -> str:
-    return f"\\xb{num}"
+    return f"0xb{num}"
 
 
 def sender_from(num: int) -> str:
-    return f"\\xf{num}"
+    return f"0xf{num}"
 
 
 TEST_BONDING_POOLS = [
@@ -89,17 +89,13 @@ def invalidate_vouch(
 
 def query_for(date_str: str, bonding_pools: list[str]) -> DuneQuery:
     return DuneQuery(
-        raw_sql="\n".join(
-            [
-                open_query(query_file("dune_v1/vouch_registry.sql")),
-                "select * from valid_vouches",
-            ]
-        ),
+        raw_sql=open_query(query_file("dune_v1/vouch_registry.sql")),
         network=Network.MAINNET,
         name="Solver Reward Targets",
         parameters=[
             QueryParameter.date_type("EndTime", date_str),
             QueryParameter.text_type("BondingPoolData", ",".join(bonding_pools)),
+            QueryParameter.text_type("VOUCH_CTE_NAME", "valid_vouches")
         ],
         query_id=-1,
         description="",


### PR DESCRIPTION
This was actually the last query to be executed using the legacy-api (however we have not fully removed our dependency on it because of the Dashboard manager). In a follow up PR (immediately after this) I will remove legacy dune client from the DuneFetcher Object. Afterward, we proceed with testing all the v1<>v2 query results.

Uses dune-client for vouch registry, updates corresponding db-tests (after slight modification of the v1 query perameters). Adds a test that both v1 and v2 queries produce identical results.


## Test Plan

```
make test-integration
```
For the new test and also:

Run the full script

```
Total Slippage deducted (ETH): -1.9123212809881986
dumping 24 results to transfers-2022-11-01-to-2022-11-08.csv
Total ETH Funds needed: 23.732583063879495
Total COW Funds needed: 226696.72088893972
```
[transfers-2022-11-01-to-2022-11-08.csv](https://github.com/cowprotocol/solver-rewards/files/10076937/transfers-2022-11-01-to-2022-11-08.csv)


No regressions [from slack post](https://cowservices.slack.com/archives/C037UV49JLR/p1667898794392419?thread_ts=1667898793.641109&cid=C037UV49JLR)