### PR TITLE
Use Batches for V2 instead of raw Events

### DIFF
--- a/queries/dune_v1/trade_counts.sql
+++ b/queries/dune_v1/trade_counts.sql
@@ -7,12 +7,3 @@ from gnosis_protocol_v2."GPv2Settlement_evt_Trade" t
 where t.evt_block_number between {{start_block}} and {{end_block}}
 group by solver
 order by num_trades desc, solver
-
--- V2 Query: https://dune.com/queries/1393633?d=1
--- select solver,
---        count(*) as num_trades
--- from gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Trade t
---          join gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Settlement s
---               on t.evt_tx_hash = s.evt_tx_hash
--- where t.evt_block_number between {{start_block}} and {{end_block}}
--- group by solver

--- a/queries/dune_v2/risk_free_batches.sql
+++ b/queries/dune_v2/risk_free_batches.sql
@@ -1,4 +1,3 @@
--- V2 Query: https://dune.com/queries/1541507
 with
 interactions as (
     select
@@ -18,10 +17,10 @@ interactions as (
 ),
 
 no_interactions as (
-    select evt_tx_hash
-    from gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Settlement
-    where evt_block_time between '{{StartTime}}' and '{{EndTime}}'
-    and evt_tx_hash not in (
+    select tx_hash
+    from cow_protocol_ethereum.batches
+    where block_time between '{{StartTime}}' and '{{EndTime}}'
+    and tx_hash not in (
         select evt_tx_hash
         from gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Interaction
         where evt_block_time between '{{StartTime}}' and '{{EndTime}}'
@@ -30,17 +29,17 @@ no_interactions as (
 
 batch_interaction_counts as (
     select
-        s.evt_tx_hash,
+        tx_hash,
         count(*) as num_interactions,
         sum(case when risk_free = true then 1 else 0 end) as risk_free
-    from gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Settlement s
+    from cow_protocol_ethereum.batches b
     inner join gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Interaction i
-        on s.evt_tx_hash = i.evt_tx_hash
+        on tx_hash = i.evt_tx_hash
     inner join interactions i2
         on i.selector = i2.selector
         and i.target = i2.target
-    where s.evt_block_time between '{{StartTime}}' and '{{EndTime}}'
-    group by s.evt_tx_hash
+    where b.block_time between '{{StartTime}}' and '{{EndTime}}'
+    group by tx_hash
 ),
 
 combined_results as (
@@ -49,4 +48,4 @@ combined_results as (
     select *, 0 as num_interactions, 0 as risk_free from no_interactions
 )
 
-select evt_tx_hash as tx_hash from combined_results
+select tx_hash from combined_results

--- a/queries/dune_v2/trade_counts.sql
+++ b/queries/dune_v2/trade_counts.sql
@@ -1,9 +1,8 @@
--- V2 Query: https://dune.com/queries/1393633?d=1
-select solver,
-       count(*) as num_trades
-from gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Trade t
-         join gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Settlement s
-              on t.evt_tx_hash = s.evt_tx_hash
-where t.evt_block_number between {{start_block}} and {{end_block}}
+-- V2 Query: https://dune.com/queries/1785586
+select
+    solver_address as solver,
+    sum(num_trades) as num_trades
+from cow_protocol_ethereum.batches
+where block_number between {{start_block}} and {{end_block}}
 group by solver
 order by num_trades desc, solver

--- a/src/queries.py
+++ b/src/queries.py
@@ -59,7 +59,7 @@ QUERIES = {
     "TRADE_COUNT": QueryData(
         name="Trade Counts",
         v1_id=1393627,
-        v2_id=1393633,
+        v2_id=1785586,
         filepath="dune_trade_counts.sql",
     ),
     "PERIOD_BLOCK_INTERVAL": QueryData(
@@ -72,7 +72,7 @@ QUERIES = {
         name="Risk Free Batches",
         filepath="risk_free_batches.sql",
         v1_id=1432733,
-        v2_id=1541507,
+        v2_id=1788450,
     ),
     "VOUCH_REGISTRY": QueryData(
         name="Vouch Registry",


### PR DESCRIPTION
In preparation for an upcoming change to solver identification via Trampoline Contracts - more context [here](https://cowservices.slack.com/archives/C0361CCTFD5/p1671539606008549) we adapt our (V2) queries to use the batches table instead of raw settlement events (since `evt_Settlement.solver` will soon contain invalid data). The batches will be adapted to compute the solver based on other ethereum events.

There are no logical changes here (however the risk free batches does now yield slightly different results). This is because our batches table ignores all settlements with no trades -- these settlements are generally for fee withdrawals and approvals and are not included in solver rewards anyway.

