### PR TITLE
[HotFix] exclude ETH flow transfers from slippage

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -94,6 +94,10 @@ other_transfers as (
       and '0x9008d19f58aabd9ed0d60971565aa8510560ab41' in (to, from)
       and not array_contains(traders_in, from)
       and not array_contains(traders_out, to)
+      and from not in ( -- ETH FLOW ORDERS ARE NOT AMM TRANSFERS!
+          select distinct contract_address
+          from cow_protocol_ethereum.CoWSwapEthFlow_evt_OrderPlacement
+      )
       and (t.evt_tx_hash = lower('{{TxHash}}') or '{{TxHash}}' = '0x')
       and (solver_address = lower('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
 ),

--- a/src/queries.py
+++ b/src/queries.py
@@ -96,6 +96,6 @@ QUERIES = {
         name="Solver Slippage for Period",
         filepath="period_slippage.sql",
         v1_id=1728478,
-        v2_id=1777559,
+        v2_id=1783854,
     ),
 }


### PR DESCRIPTION
We recently made a [change to the trades table](https://github.com/duneanalytics/spellbook/pull/2356) that populates the `trader` field with `sender` of `orderCreation`. This messed up our slippage accounting (counting transfers from ETHFlow Contract as `AMM_IN`).

This fixes that.