### PR TITLE
Add surplus fee to rewards query

### DIFF
--- a/queries/orderbook/order_rewards.sql
+++ b/queries/orderbook/order_rewards.sql
@@ -23,6 +23,7 @@ with trade_hashes as (SELECT solver,
 select concat('0x', encode(trade_hashes.order_uid, 'hex')) as order_uid,
        concat('0x', encode(solver, 'hex'))  as solver,
        concat('0x', encode(tx_hash, 'hex')) as tx_hash,
+       coalesce(surplus_fee, 0) as surplus_fee,
        coalesce(reward, 0.0)                as amount,
        -- An order is a liquidity order if and only if reward is null.
        -- A liquidity order is safe if and only if its fee_amount is > 0

--- a/queries/user_generated/order_rewards_template.sql
+++ b/queries/user_generated/order_rewards_template.sql
@@ -1,8 +1,9 @@
 select order_uid::bytea,
        solver::bytea,
        tx_hash::bytea,
+       surplus_fee::numeric,
        amount::numeric,
        safe_liquidity::bool
 from (VALUES
 {{Values}}
-) as _ (order_uid, solver, tx_hash, amount, safe_liquidity)
+) as _ (order_uid, solver, tx_hash, surplus_fee, amount, safe_liquidity)

--- a/src/update/reward_history.py
+++ b/src/update/reward_history.py
@@ -37,6 +37,7 @@ class OrderRewards:
     solver: str
     tx_hash: str
     order_uid: str
+    surplus_fee: int
     amount: float
     safe_liquidity: Optional[bool]
 
@@ -48,6 +49,7 @@ class OrderRewards:
                 solver=row["solver"],
                 tx_hash=row["tx_hash"],
                 order_uid=row["order_uid"],
+                surplus_fee=int(row["surplus_fee"]),
                 amount=float(row["amount"]),
                 safe_liquidity=row["safe_liquidity"],
             )
@@ -59,7 +61,7 @@ class OrderRewards:
             map(pg_hex2bytea, [self.solver, self.tx_hash, self.order_uid])
         )
         safe = self.safe_liquidity if self.safe_liquidity is not None else "Null"
-        return f"('{order_id}','{solver}','{tx_hash}',{self.amount},{safe})"
+        return f"('{order_id}','{solver}','{tx_hash}', {self.surplus_fee},{self.amount},{safe})"
 
 
 def fetch_and_push_order_rewards(dune: DuneAPI, env: Environment) -> None:

--- a/tests/e2e/test_get_block_number.py
+++ b/tests/e2e/test_get_block_number.py
@@ -18,7 +18,7 @@ class TestGetBlockNumber(unittest.TestCase):
 
     def test_get_block_number(self):
         self.fetcher.period = AccountingPeriod("1970-01-01")  # Before Time
-        self.assertEqual(self.fetcher.get_block_interval(), ("0", "0"))
+        self.assertEqual(self.fetcher.get_block_interval(), ("None", "None"))
 
         self.fetcher.period = AccountingPeriod(
             "2015-07-30", length_days=1

--- a/tests/unit/test_reward_aggregation.py
+++ b/tests/unit/test_reward_aggregation.py
@@ -53,6 +53,7 @@ class MyTestCase(unittest.TestCase):
             "0x007",
         ]
         amounts = [39, 0, 40, 0, 41, 50, 60, 70, 40, 50, 0]
+        surplus_fees = [None] * len(amounts)
         safe_liquidity = [
             None,
             True,
@@ -70,6 +71,7 @@ class MyTestCase(unittest.TestCase):
             {
                 "solver": solvers,
                 "tx_hash": tx_hashes,
+                "surplus_fee": surplus_fees,
                 "amount": amounts,
                 "safe_liquidity": safe_liquidity,
             }
@@ -111,6 +113,7 @@ class MyTestCase(unittest.TestCase):
             {
                 "solver": [""] * 7,
                 "tx_hash": ["t1", "t2", "t3", "t3", "t4", "t4", "t5"],
+                "surplus_fee": [None] * 7,
                 "amount": [0] * 7,
                 "safe_liquidity": [True, False, False, True, False, False, None],
             }


### PR DESCRIPTION
This changes the schema of the user generated view to add surplus fee.

We can update the view as follows (I have already done this for the "test" env), 

```sh
python -m src.update.reward_history -e test
```


<details><summary>These are the kind logs you should expect to see:</summary>

```
INFO __main__ Fetching and Merging Orderbook Rewards
INFO __main__ Got 44018 records.
INFO duneapi.api Creating 13 pages from partitioned list
INFO duneapi.api Pushing Page 0 to cow_order_rewards_test_page_0
INFO duneapi.api Pushing ~0.88 Mb to Dune.
INFO duneapi.api execution running {'execution_id': '01GKRTAE9QW27WTZXA8AA0CCSB', 'execution_user_id': 87, 'execution_type': 'execute', 'created_at': '2022-12-08T12:10:47.996798Z', 'started_at': '2022-12-08T12:10:48.034358776Z'}
INFO duneapi.api cow_order_rewards_test_page_0 successfully updated: https://dune.xyz/queries/17875
INFO duneapi.api Pushing Page 1 to cow_order_rewards_test_page_1
INFO duneapi.api Pushing ~0.88 Mb to Dune.
INFO duneapi.api execution running {'execution_id': '01GKRTAND0N694S3XWJC8AQDVQ', 'execution_user_id': 87, 'execution_type': 'execute', 'created_at': '2022-12-08T12:10:55.268193Z', 'started_at': '2022-12-08T12:10:55.309238271Z'}
INFO duneapi.api cow_order_rewards_test_page_1 successfully updated: https://dune.xyz/queries/17875
INFO duneapi.api Pushing Page 2 to cow_order_rewards_test_page_2
INFO duneapi.api Pushing ~0.88 Mb to Dune.
INFO duneapi.api execution running {'execution_id': '01GKRTAWHHX2CYWJ77CG3RHZ3B', 'execution_user_id': 87, 'execution_type': 'execute', 'created_at': '2022-12-08T12:11:02.583538Z', 'started_at': '2022-12-08T12:11:02.621088384Z'}
...
INFO duneapi.api execution running {'execution_id': '01GKRTD27KQFT564EX17X80ZCR', 'execution_user_id': 87, 'execution_type': 'execute', 'created_at': '2022-12-08T12:12:13.940228Z', 'started_at': '2022-12-08T12:12:13.942487031Z'}
INFO duneapi.api cow_order_rewards_test successfully updated: https://dune.xyz/queries/17875
```
</details>

and now surplus fee is available in `dune_user_generated.order_rewards_test`

Here is a Dune Query Showing the new column:

https://dune.com/queries/1728429