### PR TITLE
Simplify SplitTransfer.process Tests

### DIFF
--- a/tests/unit/test_split_transfer.py
+++ b/tests/unit/test_split_transfer.py
@@ -19,7 +19,7 @@ class TestSplitTransfers(unittest.TestCase):
     def setUp(self) -> None:
         self.period = AccountingPeriod("2022-06-14")
         self.solver = Address("0xde786877a10dbb7eba25a4da65aecf47654f08ab")
-        self.solver_name = "barn-0x"
+        self.solver_name = "solver_0"
         self.redirect_map = {
             self.solver: Vouch(
                 solver=self.solver,
@@ -235,13 +235,15 @@ class TestSplitTransfers(unittest.TestCase):
         )
         self.assertEqual(
             accounting.cow_transfers,
-            Transfer(
-                token=self.cow_token,
-                receiver=self.redirect_map[self.solver].reward_target,
-                # This is the amount of COW deducted based on a "deterministic" price
-                # on the date of the fixed accounting period.
-                amount_wei=cow_reward - 11549056229718590750720,
-            ),
+            [
+                Transfer(
+                    token=self.cow_token,
+                    receiver=self.redirect_map[self.solver].reward_target,
+                    # This is the amount of COW deducted based on a "deterministic" price
+                    # on the date of the fixed accounting period.
+                    amount_wei=cow_reward - 11549056229718590750720,
+                )
+            ],
         )
         self.assertEqual(accounting.unprocessed_cow, [])
         self.assertEqual(accounting.unprocessed_native, [])

--- a/tests/unit/test_split_transfer.py
+++ b/tests/unit/test_split_transfer.py
@@ -4,6 +4,7 @@ from dune_client.types import Address
 
 from src.constants import COW_TOKEN_ADDRESS
 from src.models.accounting_period import AccountingPeriod
+from src.models.overdraft import Overdraft
 from src.models.slippage import SolverSlippage, SplitSlippages
 from src.models.split_transfers import SplitTransfers
 from src.models.token import Token
@@ -15,11 +16,26 @@ ONE_ETH = 10**18
 
 
 class TestSplitTransfers(unittest.TestCase):
-    def construct_split_transfers(
+    def setUp(self) -> None:
+        self.period = AccountingPeriod("2022-06-14")
+        self.solver = Address("0xde786877a10dbb7eba25a4da65aecf47654f08ab")
+        self.solver_name = "barn-0x"
+        self.redirect_map = {
+            self.solver: Vouch(
+                solver=self.solver,
+                reward_target=Address.from_int(2),
+                bonding_pool=Address.from_int(3),
+            )
+        }
+        self.cow_token = Token(COW_TOKEN_ADDRESS)
+
+    def construct_split_transfers_and_process(
         self,
         solvers: list[Address],
         eth_amounts: list[int],
         cow_rewards: list[int],
+        slippage_amounts: list[int],
+        redirects: dict[Address, Vouch],
     ) -> SplitTransfers:
         eth_transfers = [
             Transfer(
@@ -35,17 +51,25 @@ class TestSplitTransfers(unittest.TestCase):
             )
             for i in range(len(solvers))
         ]
-        return SplitTransfers(
+        accounting = SplitTransfers(
             self.period,
             mixed_transfers=eth_transfers + cow_transfers,
             log_saver=PrintStore(),
         )
-
-    def setUp(self) -> None:
-        self.period = AccountingPeriod("2022-06-14")
-        self.solver = Address("0xde786877a10dbb7eba25a4da65aecf47654f08ab")
-        self.solver_name = "barn-0x"
-        self.cow_token = Token(COW_TOKEN_ADDRESS)
+        accounting.process(
+            slippages=SplitSlippages.from_data_set(
+                [
+                    {
+                        "eth_slippage_wei": slippage_amounts[i],
+                        "solver_address": solvers[i].address,
+                        "solver_name": f"solver_{i}",
+                    }
+                    for i in range(len(solvers))
+                ]
+            ),
+            cow_redirects=redirects,
+        )
+        return accounting
 
     def test_process_native_transfers(self):
         amount_of_transfer = 185360274773133130
@@ -115,85 +139,32 @@ class TestSplitTransfers(unittest.TestCase):
             ],
         )
 
-    def test_full_process(self):
-        """
-        This scenario involves two solvers, one with positive and one with negative slippage.
-        The negative slippage does not involve any overdraft!
-        All amounts (execution costs, cow rewards and slippage) are declared at the top of the test.
-        The expected outcome is
-        - 3 ETH transfers:
-            - 2 for execution costs with one having negative slippage deducted.
-            - 1 for positive slippage (redirected to the reward target)
-        - 2 COW transfers (one for each solver).
-        """
-        solvers = [
-            Address.from_int(1),
-            Address.from_int(2),
-        ]
-        eth_amounts = [
-            2 * ONE_ETH,
-            3 * ONE_ETH,
-        ]
-        cow_rewards = [
-            600 * ONE_ETH,
-            100 * ONE_ETH,
-        ]
-        slippage_amounts = [
-            1 * ONE_ETH,
-            -1 * ONE_ETH,
-        ]
-
-        redirect_map = {
-            solvers[0]: Vouch(
-                solver=solvers[0],
-                reward_target=Address.from_int(3),
-                bonding_pool=Address.zero(),
-            ),
-            solvers[1]: Vouch(
-                solver=solvers[1],
-                reward_target=Address.from_int(4),
-                bonding_pool=Address.zero(),
-            ),
-        }
-        accounting = self.construct_split_transfers(solvers, eth_amounts, cow_rewards)
-
-        accounting.process(
-            slippages=SplitSlippages.from_data_set(
-                [
-                    {
-                        "eth_slippage_wei": slippage_amounts[0],
-                        "solver_address": solvers[0].address,
-                        "solver_name": "irrelevant1",
-                    },
-                    {
-                        "eth_slippage_wei": slippage_amounts[1],
-                        "solver_address": solvers[1].address,
-                        "solver_name": "irrelevant2",
-                    },
-                ]
-            ),
-            cow_redirects=redirect_map,
+    def test_full_process_with_positive_slippage(self):
+        eth_amount = 2 * ONE_ETH
+        cow_reward = 600 * ONE_ETH
+        slippage_amount = 1 * ONE_ETH
+        accounting = self.construct_split_transfers_and_process(
+            solvers=[self.solver],
+            eth_amounts=[eth_amount],
+            cow_rewards=[cow_reward],
+            slippage_amounts=[slippage_amount],
+            redirects=self.redirect_map,
         )
 
         self.assertEqual(
             accounting.eth_transfers,
             [
+                # The ETH Spent
                 Transfer(
                     token=None,
-                    receiver=solvers[0],
-                    amount_wei=eth_amounts[0],
+                    receiver=self.solver,
+                    amount_wei=eth_amount,
                 ),
+                # The redirected positive slippage
                 Transfer(
                     token=None,
-                    receiver=solvers[1],
-                    # Slippage is negative (so it is added here)
-                    amount_wei=eth_amounts[1] + slippage_amounts[1],
-                ),
-                Transfer(
-                    token=None,
-                    # The solver with positive slippage!
-                    receiver=redirect_map[solvers[0]].reward_target,
-                    amount_wei=slippage_amounts[0],
+                    receiver=self.redirect_map[self.solver].reward_target,
+                    amount_wei=slippage_amount,
                 ),
             ],
         )
@@ -202,70 +173,24 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 Transfer(
                     token=self.cow_token,
-                    receiver=redirect_map[solvers[0]].reward_target,
-                    amount_wei=cow_rewards[0],
-                ),
-                Transfer(
-                    token=self.cow_token,
-                    receiver=redirect_map[solvers[1]].reward_target,
-                    amount_wei=cow_rewards[1],
+                    receiver=self.redirect_map[self.solver].reward_target,
+                    amount_wei=cow_reward,
                 ),
             ],
         )
         self.assertEqual(accounting.unprocessed_cow, [])
         self.assertEqual(accounting.unprocessed_native, [])
 
-    def test_full_process_with_overdraft(self):
-        """
-        This scenario involves three solvers - all with some form of overdraft.
-            1. Overdraft not exceeding ETH reimbursement
-            2. Overdraft exceeding ETH reimbursement, but not COW
-            3. Overdraft exceeding both.
-        All amounts (execution costs, cow rewards and slippage) are declared at the top of the test.
-        The expected outcome is
-        - 1 ETH transfer: Only for the solver whose slippage does not exceed ETH.
-        - 2 COW transfers (one for each solver whose slippage does not exceed ETH and COW).
-        """
-        n = 3
-        solvers = [Address.from_int(i) for i in range(n)]
-        eth_amounts = [
-            1 * ONE_ETH,
-            2 * ONE_ETH,
-            3 * ONE_ETH,
-        ]
-        cow_rewards = [
-            1000 * ONE_ETH,
-            100_000 * ONE_ETH,  # This is huge so COW is not exceeded!
-            3000 * ONE_ETH,
-        ]
-        slippage_amounts = [
-            -3 * ONE_ETH,  # Exceeding both ETH and COW
-            -3 * ONE_ETH,  # Exceeding only ETH
-            -1 * ONE_ETH,  # Not Exceeding ETH
-        ]
-
-        redirect_map = {
-            solvers[i]: Vouch(
-                solver=solvers[i],
-                reward_target=Address.from_int(n + i),
-                bonding_pool=Address.zero(),
-            )
-            for i in range(n)
-        }
-        accounting = self.construct_split_transfers(solvers, eth_amounts, cow_rewards)
-
-        accounting.process(
-            slippages=SplitSlippages.from_data_set(
-                [
-                    {
-                        "eth_slippage_wei": slippage_amounts[i],
-                        "solver_address": solvers[i].address,
-                        "solver_name": "irrelevant",
-                    }
-                    for i in range(n)
-                ]
-            ),
-            cow_redirects=redirect_map,
+    def test_process_with_negative_slippage_not_exceeding_eth(self):
+        eth_amount = 2 * ONE_ETH
+        cow_reward = 600 * ONE_ETH
+        slippage_amount = -1 * ONE_ETH
+        accounting = self.construct_split_transfers_and_process(
+            solvers=[self.solver],
+            eth_amounts=[eth_amount],
+            cow_rewards=[cow_reward],
+            slippage_amounts=[slippage_amount],
+            redirects=self.redirect_map,
         )
 
         self.assertEqual(
@@ -273,8 +198,9 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 Transfer(
                     token=None,
-                    receiver=solvers[2],
-                    amount_wei=eth_amounts[2] + slippage_amounts[2],
+                    receiver=self.solver,
+                    # Slippage is negative (so it is added here)
+                    amount_wei=eth_amount + slippage_amount,
                 ),
             ],
         )
@@ -283,17 +209,69 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 Transfer(
                     token=self.cow_token,
-                    receiver=redirect_map[solvers[1]].reward_target,
-                    # This is the amount of COW deducted based on a "deterministic" price
-                    # on the date of the fixed accounting period.
-                    amount_wei=cow_rewards[1] - 11549056229718590750720,
-                ),
-                Transfer(
-                    token=self.cow_token,
-                    receiver=redirect_map[solvers[2]].reward_target,
-                    amount_wei=cow_rewards[2],
+                    receiver=self.redirect_map[self.solver].reward_target,
+                    amount_wei=cow_reward,
                 ),
             ],
+        )
+        self.assertEqual(accounting.unprocessed_cow, [])
+        self.assertEqual(accounting.unprocessed_native, [])
+
+    def test_process_with_overdraft_exceeding_eth_not_cow(self):
+        eth_amount = 2 * ONE_ETH
+        cow_reward = 100_000 * ONE_ETH  # This is huge so COW is not exceeded!
+        slippage_amount = -3 * ONE_ETH
+        accounting = self.construct_split_transfers_and_process(
+            solvers=[self.solver],
+            eth_amounts=[eth_amount],
+            cow_rewards=[cow_reward],
+            slippage_amounts=[slippage_amount],
+            redirects=self.redirect_map,
+        )
+        self.assertEqual(
+            accounting.eth_transfers,
+            [],
+            "No ETH reimbursement! when slippage exceeds eth_spent",
+        )
+        self.assertEqual(
+            accounting.cow_transfers,
+            Transfer(
+                token=self.cow_token,
+                receiver=self.redirect_map[self.solver].reward_target,
+                # This is the amount of COW deducted based on a "deterministic" price
+                # on the date of the fixed accounting period.
+                amount_wei=cow_reward - 11549056229718590750720,
+            ),
+        )
+        self.assertEqual(accounting.unprocessed_cow, [])
+        self.assertEqual(accounting.unprocessed_native, [])
+
+    def test_process_with_overdraft_exceeding_both_eth_and_cow(self):
+        eth_amount = 1 * ONE_ETH
+        cow_reward = 1000 * ONE_ETH
+        slippage_amount = -3 * ONE_ETH
+
+        accounting = self.construct_split_transfers_and_process(
+            solvers=[self.solver],
+            eth_amounts=[eth_amount],
+            cow_rewards=[cow_reward],
+            slippage_amounts=[slippage_amount],
+            redirects=self.redirect_map,
+        )
+        # Solver get no ETH reimbursement and no COW tokens
+        self.assertEqual(accounting.eth_transfers, [])
+        self.assertEqual(accounting.cow_transfers, [])
+        # Additional overdraft appended to overdrafts.
+        self.assertEqual(
+            accounting.overdrafts,
+            {
+                self.solver: Overdraft(
+                    period=self.period,
+                    account=self.solver,
+                    name=self.solver_name,
+                    wei=1913412838234630144,
+                )
+            },
         )
         self.assertEqual(accounting.unprocessed_cow, [])
         self.assertEqual(accounting.unprocessed_native, [])


### PR DESCRIPTION
Closes #170

We separate two large (logically complex) unit tests into four entirely independent tests. This way if one breaks, we know exactly where!