### PR TITLE
Update Risk Free Batches Query

### DIFF
--- a/src/queries.py
+++ b/src/queries.py
@@ -72,7 +72,7 @@ QUERIES = {
         name="Risk Free Batches",
         filepath="risk_free_batches.sql",
         v1_id=1432733,
-        v2_id=1788450,
+        v2_id=1788438,
     ),
     "VOUCH_REGISTRY": QueryData(
         name="Vouch Registry",


### PR DESCRIPTION
Somehow #164 changed the Risk free batches query ID was replaced with a fork "V2: No Trade Batches". 

This is the right query ID.