### PR TITLE
[HOTFIX] Overflow Bug on ETH Spent Query.

### DIFF
--- a/queries/dune_v2/eth_spent.sql
+++ b/queries/dune_v2/eth_spent.sql
@@ -1,7 +1,7 @@
 -- V2: https://dune.com/queries/1320174
 select
-    solver_address                                            as receiver,
-    cast(sum(gas_price * gas_used) as decimal(38, 0))::string as amount,
+    solver_address                                                                         as receiver,
+    cast(sum((gas_price * gas_used) / pow(10, 18)) * pow(10,18) as decimal(38, 0))::string as amount,
     count(*) as num_transactions
 from cow_protocol_ethereum.batches
     join cow_protocol_ethereum.solvers

--- a/queries/dune_v2/period_totals.sql
+++ b/queries/dune_v2/period_totals.sql
@@ -3,7 +3,7 @@ with
 execution_costs as (
     SELECT
         success,
-        sum((gas_used * gas_price)/ pow(10, 18)) as gas_cost_eth
+        sum((gas_price * gas_used) / pow(10, 18)) as gas_cost_eth
     FROM ethereum.transactions as tx
     where block_time between '{{StartTime}}' and '{{EndTime}}'
     AND position('0x13d79a0b' in data) > 0 --! settle method ID


### PR DESCRIPTION
We saw overflow causing negative valuation of ETH spent for one of our solvers today. This updates the query to eliminate overflow. 


Test Plan:

ETH spent now agrees on both 
-- V1: https://dune.com/queries/1320169?StartTime_d83555=2022-12-27+00%3A00%3A00&EndTime_d83555=2023-01-03+00%3A00%3A00
and 
-- V2: https://dune.com/queries/1320174?StartTime_d83555=2022-12-27+00%3A00%3A00&EndTime_d83555=2023-01-03+00%3A00%3A00


for this the accounting period Dec27 to Jan3.