### PR TITLE
Fix Post Tx Test

### DIFF
--- a/tests/e2e/test_post_transaction.py
+++ b/tests/e2e/test_post_transaction.py
@@ -33,7 +33,7 @@ class TestTransactionPost(unittest.TestCase):
         post_multisend(
             safe_address=Web3().toChecksumAddress(self.test_safe),
             network=EthereumNetwork.GOERLI,
-            transfers=[
+            transactions=[
                 token_transfer.as_multisend_tx(),
                 native_transfer.as_multisend_tx(),
             ],


### PR DESCRIPTION
Recent change made to #139 did not update the corresponding test. Namely a rename of `post_transaction`. Because we don't run e2e test in CI, this was not caught. I suppose we should also run e2e tests.