### PR TITLE
[Easy] Improved Logging & Alerting

### DIFF
--- a/src/models/split_transfers.py
+++ b/src/models/split_transfers.py
@@ -156,7 +156,7 @@ class SplitTransfers:
             )
         )
         self.log_saver.print(
-            f"Total Negative Slippage (ETH): {total_penalty / 10**18}",
+            f"Total Negative Slippage (ETH): {total_penalty / 10**18:.4f}",
             category=Category.TOTALS,
         )
         # Note that positive and negative slippage is DISJOINT.
@@ -166,7 +166,7 @@ class SplitTransfers:
             positive_slippage=slippages.solvers_with_positive_total,
         )
         self.log_saver.print(
-            f"Total Positive Slippage (ETH): {total_positive_slippage / 10**18}",
+            f"Total Positive Slippage (ETH): {total_positive_slippage / 10**18:.4f}",
             category=Category.TOTALS,
         )
         if self.overdrafts:

--- a/src/models/transfer.py
+++ b/src/models/transfer.py
@@ -200,9 +200,10 @@ class Transfer:
             # Redirect COW rewards to reward target specific by VouchRegistry
             redirect_address = redirects[recipient].reward_target
             log_saver.print(
-                f"Redirecting {recipient} Transfer of {self.token or 'ETH'}"
-                f"({self.amount}) to {redirect_address}",
-                category=Category.REDIRECT,
+                f"Redirecting {recipient} Transfer of {self.amount} to {redirect_address}",
+                category=Category.ETH_REDIRECT
+                if self.token is None
+                else Category.COW_REDIRECT,
             )
             self.receiver = redirect_address
 

--- a/src/models/transfer.py
+++ b/src/models/transfer.py
@@ -81,8 +81,8 @@ class Transfer:
             t.amount_wei for t in transfers if t.token_type == TokenType.ERC20
         )
         return (
-            f"Total ETH Funds needed: {eth_total / 10 ** 18}\n"
-            f"Total COW Funds needed: {cow_total / 10 ** 18}\n"
+            f"Total ETH Funds needed: {eth_total / 10 ** 18:.4f}\n"
+            f"Total COW Funds needed: {cow_total / 10 ** 18:.4f}\n"
         )
 
     @staticmethod

--- a/src/slack.py
+++ b/src/slack.py
@@ -1,0 +1,31 @@
+"""
+Basic Slack Post functionality. Sends a message thread to a specified channel.
+"""
+from slack.web.client import WebClient
+from slack.web.slack_response import SlackResponse
+
+
+def post_to_slack(
+    slack_client: WebClient, channel: str, message: str, sub_messages: dict[str, str]
+) -> None:
+    """Posts message to Slack channel and sub message inside thread of first message"""
+    response = slack_client.chat_postMessage(
+        channel=channel,
+        text=message,
+        # Do not show link preview!
+        # https://api.slack.com/reference/messaging/link-unfurling
+        unfurl_media=False,
+    )
+    # This assertion is only for type safety,
+    # since previous function can also return a Future
+    assert isinstance(response, SlackResponse)
+    # Post logs in thread.
+    for category, log in sub_messages.items():
+        slack_client.chat_postMessage(
+            channel=channel,
+            format="mrkdwn",
+            text=f"{category}:\n```{log}```",
+            # According to https://api.slack.com/methods/conversations.replies
+            thread_ts=response.get("ts"),
+            unfurl_media=False,
+        )

--- a/src/utils/print_store.py
+++ b/src/utils/print_store.py
@@ -12,8 +12,8 @@ class Category(Enum):
     TOTALS = "Totals"
     OVERDRAFT = "Overdraft"
     COW_REDIRECT = "COW Redirects"
-    ETH_REDIRECT = "ETH Redirects"
-    SLIPPAGE = "Slippage"
+    ETH_REDIRECT = "ETH Redirects (Positive Slippage)"
+    SLIPPAGE = "Negative Slippage"
 
 
 class PrintStore:

--- a/src/utils/print_store.py
+++ b/src/utils/print_store.py
@@ -8,10 +8,11 @@ from enum import Enum
 class Category(Enum):
     """Known Categories for PrintStore"""
 
-    GENERAL = ""
+    GENERAL = "Overview"
     TOTALS = "Totals"
     OVERDRAFT = "Overdraft"
-    REDIRECT = "Redirect"
+    COW_REDIRECT = "COW Redirects"
+    ETH_REDIRECT = "ETH Redirects"
     SLIPPAGE = "Slippage"
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -345,6 +345,25 @@ class TestTransfer(unittest.TestCase):
             ),
         )
 
+    def test_summarize(self):
+        receiver = Address.from_int(1)
+        eth_amount = 123456789101112131415
+        cow_amount = 9999999999999999999999999
+        result = Transfer.summarize(
+            [
+                Transfer(token=None, receiver=receiver, amount_wei=eth_amount),
+                Transfer(
+                    token=Token(COW_TOKEN_ADDRESS),
+                    receiver=receiver,
+                    amount_wei=cow_amount,
+                ),
+            ]
+        )
+        self.assertEqual(
+            result,
+            "Total ETH Funds needed: 123.4568\nTotal COW Funds needed: 10000000.0000\n",
+        )
+
 
 class TestAccountingPeriod(unittest.TestCase):
     def test_str(self):


### PR DESCRIPTION
Based on @nlordell's [request](https://cowservices.slack.com/archives/C037UV49JLR/p1674551800569239?thread_ts=1674547627.130809&cid=C037UV49JLR) we implement a few improvements to the slack alerts:

1. Redirects are now split into COW and ETH (with ETH Redirects being equivalent to grouped positive slippage). This also fixes the issue that the redirect message was exceeding max character limit for a single slack message and will now fit again into a "code block" (cf attached screenshots)

**Before:**
<img width="486" alt="Screenshot 2023-01-25 at 11 44 29" src="https://user-images.githubusercontent.com/11778116/214543422-2e409e51-8389-487b-b673-0e00a1b8e427.png">

**After:** over 2 messages
COW Redirects:
```
0x0d2584DA2F637805071f184bCFa1268eBAe8a24A Transfer of 264.44358475189256 to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
...
```

ETH Redirects (Positive Slippage)
```
0xc9ec550BEA1C64D779124b23A26292cc223327b6 Transfer of 0.4742918273436085 to 0x84dbAE2549d67CaF00f65C355de3D6F4df59A32C
```

2. We now include both the +ve and -ve totals in the "Totals" summary

**Before:**
<img width="385" alt="Screenshot 2023-01-25 at 11 47 11" src="https://user-images.githubusercontent.com/11778116/214543846-8579ce74-8c76-4381-9b3e-a48243f38eb4.png">

**After:**
Totals:
```
Total Negative Slippage (ETH): -1.7193303904176696
Total Positive Slippage (ETH): XYZ
Total ETH Funds needed: 58.37305114145994
Total COW Funds needed: 394872.2244091329
```

3. A couple of other cosmetic changes have been made.