### PR TITLE
[Easy] fix subtle difference in (non-deterministic) test

### DIFF
--- a/src/fetch/prices.py
+++ b/src/fetch/prices.py
@@ -84,4 +84,6 @@ def usd_price(token: TokenId, day: datetime) -> float:
     item = response_list[0]
     price_time = datetime.strptime(item["timestamp"], "%Y-%m-%dT00:00:00Z")
     assert price_time == day
-    return float(item["price"])
+    result = float(item["price"])
+    log.info(f"got price {result}")
+    return result

--- a/tests/unit/test_split_transfer.py
+++ b/tests/unit/test_split_transfer.py
@@ -11,19 +11,13 @@ from src.models.token import Token
 from src.models.transfer import Transfer
 from src.models.vouch import Vouch
 from src.utils.print_store import PrintStore
-from src.fetch.prices import usd_price, TokenId
 from unittest.mock import MagicMock
 
 ONE_ETH = 10**18
 
-
-def my_side_effect(
-    token_id: TokenId,
-):
-    if token_id == TokenId.COW:
-        return 0.095696
-    elif token_id == TokenId.ETH:
-        return 1105.43
+# TODO - these tests aren't entirely deterministic because they make requests to CoinPaprika API for COW and ETH prices.
+#  We should be able to mock the return values of price fetching:
+#  cf https://github.com/cowprotocol/solver-rewards/pull/179
 
 
 class TestSplitTransfers(unittest.TestCase):

--- a/tests/unit/test_split_transfer.py
+++ b/tests/unit/test_split_transfer.py
@@ -11,8 +11,19 @@ from src.models.token import Token
 from src.models.transfer import Transfer
 from src.models.vouch import Vouch
 from src.utils.print_store import PrintStore
+from src.fetch.prices import usd_price, TokenId
+from unittest.mock import MagicMock
 
 ONE_ETH = 10**18
+
+
+def my_side_effect(
+    token_id: TokenId,
+):
+    if token_id == TokenId.COW:
+        return 0.095696
+    elif token_id == TokenId.ETH:
+        return 1105.43
 
 
 class TestSplitTransfers(unittest.TestCase):
@@ -27,6 +38,7 @@ class TestSplitTransfers(unittest.TestCase):
                 bonding_pool=Address.from_int(3),
             )
         }
+        usd_price = MagicMock(return_value=10)
         self.cow_token = Token(COW_TOKEN_ADDRESS)
 
     def construct_split_transfers_and_process(
@@ -241,7 +253,7 @@ class TestSplitTransfers(unittest.TestCase):
                     receiver=self.redirect_map[self.solver].reward_target,
                     # This is the amount of COW deducted based on a "deterministic" price
                     # on the date of the fixed accounting period.
-                    amount_wei=cow_reward - 11549056229718590750720,
+                    amount_wei=cow_reward - 11528681622554420445184,
                 )
             ],
         )
@@ -271,7 +283,7 @@ class TestSplitTransfers(unittest.TestCase):
                     period=self.period,
                     account=self.solver,
                     name=self.solver_name,
-                    wei=1913412838234630144,
+                    wei=1913259812982984448,
                 )
             },
         )

--- a/tests/unit/test_split_transfer.py
+++ b/tests/unit/test_split_transfer.py
@@ -11,7 +11,6 @@ from src.models.token import Token
 from src.models.transfer import Transfer
 from src.models.vouch import Vouch
 from src.utils.print_store import PrintStore
-from unittest.mock import MagicMock
 
 ONE_ETH = 10**18
 
@@ -32,7 +31,6 @@ class TestSplitTransfers(unittest.TestCase):
                 bonding_pool=Address.from_int(3),
             )
         }
-        usd_price = MagicMock(return_value=10)
         self.cow_token = Token(COW_TOKEN_ADDRESS)
 
     def construct_split_transfers_and_process(


### PR DESCRIPTION
Looks like CoinPaprika has changed some historical price data for WETH and COW (maybe more).

I made these two Dune queries showing mean and median prices from Dune on that day (assuming Dune has not yet replaced all their historical values).

[V2 Query](https://dune.com/queries/1955101)
[V1 Query](https://dune.com/queries/1955075)

<img width="597" alt="Screenshot 2023-02-02 at 10 06 12" src="https://user-images.githubusercontent.com/11778116/216279696-40094826-87d4-4be8-b721-1ee41ca04e04.png">

What we now see returned from Coin Paprika API:
```
INFO prices requesting price for token=eth-ethereum, day=2022-06-20
INFO prices got price 1108.99
INFO prices requesting price for token=cow-cow-protocol-token, day=2022-06-20
INFO prices got price 0.096194
```


I wanted to mock the USD price feed but it would be a much bigger change that I don't have time for. Will include an issue