### PR TITLE
Remove Safe Liquidity

### DIFF
--- a/queries/orderbook/order_rewards.sql
+++ b/queries/orderbook/order_rewards.sql
@@ -23,14 +23,8 @@ with trade_hashes as (SELECT solver,
 select concat('0x', encode(trade_hashes.order_uid, 'hex')) as order_uid,
        concat('0x', encode(solver, 'hex'))  as solver,
        concat('0x', encode(tx_hash, 'hex')) as tx_hash,
-       coalesce(surplus_fee, 0) as surplus_fee,
-       coalesce(reward, 0.0)                as amount,
-       -- An order is a liquidity order if and only if reward is null.
-       -- A liquidity order is safe if and only if its fee_amount is > 0
-       case
-           when reward is null and fee_amount > 0 then True
-           when reward is null and fee_amount = 0 then False
-           end                              as safe_liquidity
+       coalesce(surplus_fee, 0)             as surplus_fee,
+       coalesce(reward, 0.0)                as amount
 from trade_hashes
          left outer join {{reward_table}} o
                          on trade_hashes.order_uid = o.order_uid

--- a/queries/user_generated/order_rewards_template.sql
+++ b/queries/user_generated/order_rewards_template.sql
@@ -2,8 +2,7 @@ select order_uid::bytea,
        solver::bytea,
        tx_hash::bytea,
        surplus_fee::numeric,
-       amount::numeric,
-       safe_liquidity::bool
+       amount::numeric
 from (VALUES
 {{Values}}
-) as _ (order_uid, solver, tx_hash, surplus_fee, amount, safe_liquidity)
+) as _ (order_uid, solver, tx_hash, surplus_fee, amount)

--- a/src/fetch/cow_rewards.py
+++ b/src/fetch/cow_rewards.py
@@ -5,11 +5,8 @@ from web3 import Web3
 
 def map_reward(amount: float, risk_free: bool) -> float:
     """
-    Converts orderbook rewards based on additional information of
-    "risk_free" batches and (un)safe liquidity orders.
-    - risk-free are batches contain only user and liquidity orders (i.e. no AMM interactions),
-    - liquidity orders are further classified as being safe or unsafe;
-        Examples: (unsafe) 0x and just in time orders which carry some revert risk
+    Converts orderbook rewards based on additional information of "risk_free" batches
+    - risk-free are batches containing only user and liquidity orders (i.e. no AMM interactions),
     """
     if amount > 0 and risk_free:
         # Risk Free User Orders that are not contained in unsafe batches 37 COW tokens.

--- a/src/update/reward_history.py
+++ b/src/update/reward_history.py
@@ -17,7 +17,6 @@ as long as the previous pages have not been tampered with.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 from duneapi.api import DuneAPI
 from pandas import DataFrame

--- a/src/update/reward_history.py
+++ b/src/update/reward_history.py
@@ -39,7 +39,6 @@ class OrderRewards:
     order_uid: str
     surplus_fee: int
     amount: float
-    safe_liquidity: Optional[bool]
 
     @classmethod
     def from_dataframe(cls, pdf: DataFrame) -> list[OrderRewards]:
@@ -51,7 +50,6 @@ class OrderRewards:
                 order_uid=row["order_uid"],
                 surplus_fee=int(row["surplus_fee"]),
                 amount=float(row["amount"]),
-                safe_liquidity=row["safe_liquidity"],
             )
             for _, row in pdf.iterrows()
         ]
@@ -60,8 +58,9 @@ class OrderRewards:
         solver, tx_hash, order_id = list(
             map(pg_hex2bytea, [self.solver, self.tx_hash, self.order_uid])
         )
-        safe = self.safe_liquidity if self.safe_liquidity is not None else "Null"
-        return f"('{order_id}','{solver}','{tx_hash}', {self.surplus_fee},{self.amount},{safe})"
+        return (
+            f"('{order_id}','{solver}','{tx_hash}', {self.surplus_fee},{self.amount})"
+        )
 
 
 def fetch_and_push_order_rewards(dune: DuneAPI, env: Environment) -> None:

--- a/tests/unit/test_reward_aggregation.py
+++ b/tests/unit/test_reward_aggregation.py
@@ -4,11 +4,7 @@ from web3 import Web3
 
 import pandas as pd
 
-from src.fetch.cow_rewards import (
-    aggregate_orderbook_rewards,
-    map_reward,
-    unsafe_batches,
-)
+from src.fetch.cow_rewards import aggregate_orderbook_rewards, map_reward
 
 
 def to_wei(t) -> int:
@@ -54,26 +50,12 @@ class MyTestCase(unittest.TestCase):
         ]
         amounts = [39, 0, 40, 0, 41, 50, 60, 70, 40, 50, 0]
         surplus_fees = [None] * len(amounts)
-        safe_liquidity = [
-            None,
-            True,
-            None,
-            False,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            True,
-        ]
         orderbook_rewards = pd.DataFrame(
             {
                 "solver": solvers,
                 "tx_hash": tx_hashes,
                 "surplus_fee": surplus_fees,
                 "amount": amounts,
-                "safe_liquidity": safe_liquidity,
             }
         )
         results = aggregate_orderbook_rewards(
@@ -98,28 +80,10 @@ class MyTestCase(unittest.TestCase):
         self.assertIsNone(pd.testing.assert_frame_equal(expected, results))
 
     def test_map_reward(self):
-        self.assertEqual(map_reward(0, True, True), 0)
-        self.assertEqual(map_reward(0, True, False), 0)
-        self.assertEqual(map_reward(0, False, True), 0)
-        self.assertEqual(map_reward(0, False, False), 0)
-
-        self.assertEqual(map_reward(1, True, False), 37)
-        self.assertEqual(map_reward(1, True, True), 1)
-        self.assertEqual(map_reward(1, False, True), 1)
-        self.assertEqual(map_reward(1, False, False), 1)
-
-    def test_unsafe_batches(self):
-        orderbook_rewards = pd.DataFrame(
-            {
-                "solver": [""] * 7,
-                "tx_hash": ["t1", "t2", "t3", "t3", "t4", "t4", "t5"],
-                "surplus_fee": [None] * 7,
-                "amount": [0] * 7,
-                "safe_liquidity": [True, False, False, True, False, False, None],
-            }
-        )
-
-        self.assertEqual(unsafe_batches(orderbook_rewards), {"t2", "t3", "t4"})
+        self.assertEqual(map_reward(0, True), 0)
+        self.assertEqual(map_reward(1, True), 37)
+        self.assertEqual(map_reward(0, False), 0)
+        self.assertEqual(map_reward(1, False), 1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_reward_aggregation.py
+++ b/tests/unit/test_reward_aggregation.py
@@ -66,7 +66,7 @@ class MyTestCase(unittest.TestCase):
             {
                 "receiver": ["0x1", "0x2", "0x3", "0x4"],
                 "num_trades": [3, 3, 2, 3],
-                "amount": [to_wei(87), to_wei(100), to_wei(107), to_wei(74)],
+                "amount": [to_wei(87), to_wei(97), to_wei(107), to_wei(74)],
                 "token_address": [
                     "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
                     "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",


### PR DESCRIPTION
This concept of safe liquidity is no longer required (cf [here in slack](https://cowservices.slack.com/archives/C036JAGRQ04/p1670575811093429?thread_ts=1670490472.953269&cid=C036JAGRQ04)). Here we implement the removal of this field from the order book query and trickle down through all the code that depended on it.


# Test Plan

All tests adjusted to account for this removal.

