### PR TITLE
[Easy] Basic Web3 Action for Settlements

### DIFF
--- a/internal_transfers/README.md
+++ b/internal_transfers/README.md
@@ -1,0 +1,38 @@
+# Internal Transfers
+
+
+## Motivation & Summary
+Internal Settlements have been a challenge to evaluate slippage since some information
+required for the computation never winds up on chain.
+Specifically, when the driver decides to internalize an interaction provided by a solver,
+the interaction is excluded from the settlement call data.
+In order to recover this data we must make token transfers (or imbalances) from
+internalized interactions transparently available for consumption.
+
+This project replaces the subquery 
+[buffer_trades](https://github.com/cowprotocol/solver-rewards/blob/c7e9c85706decb1a1be28d639ee34e35646bca50/queries/dune_v2/period_slippage.sql#L239-L309)
+(an approximation for internal interactions implemented purely within Dune Analytics) with the actual internalized data.
+
+In brief, the project consists of a Data Pipeline implementing the following flow;
+
+1. WebHook/Event Listener for CoW Protocol Settlement Events emitted by [CoW Protocol: GPv2Settlement](https://etherscan.io/address/0x9008d19f58aabd9ed0d60971565aa8510560ab41)
+2. Settlement Events trigger an ETL Pipeline that
+   - Fetches full/unoptimized call data provided by the solver for the winning settlement from the [Orderbook API](https://api.cow.fi/docs/#)
+   - Simulates the full call data extracting and classifying transfers from event logs
+   - Evaluates the `InternalizedLedger` as the difference `FullLedger - ActualLedger`
+3. Finally, the `InternalizedLedger` from step 2 is written to a [Database](./database/README.md) and later synced into Dune community sources.
+
+For more Details on each component outlined above please visit respective readmes:
+
+
+## [Webhook] Tenderly Actions
+
+Documentation: https://tenderly.co/web3-actions
+Requirements: [Tenderly CLI](https://github.com/Tenderly/tenderly-cli)
+
+actions directory was scaffolded and deployed as follows:
+
+```shell
+tenderly actions init --language typescript
+tenderly actions deploy
+```

--- a/internal_transfers/actions/.gitignore
+++ b/internal_transfers/actions/.gitignore
@@ -1,0 +1,5 @@
+# Dependency directories
+node_modules/
+
+# Ignore tsc output
+out/**/*

--- a/internal_transfers/actions/index.ts
+++ b/internal_transfers/actions/index.ts
@@ -1,0 +1,15 @@
+import {
+	ActionFn,
+	Context,
+	Event,
+	TransactionEvent,
+} from '@tenderly/actions';
+
+export const triggerInternalTransfersPipeline: ActionFn = async (
+  context: Context,
+  event: Event
+) => {
+	const transactionEvent = event as TransactionEvent;
+ 	const txHash = transactionEvent.hash;
+     console.log(`Received Settlement Event with txHash ${txHash}`);
+};

--- a/internal_transfers/actions/package-lock.json
+++ b/internal_transfers/actions/package-lock.json
@@ -1,0 +1,18 @@
+{
+    "name": "actions",
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "@tenderly/actions": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@tenderly/actions/-/actions-0.1.0.tgz",
+            "integrity": "sha512-CY/f1gU8Pehz5F3PgBf5yYb0kEHVnXMSTxNSMfC/9MKV7bwh8lGymNgcsEFjXSxrN7aiF4voDcYwdL92h1UQiA=="
+        },
+        "typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "dev": true
+        }
+    }
+}

--- a/internal_transfers/actions/package.json
+++ b/internal_transfers/actions/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "actions",
+    "scripts": {
+        "build": "tsc"
+    },
+    "devDependencies": {
+        "typescript": "^4.3.5"
+    },
+    "dependencies": {
+        "@tenderly/actions": "^0.1.0"
+    },
+    "private": true
+}

--- a/internal_transfers/actions/tsconfig.json
+++ b/internal_transfers/actions/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compileOnSave": true,
+    "compilerOptions": {
+        "module": "commonjs",
+        "noImplicitReturns": true,
+        "noUnusedLocals": true,
+        "outDir": "out",
+        "sourceMap": true,
+        "strict": true,
+        "target": "es2020"
+    },
+    "exclude": [
+        "**/*.spec.ts"
+    ],
+    "include": [
+        "**/*"
+    ]
+}

--- a/internal_transfers/tenderly.yaml
+++ b/internal_transfers/tenderly.yaml
@@ -1,0 +1,19 @@
+actions:
+  gp-v2/solver-slippage:
+    runtime: v2
+    sources: actions
+    specs:
+      settlement-event-trigger:
+        description: Trigger Data Pipeline for each Settlement event.
+        function: index:triggerInternalTransfersPipeline
+        trigger:
+          type: transaction
+          transaction:
+            status:
+              - mined
+            filters:
+              - network: 1
+                eventEmitted:
+                  contract:
+                    address: 0x9008D19f58AAbD9eD0D60971565AA8510560ab41
+                  name: Settlement


### PR DESCRIPTION
We are taking baby steps towards a full Data Pipeline for slippage-v2. This is step two in #177 

Scaffolds a Tenderly Web3 Action which picks up settlement events and logs their Transaction Hash. The issue originally specified that we would also log solver (however, parsing the solver address out of the eventt involved more code than one would hope to see in such a basic PR). Almost all code was generated with the scaffold command

```sh
tenderly actions init --language typescript
```

Except the content of `actions/index.ts` and the specific details in `tenderly.yaml`


The Action is currently deployed [here](https://dashboard.tenderly.co/gp-v2/solver-slippage/action/4f657ddd-c054-4704-9e1e-50385ad2fc2c) for those with access, but looks a bit like this:

![Screenshot 2023-02-06 at 15 14 14](https://user-images.githubusercontent.com/11778116/216994250-50bb3a7c-67e1-46ee-94ae-134169da4317.png)


![Screenshot 2023-02-06 at 15 14 24](https://user-images.githubusercontent.com/11778116/216994219-16946339-a753-45ab-b52a-06a760913b1e.png)




