### PR TITLE
[HotFix] Add missing ETH transfers to slippage

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,7 +1,8 @@
 -- https://github.com/cowprotocol/solver-rewards/pull/169
 with
-filtered_trades as (
+batch_meta as (
     select t.block_time,
+           t.block_number,
            t.tx_hash,
            case
             when dex_swaps = 0
@@ -10,7 +11,19 @@ filtered_trades as (
                 else dex_swaps
            end as dex_swaps,
            num_trades,
-           b.solver_address,
+           b.solver_address
+    from cow_protocol_ethereum.trades t
+    join cow_protocol_ethereum.batches b
+        on t.block_number = b.block_number
+        and t.tx_hash = b.tx_hash
+    where b.block_time between '{{StartTime}}' and '{{EndTime}}'
+    and t.block_time between '{{StartTime}}' and '{{EndTime}}'
+    and (b.solver_address = lower('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
+    and (t.tx_hash = lower('{{TxHash}}') or '{{TxHash}}' = '0x')
+),
+filtered_trades as (
+    select t.tx_hash,
+           t.block_number,
            trader                                       as trader_in,
            receiver                                     as trader_out,
            sell_token_address                           as sell_token,
@@ -33,18 +46,14 @@ filtered_trades as (
 batchwise_traders as (
     select
         tx_hash,
+        block_number,
         collect_set(trader_in) as traders_in,
         collect_set(trader_out) as traders_out
     from filtered_trades
-    group by tx_hash
+    group by tx_hash, block_number
 ),
-
 user_in as (
-    select block_time,
-          tx_hash,
-          dex_swaps,
-          num_trades,
-          solver_address,
+    select  tx_hash,
           trader_in        as sender,
           contract_address as receiver,
           sell_token       as token,
@@ -53,11 +62,7 @@ user_in as (
     from filtered_trades
 ),
 user_out as (
-    select block_time,
-          tx_hash,
-          dex_swaps,
-          num_trades,
-          solver_address,
+    select tx_hash,
           contract_address as sender,
           trader_out       as receiver,
           buy_token        as token,
@@ -66,16 +71,7 @@ user_out as (
     from filtered_trades
 ),
 other_transfers as (
-    select block_time,
-          b.tx_hash,
-          case
-            when dex_swaps = 0
-            -- Estimation made here: https://dune.com/queries/1646084
-                then ((gas_used - 73688 - (70528 * num_trades)) / 90000)::int
-                else dex_swaps
-        end as dex_swaps,
-          num_trades,
-          solver_address,
+    select b.tx_hash,
           from               as sender,
           to                 as receiver,
           t.contract_address as token,
@@ -103,12 +99,51 @@ other_transfers as (
       and (t.evt_tx_hash = lower('{{TxHash}}') or '{{TxHash}}' = '0x')
       and (solver_address = lower('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
 ),
-batch_transfers as (
+eth_transfers as (
+    select
+        bt.tx_hash,
+        from as sender,
+        to as receiver,
+        '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' as token,
+        cast(value as decimal(38, 0)) as amount_wei,
+        'Native ETH' as transfer_type
+    from batchwise_traders bt
+    inner join ethereum.traces et
+        on bt.block_number = et.block_number
+        and bt.tx_hash = et.tx_hash
+        and cast(value as decimal(38, 0)) > 0
+        and success = true
+    and '0x9008d19f58aabd9ed0d60971565aa8510560ab41' in (to, from)
+    -- WETH unwraps don't have cancelling WETH transfer.
+    and from != '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+    -- ETH transfers to traders are already part of USER_OUT
+    and not array_contains(traders_out, to)
+),
+pre_batch_transfers as (
     select * from user_in
     union all
     select * from user_out
     union all
     select * from other_transfers
+    union all
+    select * from eth_transfers
+),
+batch_transfers as (
+    select
+        block_time,
+        block_number,
+        pbt.tx_hash,
+        dex_swaps,
+        num_trades,
+        solver_address,
+        sender,
+        receiver,
+        token,
+        amount_wei,
+        transfer_type
+    from batch_meta bm
+    join pre_batch_transfers pbt
+        on bm.tx_hash = pbt.tx_hash
 ),
 -- These batches involve a token AXS (Old)
 -- whose transfer function doesn't align with the emitted transfer event.

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,4 +1,4 @@
--- https://github.com/cowprotocol/solver-rewards/pull/169
+-- https://github.com/cowprotocol/solver-rewards/pull/180
 with
 batch_meta as (
     select t.block_time,
@@ -106,7 +106,11 @@ eth_transfers as (
         to as receiver,
         '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' as token,
         cast(value as decimal(38, 0)) as amount_wei,
-        'Native ETH' as transfer_type
+        case
+          when '0x9008d19f58aabd9ed0d60971565aa8510560ab41' = to
+          then 'AMM_IN'
+          else 'AMM_OUT'
+        end as transfer_type
     from batchwise_traders bt
     inner join ethereum.traces et
         on bt.block_number = et.block_number

--- a/src/queries.py
+++ b/src/queries.py
@@ -96,6 +96,6 @@ QUERIES = {
         name="Solver Slippage for Period",
         filepath="period_slippage.sql",
         v1_id=1728478,
-        v2_id=1836718,
+        v2_id=1956003,
     ),
 }

--- a/tests/queries/test_slippage_investigation.py
+++ b/tests/queries/test_slippage_investigation.py
@@ -144,39 +144,8 @@ class TestDuneAnalytics(unittest.TestCase):
         Bug was picked up by our Dune Alerts on Feb. 2, 2023
         https://cowservices.slack.com/archives/C03PW4CR38A/p1675328564060139
         """
-        old_query_id = 1836718
-        # For TX: 0x3b2e9675b6d71a34e9b7f4abb4c9e80922be311076fcbb345d7da9d91a05e048
-        old_query_results = self.dune.get_result(job_id="01GRA17C0WFB27W0TC5TZ7BFP1")
-        self.assertEqual(old_query_results.query_id, old_query_id)
-        self.assertEqual(
-            old_query_results.get_rows(),
-            [
-                {
-                    "eth_slippage_wei": -133004717098618640,
-                    "hour": "2023-02-01T01:00:00Z",
-                    "num_entries": 2,
-                    "solver_address": "0xc9ec550bea1c64d779124b23a26292cc223327b6",
-                    "usd_value": -210.78964412487517,
-                }
-            ],
-        )
-        # For TX: 0x7a007eb8ad25f5f1f1f36459998ae758b0e699ca69cc7b4c38354d42092651bf
-        old_query_results = self.dune.get_result(job_id="01GRA1FVYXSJY5916BEKVN5WHQ")
-        self.assertEqual(old_query_results.query_id, old_query_id)
-        self.assertEqual(
-            old_query_results.get_rows(),
-            [
-                {
-                    "eth_slippage_wei": -94488182834927150,
-                    "hour": "2023-02-01T01:00:00Z",
-                    "num_entries": 3,
-                    "solver_address": "0xc9ec550bea1c64d779124b23a26292cc223327b6",
-                    "usd_value": -149.7475493219728,
-                }
-            ],
-        )
-
         period = AccountingPeriod("2023-02-01", 1)
+        # Previously having -210 USD negative slippage.
         result_0x3b2e = exec_or_get(
             self.dune,
             query=self.slippage_query_for(
@@ -198,6 +167,7 @@ class TestDuneAnalytics(unittest.TestCase):
                 }
             ],
         )
+        # Previously having -150 USD slippage
         result_0x7a00 = exec_or_get(
             self.dune,
             query=self.slippage_query_for(

--- a/tests/queries/test_slippage_investigation.py
+++ b/tests/queries/test_slippage_investigation.py
@@ -185,7 +185,7 @@ class TestDuneAnalytics(unittest.TestCase):
             ),
             result_id="01GRA2NSAVSQZH6B8BPHR0FAN8",
         )
-        self.assertNotEqual(result_0x3b2e.query_id, old_query_id)
+        self.assertEqual(result_0x3b2e.query_id, self.slippage_query.v2_query.query_id)
         self.assertEqual(
             result_0x3b2e.get_rows(),
             [
@@ -206,7 +206,7 @@ class TestDuneAnalytics(unittest.TestCase):
             ),
             result_id="01GRA2Y006E4FGZMWSTACMHZDY",
         )
-        self.assertNotEqual(result_0x7a00.query_id, old_query_id)
+        self.assertEqual(result_0x7a00.query_id, self.slippage_query.v2_query.query_id)
         self.assertEqual(
             result_0x7a00.get_rows(),
             [


### PR DESCRIPTION
This bug was picked up by our [unusual slippage query alert](https://cowservices.slack.com/archives/C03PW4CR38A/p1675328564060139) today and has no historical impact. It is not expected to affect too many batches since the missing records are quite niche. In fact, it turns out that it only affects two batches both happening on Feb 1, 2023 (and which will likely continue happening as it seems to be a new liquidity integration of Otex solver).

## Bug Summary

Our slippage query is missing the following transfer types: native ETH Transfers involving the settlement contract that are to or from any accounts not contained in the set `{trader, recipient, WETH contract}`. This means, we were neglecting to account for incoming ETH from AMMs.

The example transaction we are working with is: https://etherscan.io/tx/0x3b2e9675b6d71a34e9b7f4abb4c9e80922be311076fcbb345d7da9d91a05e048

In fact there are only two relevant batches over all time matching the profile and they both occurred on Feb 1, 2023 by Otex solver (see the tests added for the two transaction hashes). This Query can be used to show that there are only [3 affected batches](https://dune.com/queries/1957339) over all time (and only 2 of which are relevant).

Where the Sell token was transferred into a swap contract (curve pool) that returned ETH instead of WETH (as would usually be expected).

## Solution Summary

The Solution approach requires querying `ethereum.traces` on batches with `value > 0` such that 
- `SETTLEMENT_CONTRACT in {to, from}` and -- we only want relevant transfers.
- `to not in set(BatchTradeRecipients)` and -- these are already accounted for as `USER_OUT` from trades
- `from != WETH_CONTRACT` -- because these ETH transfers cancel themselves out due to lack of WETH transfer on unwrap.


## Updated Queries
- Working Solution for Batchwise Token Breakdown is: https://dune.com/queries/1955401 (try it on the above transaction)
- Proposed solution for period slippage is: https://dune.com/queries/1956003
- [Unusual Slippage](https://dune.com/queries/1955814?MinAbsoluteSlippageTolerance=100&TxHash=0x&RelativeSlippageTolerance=1.0&SignificantSlippageValue=2000&StartTime=2023-02-01+00%3A00%3A00&EndTime=2023-02-02+00%3A00%3A00&EndTime_d83555=2023-02-02+00%3A00%3A00&MinAbsoluteSlippageTolerance_n26d66=100&RelativeSlippageTolerance_n26d66=1.0&SignificantSlippageValue_n26d66=2000&StartTime_d83555=2023-02-01+00%3A00%3A00&TxHash_t6c1ea=0x)

## Follow Up.

Will need to manually update the payout dashboard with new queries.

