### PR TITLE
*Properly Testing Slippage Query

### DIFF
--- a/queries/dune_v1/period_slippage.sql
+++ b/queries/dune_v1/period_slippage.sql
@@ -468,3 +468,4 @@ results as (
         solver_address,
         solver_name
 )
+select * from {{CTE_NAME}}

--- a/queries/dune_v1/period_slippage.sql
+++ b/queries/dune_v1/period_slippage.sql
@@ -453,7 +453,8 @@ results_per_tx as (
         tx_hash
     having
         bool_and(price is not null)
-)
+),
+results as (
     select
         solver_address,
         solver_name,

--- a/queries/dune_v1/period_slippage.sql
+++ b/queries/dune_v1/period_slippage.sql
@@ -107,7 +107,7 @@ batch_transfers as (
 ),
 -- These batches involve a token AXS (Old)
 -- whose transfer function doesn't align with the emitted transfer event.
-exluded_batches as (
+excluded_batches as (
     select tx_hash
     from filtered_trades
     where '\xf5d669627376ebd411e34b98f19c868c8aba5ada'
@@ -139,7 +139,7 @@ incoming_and_outgoing as (
            transfer_type
     from batch_transfers i
              left outer join erc20.tokens t on i.token = t.contract_address
-    where tx_hash not in (select tx_hash from exluded_batches)
+    where tx_hash not in (select tx_hash from excluded_batches)
        -- We exclude settlements that have zero AMM interactions and settle several trades,
        -- as our query is not good enough to handle these cases accurately.
        -- Settlements with dex_swaps = 0 and num_trades = 0 can be handled in the following

--- a/queries/dune_v1/period_slippage.sql
+++ b/queries/dune_v1/period_slippage.sql
@@ -139,14 +139,12 @@ incoming_and_outgoing as (
            transfer_type
     from batch_transfers i
              left outer join erc20.tokens t on i.token = t.contract_address
-    where
+    where tx_hash not in (select tx_hash from exluded_batches)
        -- We exclude settlements that have zero AMM interactions and settle several trades,
        -- as our query is not good enough to handle these cases accurately.
        -- Settlements with dex_swaps = 0 and num_trades = 0 can be handled in the following
-       -- and we want to consider them in order to filter out illegal behaviour
-        (dex_swaps = 0 and num_trades < 2) or dex_swaps > 0
-
-        and tx_hash not in (select tx_hash from exluded_batches)
+      -- and we want to consider them in order to filter out illegal behaviour
+      and ((dex_swaps = 0 and num_trades < 2) or dex_swaps > 0)
 ),
 pre_clearing_prices as (
     select call_tx_hash             as tx_hash,

--- a/queries/dune_v1/period_slippage.sql
+++ b/queries/dune_v1/period_slippage.sql
@@ -453,7 +453,8 @@ results_per_tx as (
         tx_hash
     having
         bool_and(price is not null)
-)
+),
+results as (
     select
         solver_address,
         solver_name,
@@ -466,3 +467,4 @@ results_per_tx as (
     group by
         solver_address,
         solver_name
+)

--- a/queries/dune_v1/period_slippage.sql
+++ b/queries/dune_v1/period_slippage.sql
@@ -453,8 +453,7 @@ results_per_tx as (
         tx_hash
     having
         bool_and(price is not null)
-),
-results as (
+)
     select
         solver_address,
         solver_name,
@@ -467,5 +466,3 @@ results as (
     group by
         solver_address,
         solver_name
-)
-select * from {{CTE_NAME}}

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -102,7 +102,7 @@ batch_transfers as (
 ),
 -- These batches involve a token AXS (Old)
 -- whose transfer function doesn't align with the emitted transfer event.
-exluded_batches as (
+excluded_batches as (
     select tx_hash from filtered_trades
     where '0xf5d669627376ebd411e34b98f19c868c8aba5ada' in (buy_token, sell_token)
 ),
@@ -133,7 +133,7 @@ incoming_and_outgoing as (
         left outer join tokens.erc20 t
             on i.token = t.contract_address
             and blockchain = 'ethereum'
-    where tx_hash not in (select tx_hash from exluded_batches)
+    where tx_hash not in (select tx_hash from excluded_batches)
       -- We exclude settlements that have zero AMM interactions and settle several trades,
       -- as our query is not good enough to handle these cases accurately.
       -- Settlements with dex_swaps = 0 and num_trades = 0 can be handled in the following

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,11 +1,9 @@
--- noinspection SqlNoDataSourceInspectionForFile
-
 with
 filtered_trades as (
     select t.block_time,
            t.tx_hash,
            case
-            when dex_swaps is null
+            when dex_swaps = 0
             -- Estimation made here: https://dune.com/queries/1646084
                 then ((gas_used - 73688 - (70528 * num_trades)) / 90000)::int
                 else dex_swaps
@@ -27,7 +25,6 @@ filtered_trades as (
     and (solver_address = lower('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
     and (t.tx_hash = lower('{{TxHash}}') or '{{TxHash}}' = '0x')
 ),
-
 batchwise_traders as (
     select
         tx_hash,
@@ -67,7 +64,7 @@ other_transfers as (
     select block_time,
           b.tx_hash,
           case
-            when dex_swaps is null
+            when dex_swaps = 0
             -- Estimation made here: https://dune.com/queries/1646084
                 then ((gas_used - 73688 - (70528 * num_trades)) / 90000)::int
                 else dex_swaps
@@ -136,13 +133,12 @@ incoming_and_outgoing as (
         left outer join tokens.erc20 t
             on i.token = t.contract_address
             and blockchain = 'ethereum'
-    where
+    where tx_hash not in (select tx_hash from exluded_batches)
       -- We exclude settlements that have zero AMM interactions and settle several trades,
       -- as our query is not good enough to handle these cases accurately.
       -- Settlements with dex_swaps = 0 and num_trades = 0 can be handled in the following
       -- and we want to consider them in order to filter out illegal behaviour
-        (dex_swaps = 0 and num_trades < 2) or dex_swaps > 0
-        and tx_hash not in (select tx_hash from exluded_batches)
+      and ((dex_swaps = 0 and num_trades < 2) or dex_swaps > 0)
 ),
 -- Benchmark takes 3 minuites to get here for ONE DAY interval!
 
@@ -447,7 +443,7 @@ results_per_tx as (
         solver_address,
         sum(token_imbalance_wei * price / pow(10, p.decimals)) as usd_value,
         sum(token_imbalance_wei * price / pow(10, p.decimals) / eth_price) * pow(10, 18) as eth_slippage_wei,
-        tx_hash
+        count(*) as num_entries
     from
         final_token_balance_sheet ftbs
     left join prices p
@@ -462,8 +458,6 @@ results_per_tx as (
     having
         bool_and(price is not null)
 ),
--- Benchmark: 10 minutes for ONE DAY with non-pro account.
--- select * from results_per_tx limit 10
 results as (
     select
         solver_address,
@@ -480,23 +474,4 @@ results as (
         solver_address,
         solver_name
 )
-select * from results
-
--- -- select
--- --     block_time,
--- --     rpt.solver_name,
--- --     concat('<a href="https://dune.com/queries/663231?TxHash=', concat('0x', encode(rpt.tx_hash, 'hex')), '" target="_blank">link</a>') as token_breakdown,
--- --     concat('0x', encode(rpt.tx_hash, 'hex')) as tx_hash,
--- --     usd_value,
--- --     batch_value,
--- --     100 * usd_value / batch_value as relative_slippage
--- -- from results_per_tx rpt
--- -- join gnosis_protocol_v2."batches" b
--- --     on rpt.tx_hash = b.tx_hash
--- -- where (
--- --     abs(usd_value) > '{{MinAbsoluteSlippageTolerance}}'
--- --     and
--- --     100.0 * abs(usd_value) / batch_value > '{{RelativeSlippageTolerance}}'
--- -- ) or
--- --     abs(usd_value) > '{{SignificantSlippageValue}}'
--- -- order by relative_slippage
+select * from {{CTE_NAME}}

--- a/tests/integration/test_query_migration.py
+++ b/tests/integration/test_query_migration.py
@@ -1,12 +1,10 @@
 import os
 import unittest
 
-import pytest
 from dune_client.client import DuneClient
 
 from src.fetch.dune import DuneFetcher
 from src.models.accounting_period import AccountingPeriod
-from src.models.slippage import SplitSlippages
 from src.models.transfer import Transfer
 from src.queries import DuneVersion
 from src.utils.dataset import index_by
@@ -21,56 +19,6 @@ class TestQueryMigration(unittest.TestCase):
         )
         self.v2_fetcher = DuneFetcher(
             dune=self.dune, period=period, dune_version=DuneVersion.V2
-        )
-
-    def test_similar_slippage_cached_results_one_day(self):
-        # These results expire at 2024-11-22
-        v1_result = self.dune.get_result("01GJJBP5E0CE4XM8FJ7KBVB8KW")
-        v2_result = self.dune.get_result("01GJJBNWMZNTTB6VQCFZMK7JCN")
-        print(v1_result)
-        print(v2_result)
-
-        v1_slippage = SplitSlippages.from_data_set(v1_result.get_rows())
-        v2_slippage = SplitSlippages.from_data_set(v2_result.get_rows())
-
-        # v1_fetcher = DuneFetcher(dune_v1, dune, period, dune_version=DuneVersion.V1)
-        # v2_fetcher = DuneFetcher(dune_v1, dune, period, dune_version=DuneVersion.V2)
-        # # Takes about 2-3 minutes each. Could be parallelized!
-        # v1_slippage = v1_fetcher.get_period_slippage()
-        # v2_slippage = v2_fetcher.get_period_slippage()
-        delta = 2  # decimal places ETH. This is 2.20 USD with ETH at 100
-        self.assertAlmostEqual(
-            v1_slippage.sum_negative() / 10**18,
-            v2_slippage.sum_negative() / 10**18,
-            delta,
-        )
-        self.assertAlmostEqual(
-            v1_slippage.sum_positive() / 10**18,
-            v2_slippage.sum_positive() / 10**18,
-            delta,
-        )
-
-    @pytest.mark.skip(
-        reason="This test takes FOREVER (~8m) to run, use the Cached version above."
-    )
-    def test_similar_slippage_for_period(self):
-        # Takes about 2-3 minutes each. Could be parallelized!
-        v1_slippage = self.v1_fetcher.get_period_slippage()
-        v2_slippage = self.v2_fetcher.get_period_slippage()
-        # Cached Results available at
-        # V1: 01GJJD92TNQE0476SSWP2EMC34
-        # V2: 01GJJDAZFKMNP7KKZWFWQKY05S
-
-        delta = 2  # decimal places ETH. This is 2.20 USD with ETH at 100
-        self.assertAlmostEqual(
-            v1_slippage.sum_negative() / 10**18,
-            v2_slippage.sum_negative() / 10**18,
-            delta,
-        )
-        self.assertAlmostEqual(
-            v1_slippage.sum_positive() / 10**18,
-            v2_slippage.sum_positive() / 10**18,
-            delta,
         )
 
     def test_identical_vouch_registry(self):

--- a/tests/integration/test_solver_slippage.py
+++ b/tests/integration/test_solver_slippage.py
@@ -97,8 +97,6 @@ class TestQueryMigration(unittest.TestCase):
         v1_cache: Optional[str] = None,
         v2_cache: Optional[str] = None,
     ):
-        # tokens.erc20 broken because of: https://github.com/duneanalytics/spellbook/pull/2083
-        # Had to make query forks.
         v1_rows, v2_rows = self.get_cte_rows(cte_name, tx_hash, v1_cache, v2_cache)
         self.writer.write_csv(v1_rows, f"{cte_name}_{tx_hash}_v1.csv")
         self.writer.write_csv(v2_rows, f"{cte_name}_{tx_hash}_v2.csv")

--- a/tests/integration/test_solver_slippage.py
+++ b/tests/integration/test_solver_slippage.py
@@ -1,0 +1,206 @@
+import json
+import os
+import unittest
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+from dune_client.client import DuneClient
+from dune_client.query import Query
+from dune_client.file.interface import FileIO
+from dune_client.types import QueryParameter
+
+from src.constants import FILE_OUT_DIR
+from src.fetch.dune import DuneFetcher
+from src.models.accounting_period import AccountingPeriod
+from src.models.slippage import SplitSlippages
+from src.queries import QUERIES, DuneVersion
+
+
+@dataclass
+class Comparison:
+    v1: dict[str, list]
+    v2: dict[str, list]
+    v1_not_v2: set[str]
+    v2_not_v1: set[str]
+    overlap: set[str]
+
+    @classmethod
+    def from_dune_results(
+        cls, v1_result: list[dict[str, str]], v2_result: list[dict[str, str]]
+    ):
+        v1, v2 = defaultdict(list), defaultdict(list)
+        while v1_result:
+            row = v1_result.pop()
+            v1[row["tx_hash"].replace("\\x", "0x")].append(row)
+
+        while v2_result:
+            row = v2_result.pop()
+            v2[row["tx_hash"]].append(row)
+
+        return cls(
+            v1=v1,
+            v2=v2,
+            v1_not_v2=set(v1.keys()) - set(v2.keys()),
+            v2_not_v1=set(v2.keys()) - set(v1.keys()),
+            overlap=set(v2.keys()).intersection(set(v1.keys())),
+        )
+
+    def __str__(self):
+        return (
+            f"v1_not_v2={len(self.v1_not_v2)}\n"
+            f"v2_not_v1={len(self.v2_not_v1)}\n"
+            f"overlap={len(self.overlap)}"
+        )
+
+    def to_json(self, tx_hash: str):
+        return json.dumps({"V1": self.v1[tx_hash], "V2": self.v2[tx_hash]})
+
+
+class TestQueryMigration(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dune = DuneClient(os.environ["DUNE_API_KEY"])
+        self.period = AccountingPeriod("2022-11-01", length_days=7)
+        self.slippage_query = QUERIES["PERIOD_SLIPPAGE"]
+        self.parameters = self.period.as_query_params()
+        self.writer = FileIO(FILE_OUT_DIR)
+
+    def exec_or_get(self, query: Query, result_id: Optional[str] = None):
+        if not result_id:
+            return self.dune.refresh(query)
+        return self.dune.get_result(result_id)
+
+    def get_cte_rows(
+        self,
+        cte_name: str,
+        tx_hash: Optional[str] = None,
+        v1_cache: Optional[str] = None,
+        v2_cache: Optional[str] = None,
+    ):
+        parameters = self.period.as_query_params()
+        parameters.append(QueryParameter.enum_type("CTE_NAME", cte_name))
+        if tx_hash:
+            parameters.append(QueryParameter.text_type("TxHash", tx_hash))
+
+        v1_results = self.exec_or_get(Query(1570227, params=parameters), v1_cache)
+        v2_results = self.exec_or_get(Query(1570561, params=parameters), v2_cache)
+
+        v1_rows = v1_results.get_rows()
+        v2_rows = v2_results.get_rows()
+        return v1_rows, v2_rows
+
+    def get_cte_results(
+        self,
+        cte_name: str,
+        tx_hash: Optional[str] = None,
+        v1_cache: Optional[str] = None,
+        v2_cache: Optional[str] = None,
+    ):
+        # tokens.erc20 broken because of: https://github.com/duneanalytics/spellbook/pull/2083
+        # Had to make query forks.
+        v1_rows, v2_rows = self.get_cte_rows(cte_name, tx_hash, v1_cache, v2_cache)
+        self.writer.write_csv(v1_rows, f"{cte_name}_{tx_hash}_v1.csv")
+        self.writer.write_csv(v2_rows, f"{cte_name}_{tx_hash}_v2.csv")
+        return Comparison.from_dune_results(v1_rows, v2_rows)
+
+    def test_batch_transfers(self):
+        table_name = "batch_transfers"
+        data = self.get_cte_results(
+            table_name,
+            v1_cache="01GJQNSER0PYSMGHMEBDT03805",
+            v2_cache="01GJQNSER0PYSMGHMEBDT03805",
+        )
+
+        # No missing transactions.
+        self.assertEqual(data.v2_not_v1, set())
+        self.assertEqual(data.v1_not_v2, set())
+
+        for tx_hash in data.overlap:
+            x = data.v1[tx_hash]
+            y = data.v2[tx_hash]
+            self.assertEqual(
+                len(x),
+                len(y),
+                f"{table_name} failed at {tx_hash} on\n {data.to_json(tx_hash)}",
+            )
+
+    def test_excluded_batches(self):
+        data = self.get_cte_results("excluded_batches")
+        self.assertEqual(len(data.v1), len(data.v2))
+
+    def test_incoming_and_outgoing(self):
+        # This test demonstrates that records are "essentially" matching up to this table.
+        table_name = "incoming_and_outgoing"
+        data = self.get_cte_results(
+            table_name,
+            # v1_cache="01GJR1HKR37V7HRPTRJCDMZBAX",
+            # v2_cache="01GJR1HTNS87RKTV90WKH4TVSC",
+        )
+
+        # There are 14 records in missing_v2 for the specified accounting period.
+        # This appears to be due to the estimated dex_swaps (in v1 are 0, but in v2 check)
+        # https://dune.com/queries/1655081?CTE_NAME=batch_data&TxHash={TxHash}
+        missing_v2 = {k: v for k, v in data.v1.items() if k in data.v1_not_v2}
+        missing_v1 = {k: v for k, v in data.v2.items() if k in data.v2_not_v1}
+
+        self.assertEqual(
+            set(missing_v1),
+            # This was an incorrectly classified batch due to our dex_swaps estimation
+            # The V1 query estimates dex_swaps = 1 (while there were none).
+            # We could probably adapt the query to
+            {"0x595ab6fb4b6723473b0c77009aa39df4939f32510ad3a5c3f81ae69eec6fdea1"},
+        )
+        self.assertEqual(set(missing_v2), set())
+
+        for tx_hash in data.overlap:
+            x = data.v1[tx_hash]
+            y = data.v2[tx_hash]
+            prepped_items = {"V1": x, "V2": y}
+            self.assertEqual(
+                len(x),
+                len(y),
+                f"Failed {table_name} at {tx_hash} on\n {json.dumps(prepped_items)}",
+            )
+            # TODO - could also check amounts are ~ equal,
+            #  but we will do this later anyway
+
+    def test_final_token_balance_sheet(self):
+        table_name = "final_token_balance_sheet"
+        data = self.get_cte_results(
+            table_name,
+            v1_cache="01GJR2PTEXWT63HVG6WZ7PXB4R",
+            v2_cache="01GJR2Q0CWVKKRZ7J53RC463X9",
+        )
+        print(str(data))
+        # Probably need to investigate this difference a bit more.
+        # v1_not_v2 = 172
+        # v2_not_v1 = 107
+        # overlap = 3062
+
+    def test_similar_slippage_for_period(self):
+        table_name = "results"
+        v1_result, v2_result = self.get_cte_rows(
+            table_name,
+            v1_cache="01GJR7DV87RM5D5W2T25FTXA0F",
+            v2_cache="01GJR7G2JKADDZDY94BP96V1C6",
+        )
+        v1_slippage = SplitSlippages.from_data_set(v1_result)
+        v2_slippage = SplitSlippages.from_data_set(v2_result)
+
+        delta = 1  # decimal places ETH.
+        self.assertAlmostEqual(
+            v1_slippage.sum_negative() / 10**18,  # 1.9123 ETH
+            v2_slippage.sum_negative() / 10**18,  # 1.9029 ETH
+            delta,  # |v1 - v2| ~ 0.0094 --> 9.4 USD (with ETH at 1000)
+        )
+
+        self.assertAlmostEqual(
+            v1_slippage.sum_positive() / 10**18,  # 2.625 ETH
+            v2_slippage.sum_positive() / 10**18,  # 2.629 ETH
+            5,  # |v1 - v2| ~ 0.004 --> 4 USD (with ETH at 1000)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_solver_slippage.py
+++ b/tests/integration/test_solver_slippage.py
@@ -174,9 +174,9 @@ class TestQueryMigration(unittest.TestCase):
         )
         print(str(data))
         # Probably need to investigate this difference a bit more.
-        # v1_not_v2 = 172
-        # v2_not_v1 = 107
-        # overlap = 3062
+        # v1_not_v2 = 172 batches
+        # v2_not_v1 = 107 batches
+        # overlap = 3062 batches
 
     def test_similar_slippage_for_period(self):
         table_name = "results"
@@ -189,17 +189,23 @@ class TestQueryMigration(unittest.TestCase):
         v2_slippage = SplitSlippages.from_data_set(v2_result)
 
         delta = 1  # decimal places ETH.
-        self.assertAlmostEqual(
+        self.assertLess(
             v1_slippage.sum_negative() / 10**18,  # 1.9123 ETH
             v2_slippage.sum_negative() / 10**18,  # 1.9029 ETH
-            delta,  # |v1 - v2| ~ 0.0094 --> 9.4 USD (with ETH at 1000)
+            1,  # |v1 - v2| ~ 0.0094 --> 9.4 USD (with ETH at 1000)
         )
 
         self.assertAlmostEqual(
             v1_slippage.sum_positive() / 10**18,  # 2.625 ETH
             v2_slippage.sum_positive() / 10**18,  # 2.629 ETH
-            5,  # |v1 - v2| ~ 0.004 --> 4 USD (with ETH at 1000)
+            2,  # |v1 - v2| ~ 0.004 --> 4 USD (with ETH at 1000)
         )
+
+        # an even strong assertion because I consider the above a bug on negative slippage is
+        self.assertLess(abs(v1_slippage.sum_negative() - v2_slippage.sum_negative()) / 10**18, 0.01)
+        # which says difference is less than 0.01 ETH
+        # The above fails when decimals = 2 (probably because of rounding)
+        # and decimals = 1 only asserts that the difference is < 0.1 ETH
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_solver_slippage.py
+++ b/tests/integration/test_solver_slippage.py
@@ -177,6 +177,8 @@ class TestQueryMigration(unittest.TestCase):
             # v1_not_v2 = 172 batches
             # v2_not_v1 = 107 batches
             # overlap   = 3062 batches
+            # Check out the missing records for this period:
+            # http://jsonblob.com/1046134755808264192
             v1_cache="01GJR2PTEXWT63HVG6WZ7PXB4R",
             v2_cache="01GJR2Q0CWVKKRZ7J53RC463X9",
             # --------------------------------------

--- a/tests/integration/test_solver_slippage.py
+++ b/tests/integration/test_solver_slippage.py
@@ -45,6 +45,16 @@ class Comparison:
             overlap=set(v2.keys()).intersection(set(v1.keys())),
         )
 
+    def describe_missing(self):
+        print(
+            json.dumps(
+                {
+                    "V1/V2": {k: self.v1[k] for k in self.v1_not_v2},
+                    "V2/V1": {k: self.v2[k] for k in self.v2_not_v1},
+                }
+            )
+        )
+
     def __str__(self):
         return (
             f"v1_not_v2={len(self.v1_not_v2)}\n"
@@ -130,8 +140,8 @@ class TestQueryMigration(unittest.TestCase):
         table_name = "incoming_and_outgoing"
         data = self.get_cte_results(
             table_name,
-            # v1_cache="01GJR1HKR37V7HRPTRJCDMZBAX",
-            # v2_cache="01GJR1HTNS87RKTV90WKH4TVSC",
+            v1_cache="01GJR1HKR37V7HRPTRJCDMZBAX",
+            v2_cache="01GJR1HTNS87RKTV90WKH4TVSC",
         )
 
         # There are 14 records in missing_v2 for the specified accounting period.
@@ -167,8 +177,8 @@ class TestQueryMigration(unittest.TestCase):
             # v1_not_v2 = 172 batches
             # v2_not_v1 = 107 batches
             # overlap   = 3062 batches
-            # v1_cache="01GJR2PTEXWT63HVG6WZ7PXB4R",
-            # v2_cache="01GJR2Q0CWVKKRZ7J53RC463X9",
+            v1_cache="01GJR2PTEXWT63HVG6WZ7PXB4R",
+            v2_cache="01GJR2Q0CWVKKRZ7J53RC463X9",
             # --------------------------------------
             # Results for Period(2022-11-08)
             # v1_not_v2 = 160 batches
@@ -196,8 +206,9 @@ class TestQueryMigration(unittest.TestCase):
         # (v1   (-------overlap-------)   v2)
         # |--A--|----------D----------|--B--|
         # assert (A + B) / D < 10%
-        print(data)
         self.assertLess(num_outliers / size_overlap, 0.1)
+        print(data)
+        data.describe_missing()
 
     def test_similar_slippage_for_period(self):
         table_name = "results"
@@ -207,8 +218,8 @@ class TestQueryMigration(unittest.TestCase):
             # Results for Period(2022-11-01)
             # Negative: 0.0094 difference --> 9.4 USD
             # Positive: 0.004  difference --> 4 USD
-            # v1_cache="01GJR7DV87RM5D5W2T25FTXA0F",
-            # v2_cache="01GJR7G2JKADDZDY94BP96V1C6",
+            v1_cache="01GJR7DV87RM5D5W2T25FTXA0F",
+            v2_cache="01GJR7G2JKADDZDY94BP96V1C6",
             # ---------------------------------------
             # Results for Period(2022-11-08)
             # Negative: 0.0376 difference --> 37.6 USD

--- a/tests/integration/test_solver_slippage.py
+++ b/tests/integration/test_solver_slippage.py
@@ -123,10 +123,6 @@ class TestQueryMigration(unittest.TestCase):
                 f"{table_name} failed at {tx_hash} on\n {data.to_json(tx_hash)}",
             )
 
-    def test_excluded_batches(self):
-        data = self.get_cte_results("excluded_batches")
-        self.assertEqual(len(data.v1), len(data.v2))
-
     def test_incoming_and_outgoing(self):
         # This test demonstrates that records are "essentially" matching up to this table.
         table_name = "incoming_and_outgoing"
@@ -160,8 +156,6 @@ class TestQueryMigration(unittest.TestCase):
                 len(y),
                 f"Failed {table_name} at {tx_hash} on\n {json.dumps(prepped_items)}",
             )
-            # TODO - could also check amounts are ~ equal,
-            #  but we will do this later anyway
 
     def test_final_token_balance_sheet(self):
         table_name = "final_token_balance_sheet"

--- a/tests/integration/test_solver_slippage.py
+++ b/tests/integration/test_solver_slippage.py
@@ -202,7 +202,10 @@ class TestQueryMigration(unittest.TestCase):
         )
 
         # an even strong assertion because I consider the above a bug on negative slippage is
-        self.assertLess(abs(v1_slippage.sum_negative() - v2_slippage.sum_negative()) / 10**18, 0.01)
+        self.assertLess(
+            abs(v1_slippage.sum_negative() - v2_slippage.sum_negative()) / 10**18,
+            0.01,
+        )
         # which says difference is less than 0.01 ETH
         # The above fails when decimals = 2 (probably because of rounding)
         # and decimals = 1 only asserts that the difference is < 0.1 ETH


### PR DESCRIPTION
Our previous test was not good enough and several issues were found (related to the minor changes made here). we are still not entirely accurate on the `dex_swaps` field (a crucial value for this calculation) because v2's dex.trades table is not fully populated with all the supported liquidity sources available. Furthermore, there was a logical constraint in one query that was not syntactically representative of its actual meaning -- comments inline.

We now test the slippage query at several "checkpoints" to ensure records are matching. Unfortunately, it is clear that our record filtration cannot be 100% accurate at this stage due to the lack of dex.trades precision. However, we do make up for it later, because the price feed in V2 is more complete.

## Follow up

Migrate Integration tests to Hive!

### Test Plan
```
make test-integration
```

This will run all the new tests introduced here. In particular, we "checkpoint" this query at
- batch_transfers: At this stage the entire query should be 100% accurate, deterministically.
- incoming_and_outgoing: Here is where we must make use of an approximation, and also where there was a logical bug in the filtration clauses.
- final_token_balance_sheet: This is actually impressive because at this stage we have already applied our price (estimations) and filtered out a whole class of records based on these prices and some additional assumptions about what constitutes a "buffer trade".
- the final results table: here we measure that the total negative and positive slippage (separately) for an entire accounting period is withing 0.01 ETH 

For faster performance these tests are hard coded with an query execution ID corresponding to the query state at the time of this commit. To be MORE confident in these tests, you can comment out the "caches" (but they take quite a bit longer to run). 

Another modification that can be made is to change the accounting period in the `setUp` method to try for a completely different (untested) time window.

