### PR TITLE
[V2] Deduct Surplus Fee in Slippage

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -21,7 +21,7 @@ filtered_trades as (
     from cow_protocol_ethereum.trades t
          join cow_protocol_ethereum.batches b
             on t.tx_hash = b.tx_hash
-    left outer join cowswap.cow_order_rewards_barn f
+    left outer join cow_protocol_ethereum.order_rewards f
         on f.tx_hash = t.tx_hash
         and f.order_uid = t.order_uid
     where b.block_time between '{{StartTime}}' and '{{EndTime}}'

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -10,7 +10,7 @@ filtered_trades as (
                 else dex_swaps
            end as dex_swaps,
            num_trades,
-           solver_address,
+           b.solver_address,
            trader                                       as trader_in,
            receiver                                     as trader_out,
            sell_token_address                           as sell_token,
@@ -26,7 +26,7 @@ filtered_trades as (
         and f.order_uid = t.order_uid
     where b.block_time between '{{StartTime}}' and '{{EndTime}}'
     and t.block_time between '{{StartTime}}' and '{{EndTime}}'
-    and (solver_address = lower('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
+    and (b.solver_address = lower('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
     and (t.tx_hash = lower('{{TxHash}}') or '{{TxHash}}' = '0x')
 ),
 batchwise_traders as (

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,3 +1,4 @@
+-- Query here: https://dune.com/queries/1777559
 with
 filtered_trades as (
     select t.block_time,
@@ -7,24 +8,22 @@ filtered_trades as (
             -- Estimation made here: https://dune.com/queries/1646084
                 then ((gas_used - 73688 - (70528 * num_trades)) / 90000)::int
                 else dex_swaps
-            end as dex_swaps,
+           end as dex_swaps,
            num_trades,
            solver_address,
-           trader                                              as trader_in,
-           -- Null Receiver: https://dune.com/queries/1729130
-           -- TODO - This could also be fixed in the spellbook!
-           case
-                when receiver = '0x0000000000000000000000000000000000000000'
-                then trader
-            else receiver end                                  as trader_out,
-           sell_token_address                                  as sell_token,
-           buy_token_address                                   as buy_token,
-           atoms_sold,
+           trader                                       as trader_in,
+           receiver                                     as trader_out,
+           sell_token_address                           as sell_token,
+           buy_token_address                            as buy_token,
+           atoms_sold - coalesce(surplus_fee, 0)        as atoms_sold,
            atoms_bought,
            '0x9008d19f58aabd9ed0d60971565aa8510560ab41' as contract_address
     from cow_protocol_ethereum.trades t
          join cow_protocol_ethereum.batches b
             on t.tx_hash = b.tx_hash
+    left outer join cowswap.cow_order_rewards_barn f
+        on f.tx_hash = t.tx_hash
+        and f.order_uid = t.order_uid
     where b.block_time between '{{StartTime}}' and '{{EndTime}}'
     and t.block_time between '{{StartTime}}' and '{{EndTime}}'
     and (solver_address = lower('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')

--- a/src/queries.py
+++ b/src/queries.py
@@ -96,6 +96,6 @@ QUERIES = {
         name="Solver Slippage for Period",
         filepath="period_slippage.sql",
         v1_id=1728478,
-        v2_id=1729274,
+        v2_id=1777559,
     ),
 }

--- a/tests/integration/test_solver_slippage.py
+++ b/tests/integration/test_solver_slippage.py
@@ -277,9 +277,7 @@ class TestQueryMigration(unittest.TestCase):
         )
         # V2 Query does not yet implement surplus fee.
         self.assertAlmostEqual(
-            weth_in - known_surplus_fee,
-            parsed_v2["WETH"],
-            places=18
+            weth_in - known_surplus_fee, parsed_v2["WETH"], places=18
         )
 
 

--- a/tests/integration/test_solver_slippage.py
+++ b/tests/integration/test_solver_slippage.py
@@ -246,8 +246,8 @@ class TestQueryMigration(unittest.TestCase):
             table_name,
             period=AccountingPeriod("2022-11-29", 1),
             tx_hash="0xfe4589525c1ed764273fbca9120b0e5f7f101d5d4996939ead95a50312f4d8b3",
-            v1_cache="01GKS1X2Y18ECYRRJPCSGEE57X",
-            v2_cache="01GKS1X8BPMXMD9FQ4T1ER22YW",
+            v1_cache="01GMMZWQC8MGGHSPQP2RY9G00G",
+            v2_cache="01GMMZWWW0E28Q78S2K29NMHK0",
         )
 
         known_surplus_fee = 1323758338760117
@@ -276,7 +276,11 @@ class TestQueryMigration(unittest.TestCase):
             delta=13,
         )
         # V2 Query does not yet implement surplus fee.
-        self.assertAlmostEqual(weth_in, parsed_v2["WETH"], places=18)
+        self.assertAlmostEqual(
+            weth_in - known_surplus_fee,
+            parsed_v2["WETH"],
+            places=18
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Similar to #156 but for Dune V2. Now that order rewards are available via community sources.

Check it out on Dune [here](https://dune.com/queries/1777559)

Our tests detected a bug with duplicated records in order rewards. This lead to a [hotfix PR](https://github.com/duneanalytics/spellbook/pull/2351) on Dune Spellbook (will also continue debugging what actually happened).

