### PR TITLE
CIP17: Symmetric Slippage

### DIFF
--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -197,9 +197,12 @@ class DuneFetcher:
         # TODO - fetch these three results asynchronously!
         reimbursements = self.get_eth_spent()
         rewards = self.get_cow_rewards()
-        split_transfers = SplitTransfers(self.period, reimbursements + rewards)
+        split_transfers = SplitTransfers(
+            period=self.period,
+            mixed_transfers=reimbursements + rewards,
+            log_saver=self.log_saver,
+        )
         return split_transfers.process(
             slippage=self.get_period_slippage(),
             cow_redirects=self.get_vouches(),
-            log_saver=self.log_saver,
         )

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -203,6 +203,6 @@ class DuneFetcher:
             log_saver=self.log_saver,
         )
         return split_transfers.process(
-            slippage=self.get_period_slippage(),
+            slippages=self.get_period_slippage(),
             cow_redirects=self.get_vouches(),
         )

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -16,7 +16,6 @@ from src.models.transfer import Transfer
 from src.models.vouch import Vouch, RECOGNIZED_BONDING_POOLS, parse_vouches
 from src.pg_client import DualEnvDataframe
 from src.queries import QUERIES, DuneVersion, QueryData
-from src.utils.dataset import index_by
 from src.utils.print_store import PrintStore
 
 log = set_log(__name__)
@@ -199,10 +198,8 @@ class DuneFetcher:
         reimbursements = self.get_eth_spent()
         rewards = self.get_cow_rewards()
         split_transfers = SplitTransfers(self.period, reimbursements + rewards)
-        negative_slippage = self.get_period_slippage().negative
-
         return split_transfers.process(
-            indexed_slippage=index_by(negative_slippage, "solver_address"),
+            slippage=self.get_period_slippage(),
             cow_redirects=self.get_vouches(),
             log_saver=self.log_saver,
         )

--- a/src/models/slippage.py
+++ b/src/models/slippage.py
@@ -10,6 +10,7 @@ from enum import Enum
 
 from dune_client.types import Address
 
+# from src.models.transfer import Transfer
 from src.utils.query_file import (
     open_dashboard_query,
     open_query,

--- a/src/models/slippage.py
+++ b/src/models/slippage.py
@@ -40,12 +40,12 @@ class SolverSlippage:
 class SplitSlippages:
     """Basic class to store the output of slippage fetching"""
 
-    negative: list[SolverSlippage]
-    positive: list[SolverSlippage]
+    solvers_with_negative_total: list[SolverSlippage]
+    solvers_with_positive_total: list[SolverSlippage]
 
     def __init__(self) -> None:
-        self.negative = []
-        self.positive = []
+        self.solvers_with_negative_total = []
+        self.solvers_with_positive_total = []
 
     @classmethod
     def from_data_set(cls, data_set: list[dict[str, str]]) -> SplitSlippages:
@@ -58,20 +58,22 @@ class SplitSlippages:
     def append(self, slippage: SolverSlippage) -> None:
         """Appends the Slippage to the appropriate half based on signature of amount"""
         if slippage.amount_wei < 0:
-            self.negative.append(slippage)
+            self.solvers_with_negative_total.append(slippage)
         else:
-            self.positive.append(slippage)
+            self.solvers_with_positive_total.append(slippage)
 
     def __len__(self) -> int:
-        return len(self.negative) + len(self.positive)
+        return len(self.solvers_with_negative_total) + len(
+            self.solvers_with_positive_total
+        )
 
     def sum_negative(self) -> int:
         """Returns total negative slippage"""
-        return sum(neg.amount_wei for neg in self.negative)
+        return sum(neg.amount_wei for neg in self.solvers_with_negative_total)
 
     def sum_positive(self) -> int:
         """Returns total positive slippage"""
-        return sum(pos.amount_wei for pos in self.positive)
+        return sum(pos.amount_wei for pos in self.solvers_with_positive_total)
 
 
 class QueryType(Enum):

--- a/src/models/slippage.py
+++ b/src/models/slippage.py
@@ -10,7 +10,6 @@ from enum import Enum
 
 from dune_client.types import Address
 
-# from src.models.transfer import Transfer
 from src.utils.query_file import (
     open_dashboard_query,
     open_query,

--- a/src/models/split_transfers.py
+++ b/src/models/split_transfers.py
@@ -131,7 +131,7 @@ class SplitTransfers:
 
     def process(
         self,
-        slippage: SplitSlippages,
+        slippages: SplitSlippages,
         cow_redirects: dict[Address, Vouch],
     ) -> list[Transfer]:
         """
@@ -142,13 +142,15 @@ class SplitTransfers:
         the COW rewards.
         """
         penalty_total = self._process_native_transfers(
-            indexed_slippage=index_by(slippage.negative, "solver_address")
+            indexed_slippage=index_by(
+                slippages.solvers_with_negative_total, "solver_address"
+            )
         )
         # Note that positive and negative slippage is DISJOINT.
         # So no overdraft computations will overlap with the positive slippage perturbations.
         self._process_rewards(
             cow_redirects,
-            positive_slippage=slippage.positive,
+            positive_slippage=slippages.solvers_with_positive_total,
         )
         self.log_saver.print(
             f"Total Slippage deducted (ETH): {penalty_total / 10**18}",

--- a/src/models/split_transfers.py
+++ b/src/models/split_transfers.py
@@ -121,7 +121,11 @@ class SplitTransfers:
         # and positive slippage adjustments, because positive/negative slippage
         # is disjoint between solvers.
         while positive_slippage:
-            slippage_transfer = Transfer.from_slippage(positive_slippage.pop())
+            slippage = positive_slippage.pop()
+            assert (
+                slippage.amount_wei > 0
+            ), f"Expected positive slippage got {slippage.amount_wei}"
+            slippage_transfer = Transfer.from_slippage(slippage)
             slippage_transfer.redirect_to(redirect_map, self.log_saver)
             self.eth_transfers.append(slippage_transfer)
 

--- a/src/models/split_transfers.py
+++ b/src/models/split_transfers.py
@@ -103,14 +103,14 @@ class SplitTransfers:
                     # Reinsert since there is still an amount owed.
                     self.overdrafts[solver] = overdraft
                     continue
-            transfer.redirect_from(cow_redirects, log_saver)
+            transfer.redirect_to(cow_redirects, log_saver)
             self.cow_transfers.append(transfer)
         # We do not need to worry about any controversy between overdraft
         # and positive slippage adjustments, because positive/negative slippage
         # is disjoint between solvers.
         while positive_slippage:
             slippage_transfer = Transfer.from_slippage(positive_slippage.pop())
-            slippage_transfer.redirect_from(cow_redirects, log_saver)
+            slippage_transfer.redirect_to(cow_redirects, log_saver)
             self.eth_transfers.append(slippage_transfer)
 
     def process(

--- a/src/models/split_transfers.py
+++ b/src/models/split_transfers.py
@@ -134,7 +134,7 @@ class SplitTransfers:
         This is the public interface to construct the final transfer file based on
         raw (unpenalized) results, positive, negative slippage, rewards and overdrafts.
         It is very important that the native token transfers are processed first,
-        so that and overdraft from slippage can be carried over and deducted from
+        so that any overdraft from slippage can be carried over and deducted from
         the COW rewards.
         """
         penalty_total = self._process_native_transfers(

--- a/src/models/token.py
+++ b/src/models/token.py
@@ -55,6 +55,9 @@ class Token:
             decimals if decimals is not None else get_token_decimals(web3, address)
         )
 
+    def __repr__(self) -> str:
+        return str(self.address)
+
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Token):
             return self.address == other.address and self.decimals == other.decimals

--- a/src/models/transfer.py
+++ b/src/models/transfer.py
@@ -188,7 +188,7 @@ class Transfer:
             )
         raise ValueError(f"Invalid Token Type {self.token_type}")
 
-    def redirect_from(
+    def redirect_to(
         self, redirects: dict[Address, Vouch], log_saver: PrintStore
     ) -> None:
         """

--- a/src/models/transfer.py
+++ b/src/models/transfer.py
@@ -192,7 +192,7 @@ class Transfer:
         self, redirects: dict[Address, Vouch], log_saver: PrintStore
     ) -> None:
         """
-        Redirects Transfers via Address => Vouch.redirect_address
+        Redirects Transfers via Address => Vouch.reward_target
         This function modifies self!
         """
         recipient = self.receiver

--- a/src/models/transfer.py
+++ b/src/models/transfer.py
@@ -200,7 +200,7 @@ class Transfer:
             # Redirect COW rewards to reward target specific by VouchRegistry
             redirect_address = redirects[recipient].reward_target
             log_saver.print(
-                f"Redirecting {recipient} Transfer of {self.token}"
+                f"Redirecting {recipient} Transfer of {self.token or 'ETH'}"
                 f"({self.amount}) to {redirect_address}",
                 category=Category.REDIRECT,
             )

--- a/tests/queries/test_slippage_investigation.py
+++ b/tests/queries/test_slippage_investigation.py
@@ -66,6 +66,35 @@ class TestDuneAnalytics(unittest.TestCase):
         for obj in top_five_negative + top_five_positive:
             assert abs(int(obj["eth_slippage_wei"])) < 1 * 10**18
 
+    def test_positive_slippage_evaluation(self):
+        """
+        Transaction 0x5c4e410ce5d741f60e06a8621c6f12839ad39273f5abf78d4bbc1cd3b31de46c
+        Alerted on January 1, 2023.
+        https://dune.com/queries/1688044?MinAbsoluteSlippageTolerance=100&TxHash=0x&RelativeSlippageTolerance=1.0&SignificantSlippageValue=2000&StartTime=2023-01-01+00%3A00%3A00&EndTime=2023-01-02+00%3A00%3A00&EndTime_d83555=2023-01-02+00%3A00%3A00&MinAbsoluteSlippageTolerance_n26d66=100&RelativeSlippageTolerance_n26d66=1.0&SignificantSlippageValue_n26d66=2000&StartTime_d83555=2023-01-01+00%3A00%3A00&TxHash_t6c1ea=0x
+        """
+        period = AccountingPeriod("2023-01-01", 1)
+        query = QUERIES["PERIOD_SLIPPAGE"].with_params(
+            period.as_query_params()
+            + [
+                # Default values (on the query definition) do not need to be provided!
+                QueryParameter.text_type("TxHash", "0x5c4e410ce5d741f60e06a8621c6f12839ad39273f5abf78d4bbc1cd3b31de46c"),
+                # QueryParameter.text_type("SolverAddress", "0x97ec0a17432d71a3234ef7173c6b48a2c0940896"),
+                # QueryParameter.text_type("TokenList", ",".join(get_trusted_tokens())),
+                QueryParameter.text_type("CTE_NAME", "results_per_tx")
+            ],
+            dune_version=DuneVersion.V2,
+        )
+        results = exec_or_get(self.dune, query, result_id="01GP11D7FH4WAEFW1Z46Q79VBC")
+        tx_slippage = results.get_rows()[0]
+        self.assertEqual(tx_slippage["eth_slippage_wei"], 148427839329771300)
+        self.assertAlmostEqual(tx_slippage["usd_value"], 177.37732880251593, delta=0.000000001)
+        # When looking at the pure batch token imbalance:
+        # https://dune.com/queries/1380984?TxHash=0x5c4e410ce5d741f60e06a8621c6f12839ad39273f5abf78d4bbc1cd3b31de46c
+        # One sees 5 tokens listed. However, this calculation merges ETH/WETH together
+        # as a single row one of those imbalances was excluded as an "internal trade"
+        # https://dune.com/queries/1836718?CTE_NAME_e15077=final_token_balance_sheet&EndTime_d83555=2023-01-02+00%3A00%3A00&StartTime_d83555=2023-01-01+00%3A00%3A00&TxHash_t6c1ea=0x5c4e410ce5d741f60e06a8621c6f12839ad39273f5abf78d4bbc1cd3b31de46c
+        self.assertEqual(tx_slippage["num_entries"], 4)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/queries/test_slippage_investigation.py
+++ b/tests/queries/test_slippage_investigation.py
@@ -77,17 +77,22 @@ class TestDuneAnalytics(unittest.TestCase):
             period.as_query_params()
             + [
                 # Default values (on the query definition) do not need to be provided!
-                QueryParameter.text_type("TxHash", "0x5c4e410ce5d741f60e06a8621c6f12839ad39273f5abf78d4bbc1cd3b31de46c"),
+                QueryParameter.text_type(
+                    "TxHash",
+                    "0x5c4e410ce5d741f60e06a8621c6f12839ad39273f5abf78d4bbc1cd3b31de46c",
+                ),
                 # QueryParameter.text_type("SolverAddress", "0x97ec0a17432d71a3234ef7173c6b48a2c0940896"),
                 # QueryParameter.text_type("TokenList", ",".join(get_trusted_tokens())),
-                QueryParameter.text_type("CTE_NAME", "results_per_tx")
+                QueryParameter.text_type("CTE_NAME", "results_per_tx"),
             ],
             dune_version=DuneVersion.V2,
         )
         results = exec_or_get(self.dune, query, result_id="01GP11D7FH4WAEFW1Z46Q79VBC")
         tx_slippage = results.get_rows()[0]
         self.assertEqual(tx_slippage["eth_slippage_wei"], 148427839329771300)
-        self.assertAlmostEqual(tx_slippage["usd_value"], 177.37732880251593, delta=0.000000001)
+        self.assertAlmostEqual(
+            tx_slippage["usd_value"], 177.37732880251593, delta=0.000000001
+        )
         # When looking at the pure batch token imbalance:
         # https://dune.com/queries/1380984?TxHash=0x5c4e410ce5d741f60e06a8621c6f12839ad39273f5abf78d4bbc1cd3b31de46c
         # One sees 5 tokens listed. However, this calculation merges ETH/WETH together

--- a/tests/queries/test_slippage_investigation.py
+++ b/tests/queries/test_slippage_investigation.py
@@ -86,7 +86,6 @@ class TestDuneAnalytics(unittest.TestCase):
         )
         results = exec_or_get(self.dune, query, result_id="01GP3A0QV1BNWF55Z5N362RK8M")
         tx_slippage = results.get_rows()[0]
-        print(tx_slippage)
         self.assertEqual(tx_slippage["eth_slippage_wei"], 71151929005056890)
         self.assertAlmostEqual(
             tx_slippage["usd_value"], 83.37280645114296, delta=0.00001

--- a/tests/unit/test_split_transfer.py
+++ b/tests/unit/test_split_transfer.py
@@ -4,7 +4,7 @@ from dune_client.types import Address
 
 from src.constants import COW_TOKEN_ADDRESS
 from src.models.accounting_period import AccountingPeriod
-from src.models.slippage import SolverSlippage
+from src.models.slippage import SolverSlippage, SplitSlippages
 from src.models.split_transfers import SplitTransfers
 from src.models.token import Token
 from src.models.transfer import Transfer
@@ -86,6 +86,128 @@ class TestSplitTransfers(unittest.TestCase):
                     receiver=redirect_map[self.solver].reward_target,
                     amount_wei=cow_reward,
                 )
+            ],
+        )
+
+    def test_full_process(self):
+        """
+        This scenario involves two solvers, one with positive and one with negative slippage.
+        The negative slippage does not involve any overdraft!
+        All amounts (execution costs, cow rewards and slippage) are declared at the top of the test.
+        The expected outcome is
+        - 3 ETH transfers:
+            - 2 for execution costs with one having negative slippage deducted.
+            - 1 for positive slippage (redirected to the reward target)
+        - 2 COW transfers (one for each solver).
+        """
+        solvers = [
+            Address.from_int(1),
+            Address.from_int(2),
+        ]
+        eth_amounts = [
+            2 * ONE_ETH,
+            3 * ONE_ETH,
+        ]
+        cow_rewards = [
+            600 * ONE_ETH,
+            100 * ONE_ETH,
+        ]
+        slippage_amounts = [
+            1 * ONE_ETH,
+            -1 * ONE_ETH,
+        ]
+
+        accounting = SplitTransfers(
+            self.period,
+            mixed_transfers=[
+                Transfer(
+                    token=None,
+                    receiver=solvers[0],
+                    amount_wei=eth_amounts[0],
+                ),
+                Transfer(
+                    token=None,
+                    receiver=solvers[1],
+                    amount_wei=eth_amounts[1],
+                ),
+                Transfer(
+                    token=self.cow_token, receiver=solvers[0], amount_wei=cow_rewards[0]
+                ),
+                Transfer(
+                    token=self.cow_token, receiver=solvers[1], amount_wei=cow_rewards[1]
+                ),
+            ],
+            log_saver=PrintStore(),
+        )
+        reward_targets = [
+            Address.from_int(3),
+            Address.from_int(4),
+        ]
+        redirect_map = {
+            solvers[0]: Vouch(
+                solver=solvers[0],
+                reward_target=reward_targets[0],
+                bonding_pool=Address.zero(),
+            ),
+            solvers[1]: Vouch(
+                solver=solvers[1],
+                reward_target=reward_targets[1],
+                bonding_pool=Address.zero(),
+            ),
+        }
+        accounting.process(
+            slippage=SplitSlippages.from_data_set(
+                [
+                    {
+                        "eth_slippage_wei": slippage_amounts[0],
+                        "solver_address": solvers[0].address,
+                        "solver_name": "irrelevant1",
+                    },
+                    {
+                        "eth_slippage_wei": slippage_amounts[1],
+                        "solver_address": solvers[1].address,
+                        "solver_name": "irrelevant2",
+                    },
+                ]
+            ),
+            cow_redirects=redirect_map,
+        )
+        # Although we haven't called process_native_transfers, we are appending positive slippage inside
+        self.assertEqual(
+            accounting.eth_transfers,
+            [
+                Transfer(
+                    token=None,
+                    receiver=solvers[0],
+                    amount_wei=eth_amounts[0],
+                ),
+                Transfer(
+                    token=None,
+                    receiver=solvers[1],
+                    # Slippage is negative (so it is added here)
+                    amount_wei=eth_amounts[1] + slippage_amounts[1],
+                ),
+                Transfer(
+                    token=None,
+                    # The solver with positive slippage!
+                    receiver=redirect_map[solvers[0]].reward_target,
+                    amount_wei=slippage_amounts[0],
+                ),
+            ],
+        )
+        self.assertEqual(
+            accounting.cow_transfers,
+            [
+                Transfer(
+                    token=self.cow_token,
+                    receiver=redirect_map[solvers[0]].reward_target,
+                    amount_wei=cow_rewards[0],
+                ),
+                Transfer(
+                    token=self.cow_token,
+                    receiver=redirect_map[solvers[1]].reward_target,
+                    amount_wei=cow_rewards[1],
+                ),
             ],
         )
 

--- a/tests/unit/test_split_transfer.py
+++ b/tests/unit/test_split_transfer.py
@@ -158,7 +158,7 @@ class TestSplitTransfers(unittest.TestCase):
         accounting = self.construct_split_transfers(solvers, eth_amounts, cow_rewards)
 
         accounting.process(
-            slippage=SplitSlippages.from_data_set(
+            slippages=SplitSlippages.from_data_set(
                 [
                     {
                         "eth_slippage_wei": slippage_amounts[0],
@@ -255,7 +255,7 @@ class TestSplitTransfers(unittest.TestCase):
         accounting = self.construct_split_transfers(solvers, eth_amounts, cow_rewards)
 
         accounting.process(
-            slippage=SplitSlippages.from_data_set(
+            slippages=SplitSlippages.from_data_set(
                 [
                     {
                         "eth_slippage_wei": slippage_amounts[i],

--- a/tests/unit/test_split_transfer.py
+++ b/tests/unit/test_split_transfer.py
@@ -15,8 +15,12 @@ ONE_ETH = 10**18
 
 
 class TestSplitTransfers(unittest.TestCase):
-
-    def construct_split_transfers(self, solvers: list[Address], eth_amounts: list[int], cow_rewards: list[int], ) -> SplitTransfers:
+    def construct_split_transfers(
+        self,
+        solvers: list[Address],
+        eth_amounts: list[int],
+        cow_rewards: list[int],
+    ) -> SplitTransfers:
         eth_transfers = [
             Transfer(
                 token=None,
@@ -36,6 +40,7 @@ class TestSplitTransfers(unittest.TestCase):
             mixed_transfers=eth_transfers + cow_transfers,
             log_saver=PrintStore(),
         )
+
     def setUp(self) -> None:
         self.period = AccountingPeriod("2022-06-14")
         self.solver = Address("0xde786877a10dbb7eba25a4da65aecf47654f08ab")
@@ -210,7 +215,6 @@ class TestSplitTransfers(unittest.TestCase):
         self.assertEqual(accounting.unprocessed_cow, [])
         self.assertEqual(accounting.unprocessed_native, [])
 
-
     def test_full_process_with_overdraft(self):
         """
         This scenario involves three solvers - all with some form of overdraft.
@@ -237,7 +241,7 @@ class TestSplitTransfers(unittest.TestCase):
         slippage_amounts = [
             -3 * ONE_ETH,  # Exceeding both ETH and COW
             -3 * ONE_ETH,  # Exceeding only ETH
-            -1 * ONE_ETH   # Not Exceeding ETH
+            -1 * ONE_ETH,  # Not Exceeding ETH
         ]
 
         redirect_map = {
@@ -245,7 +249,8 @@ class TestSplitTransfers(unittest.TestCase):
                 solver=solvers[i],
                 reward_target=Address.from_int(n + i),
                 bonding_pool=Address.zero(),
-            ) for i in range(n)
+            )
+            for i in range(n)
         }
         accounting = self.construct_split_transfers(solvers, eth_amounts, cow_rewards)
 
@@ -256,7 +261,8 @@ class TestSplitTransfers(unittest.TestCase):
                         "eth_slippage_wei": slippage_amounts[i],
                         "solver_address": solvers[i].address,
                         "solver_name": "irrelevant",
-                    } for i in range(n)
+                    }
+                    for i in range(n)
                 ]
             ),
             cow_redirects=redirect_map,

--- a/tests/unit/test_split_transfer.py
+++ b/tests/unit/test_split_transfer.py
@@ -15,19 +15,6 @@ ONE_ETH = 10**18
 
 class TestSplitTransfers(unittest.TestCase):
     def test_process_native_transfers(self):
-        class SplitTransfersTest(SplitTransfers):
-            def __init__(
-                self, period: AccountingPeriod, mixed_transfers: list[Transfer]
-            ):
-                SplitTransfers.__init__(self, period, mixed_transfers)
-
-            def process_native_transfers(
-                self, indexed_slippage: dict[Address, SolverSlippage]
-            ) -> int:
-                return SplitTransfers._process_native_transfers(
-                    self, indexed_slippage, PrintStore()
-                )
-
         period = AccountingPeriod("2022-06-14")
         barn_zerox = Address("0xde786877a10dbb7eba25a4da65aecf47654f08ab")
         cow_token = Token(COW_TOKEN_ADDRESS)
@@ -47,9 +34,9 @@ class TestSplitTransfers(unittest.TestCase):
             solver_address=barn_zerox,
         )
         indexed_slippage = {barn_zerox: barn_slippage}
-        accounting = SplitTransfersTest(period, mixed_transfers)
+        accounting = SplitTransfers(period, mixed_transfers, PrintStore())
 
-        total_penalty = accounting.process_native_transfers(indexed_slippage)
+        total_penalty = accounting._process_native_transfers(indexed_slippage)
         expected_total_penalty = -amount_of_transfer
         self.assertEqual(total_penalty, expected_total_penalty)
 

--- a/tests/unit/test_split_transfer.py
+++ b/tests/unit/test_split_transfer.py
@@ -8,37 +8,86 @@ from src.models.slippage import SolverSlippage
 from src.models.split_transfers import SplitTransfers
 from src.models.token import Token
 from src.models.transfer import Transfer
+from src.models.vouch import Vouch
 from src.utils.print_store import PrintStore
 
 ONE_ETH = 10**18
 
 
 class TestSplitTransfers(unittest.TestCase):
+    def setUp(self) -> None:
+        self.period = AccountingPeriod("2022-06-14")
+        self.solver = Address("0xde786877a10dbb7eba25a4da65aecf47654f08ab")
+        self.solver_name = "barn-0x"
+        self.cow_token = Token(COW_TOKEN_ADDRESS)
+
     def test_process_native_transfers(self):
-        period = AccountingPeriod("2022-06-14")
-        barn_zerox = Address("0xde786877a10dbb7eba25a4da65aecf47654f08ab")
-        cow_token = Token(COW_TOKEN_ADDRESS)
         amount_of_transfer = 185360274773133130
         mixed_transfers = [
             Transfer(
                 token=None,
-                receiver=barn_zerox,
+                receiver=self.solver,
                 amount_wei=amount_of_transfer,
             ),
-            Transfer(token=cow_token, receiver=barn_zerox, amount_wei=600 * ONE_ETH),
+            Transfer(
+                token=self.cow_token, receiver=self.solver, amount_wei=600 * ONE_ETH
+            ),
         ]
 
-        barn_slippage = SolverSlippage(
+        slippage = SolverSlippage(
             amount_wei=-amount_of_transfer - ONE_ETH,
-            solver_name="barn-0x",
-            solver_address=barn_zerox,
+            solver_name=self.solver_name,
+            solver_address=self.solver,
         )
-        indexed_slippage = {barn_zerox: barn_slippage}
-        accounting = SplitTransfers(period, mixed_transfers, PrintStore())
+        indexed_slippage = {self.solver: slippage}
+        accounting = SplitTransfers(self.period, mixed_transfers, PrintStore())
 
         total_penalty = accounting._process_native_transfers(indexed_slippage)
         expected_total_penalty = -amount_of_transfer
         self.assertEqual(total_penalty, expected_total_penalty)
+
+    def test_process_rewards(self):
+        cow_reward = 600 * ONE_ETH
+        mixed_transfers = [
+            Transfer(token=self.cow_token, receiver=self.solver, amount_wei=cow_reward),
+        ]
+        accounting = SplitTransfers(self.period, mixed_transfers, PrintStore())
+        reward_target = Address.from_int(7)
+        redirect_map = {
+            self.solver: Vouch(
+                solver=self.solver,
+                reward_target=reward_target,
+                bonding_pool=Address.zero(),
+            )
+        }
+        slippage_amount = 1
+        positive_slippage = [
+            SolverSlippage(
+                amount_wei=slippage_amount, solver_address=self.solver, solver_name=""
+            )
+        ]
+        accounting._process_rewards(redirect_map, positive_slippage)
+        # Although we haven't called process_native_transfers, we are appending positive slippage inside
+        self.assertEqual(
+            accounting.eth_transfers,
+            [
+                Transfer(
+                    token=None,
+                    receiver=redirect_map[self.solver].reward_target,
+                    amount_wei=slippage_amount,
+                )
+            ],
+        )
+        self.assertEqual(
+            accounting.cow_transfers,
+            [
+                Transfer(
+                    token=self.cow_token,
+                    receiver=redirect_map[self.solver].reward_target,
+                    amount_wei=cow_reward,
+                )
+            ],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
According to the specification requested in [slack](https://cowservices.slack.com/archives/C0361CCTFD5/p1671440031006519), this PR introduces an accounting of positive solver slippage. In particular, instead of ignoring the positive slippage, it is considered as part of the reward and redirected to the reward target from the Vouch Registry (i.e. the account receiving COW token rewards). 

Note that (mathematically) the negative and positive slippage is disjoint by solver address. While it is important for us to incorporate the negative slippage before making reward computations. In essence "If they do not have negative slippage then nothing was or will be deducted".

# Formal Specification

[CIP-17 in Snapshot](https://snapshot.org/#/cow.eth/proposal/0xf9c98a2710dc72c906bbeab9b8fe169c1ed2e9af6a67776cc29b8b4eb44d0fb2)

# Test Plan

3 unit tests covering:
- private method _process_rewards
- full_process (two solvers, one with +ve and one with -ve slippage, no over draft)
- full_process (three solvers, every different overdraft scenario -- not exceeding ETH, exceeding ETH but not COW, exceeding both).

1 Query test demonstrating that positive slippage is as expected for a specific transaction.


The logs will change slightly during redirect because we are now redirecting both COW and ETH (so it has become a less specific message). 

 