### PR TITLE
DuneVersion as Runtime Argument.

### DIFF
--- a/src/queries.py
+++ b/src/queries.py
@@ -14,8 +14,16 @@ from dune_client.types import QueryParameter
 class DuneVersion(Enum):
     """Dune Version Identifier"""
 
-    V1 = 1
-    V2 = 2
+    V1 = "1"
+    V2 = "2"
+
+    @staticmethod
+    def from_string(version_str: str) -> DuneVersion:
+        """Constructor of Dune version from string"""
+        try:
+            return DuneVersion[version_str]
+        except KeyError as err:
+            raise ValueError(f"Invalid DuneVersion string {version_str}") from err
 
 
 @dataclass

--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -8,6 +8,7 @@ from dune_client.client import DuneClient
 
 from src.fetch.dune import DuneFetcher
 from src.models.accounting_period import AccountingPeriod
+from src.queries import DuneVersion
 
 
 def previous_tuesday(day: date = date.today()) -> date:
@@ -51,6 +52,13 @@ def generic_script_init(description: str) -> ScriptArgs:
         default=False,
     )
     parser.add_argument(
+        "--dune-version",
+        type=DuneVersion,
+        help="Which Dune Client version to use (legacy or official)",
+        default=DuneVersion.V2,
+        choices=list(DuneVersion),
+    )
+    parser.add_argument(
         "--dry-run",
         type=bool,
         help="Flag indicating whether script should not post alerts or transactions. "
@@ -63,6 +71,7 @@ def generic_script_init(description: str) -> ScriptArgs:
         dune=DuneFetcher(
             dune=DuneClient(os.environ["DUNE_API_KEY"]),
             period=AccountingPeriod(args.start),
+            dune_version=args.dune_version,
         ),
         post_tx=args.post_tx,
         dry_run=args.dry_run,

--- a/tests/e2e/test_get_block_number.py
+++ b/tests/e2e/test_get_block_number.py
@@ -18,7 +18,7 @@ class TestGetBlockNumber(unittest.TestCase):
 
     def test_get_block_number(self):
         self.fetcher.period = AccountingPeriod("1970-01-01")  # Before Time
-        self.assertEqual(self.fetcher.get_block_interval(), ("0", "0"))
+        self.assertEqual(self.fetcher.get_block_interval(), ("None", "None"))
 
         self.fetcher.period = AccountingPeriod(
             "2015-07-30", length_days=1


### PR DESCRIPTION
For testing this weeks payout with both versions, this makes it easier to run the script.

Note that default version is V2 so the deployment does not need to change anything.

Also, it appears Dune has changed their interface for Get Block Number which now returns empty before the first block instead of 0.