### PR TITLE
Add initial DB migration scripting

### DIFF
--- a/internal_transfers/database/.env.sample
+++ b/internal_transfers/database/.env.sample
@@ -1,0 +1,5 @@
+# Internalized Transfers DB
+POSTGRES_URL=
+POSTGRES_DB=postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=

--- a/internal_transfers/database/.env.sample
+++ b/internal_transfers/database/.env.sample
@@ -1,5 +1,5 @@
 # Internalized Transfers DB
-POSTGRES_URL=
+POSTGRES_HOST=localhost
 POSTGRES_DB=postgres
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=
+POSTGRES_PASSWORD=postgress

--- a/internal_transfers/database/.env.sample
+++ b/internal_transfers/database/.env.sample
@@ -2,4 +2,4 @@
 POSTGRES_HOST=localhost
 POSTGRES_DB=postgres
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgress
+POSTGRES_PASSWORD=postgres

--- a/internal_transfers/database/Dockerfile
+++ b/internal_transfers/database/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.io/flyway/flyway:7.5.3
+
+COPY ./sql sql/

--- a/internal_transfers/database/README.md
+++ b/internal_transfers/database/README.md
@@ -1,12 +1,5 @@
 The system stores all data in a postgres database.
 This repo contains the docker image and the flyway migrations to run the database.
-Prepare your environment (Database credentials)
-
-```shell
-cp .env.sample .env
-# populate .env with relevant fields
-source .env
-```
 
 ## [Optional] Empty Local Instance of Postgres
 
@@ -16,13 +9,22 @@ docker run -e POSTGRES_PASSWORD=password -p 5432:5432 docker.io/postgres
 
 ## Perform Migration
 
-```sh
+Prepare your environment (Database credentials)
+
+```shell
 cd internal_transfers/database
+cp .env.sample .env
+# populate .env with relevant fields
 source .env
+```
+
+Now, assuming environment variables are in place:
+
+```sh
 docker build --tag migration-image .
-# REMOTE DB
+# Remote DB Instance
 docker run --add-host=host.docker.internal:host-gateway --rm migration-image -url=jdbc:postgresql://$POSTGRES_HOST/$POSTGRES_DB -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD migrate
-# Local Instance DB (from above)
+# Local DB Instance (from above)
 docker run --network host --add-host=localhost:host-gateway --rm migration-image -url=jdbc:postgresql://$POSTGRES_HOST/$POSTGRES_DB -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD migrate
 ```
 

--- a/internal_transfers/database/README.md
+++ b/internal_transfers/database/README.md
@@ -11,7 +11,7 @@ source .env
 ## [Optional] Empty Local Instance of Postgres
 
 ```sh
-docker run -d --env-file .env -p 5432:5432 docker.io/postgres
+docker run -e POSTGRES_PASSWORD=password -p 5432:5432 docker.io/postgres
 ```
 
 ## Perform Migration
@@ -20,12 +20,22 @@ docker run -d --env-file .env -p 5432:5432 docker.io/postgres
 cd internal_transfers/database
 source .env
 docker build --tag migration-image .
-docker run --add-host=host.docker.internal:host-gateway --rm migration-image -url=jdbc:postgresql://$POSTGRES_URL/$POSTGRES_DB -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD migrate
+# REMOTE DB
+docker run --add-host=host.docker.internal:host-gateway --rm migration-image -url=jdbc:postgresql://$POSTGRES_HOST/$POSTGRES_DB -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD migrate
+# Local Instance DB (from above)
+docker run --network host --add-host=localhost:host-gateway --rm migration-image -url=jdbc:postgresql://$POSTGRES_HOST/$POSTGRES_DB -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD migrate
 ```
 
 ### Troubleshooting
+
 * In case you run into `java.net.UnknownHostException: host.docker.internal`
-add `--add-host=host.docker.internal:host-gateway` right after `docker run`.
+  add `--add-host=host.docker.internal:host-gateway` right after `docker run`.
 
 * If you're combining a local postgres installation with docker flyway you have to add to the above `--network host` and
-change `host.docker.internal` to `localhost`.
+  change `host.docker.internal` to `localhost`.
+
+So to test migration with optional local DB described above, use:
+
+```shell
+docker run --network host --add-host=localhost:host-gateway --rm migration-image -url=jdbc:postgresql://$POSTGRES_HOST/$POSTGRES_DB -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD migrate
+```

--- a/internal_transfers/database/README.md
+++ b/internal_transfers/database/README.md
@@ -4,7 +4,7 @@ This repo contains the docker image and the flyway migrations to run the databas
 ## [Optional] Empty Local Instance of Postgres
 
 ```sh
-docker run -e POSTGRES_PASSWORD=password -p 5432:5432 docker.io/postgres
+docker run -e POSTGRES_PASSWORD=postgres -p 5432:5432 docker.io/postgres
 ```
 
 ## Perform Migration

--- a/internal_transfers/database/README.md
+++ b/internal_transfers/database/README.md
@@ -1,0 +1,31 @@
+The system stores all data in a postgres database.
+This repo contains the docker image and the flyway migrations to run the database.
+Prepare your environment (Database credentials)
+
+```shell
+cp .env.sample .env
+# populate .env with relevant fields
+source .env
+```
+
+## [Optional] Empty Local Instance of Postgres
+
+```sh
+docker run -d --env-file .env -p 5432:5432 docker.io/postgres
+```
+
+## Perform Migration
+
+```sh
+cd internal_transfers/database
+source .env
+docker build --tag migration-image .
+docker run --add-host=host.docker.internal:host-gateway --rm migration-image -url=jdbc:postgresql://$POSTGRES_URL/$POSTGRES_DB -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD migrate
+```
+
+### Troubleshooting
+* In case you run into `java.net.UnknownHostException: host.docker.internal`
+add `--add-host=host.docker.internal:host-gateway` right after `docker run`.
+
+* If you're combining a local postgres installation with docker flyway you have to add to the above `--network host` and
+change `host.docker.internal` to `localhost`.

--- a/internal_transfers/database/sql/V001__create_settlements.sql
+++ b/internal_transfers/database/sql/V001__create_settlements.sql
@@ -1,5 +1,11 @@
-create table settlements (
-  tx_hash bytea NOT NULL,
+CREATE TABLE settlements
+(
   block_number bigint NOT NULL,
-  solver bytea NOT NULL
+  log_index    bigint NOT NULL,
+  solver       bytea  NOT NULL,
+  tx_hash      bytea  NOT NULL,
+
+  PRIMARY KEY (block_number, log_index)
 );
+
+CREATE INDEX settlements_idx ON settlements (tx_hash);

--- a/internal_transfers/database/sql/V001__create_settlements.sql
+++ b/internal_transfers/database/sql/V001__create_settlements.sql
@@ -1,0 +1,5 @@
+create table settlements (
+  tx_hash bytea NOT NULL,
+  block_number bigint NOT NULL,
+  solver bytea NOT NULL
+);


### PR DESCRIPTION
Credentials are in [1Password](https://start.1password.com/open/i?a=6DWD777JFFEZZLYS6J4DUURYLE&v=weisopuq6vd4jkgfi443z2fe64&i=wa35pbskw4i6vhtvwqwukihajm&h=my.1password.com) where migration has already been applied (don't mess with it too much). Rather try the (optional) local setup provided in README.

You should expect to see logs like:

```
Flyway Community Edition 7.5.3 by Redgate
Database: jdbc:postgresql://${POSTGRES_HOST}/${POSTGRES_USER} (PostgreSQL 13.7)
Successfully validated 1 migration (execution time 00:00.105s)
Creating Schema History table "public"."flyway_schema_history" ...
Current version of schema "public": << Empty Schema >>
Migrating schema "public" to version "001 - create settlements"
Successfully applied 1 migration to schema "public" (execution time 00:00.609s)
```

and then an empty table `select * from settlements`.


# Test Plan

Follow the README.md file introduced here (using the optional local setup).

