### PR TITLE
Revert "[Easy] fix subtle difference in (non-deterministic) test (#179)"

### DIFF
--- a/src/fetch/prices.py
+++ b/src/fetch/prices.py
@@ -84,6 +84,4 @@ def usd_price(token: TokenId, day: datetime) -> float:
     item = response_list[0]
     price_time = datetime.strptime(item["timestamp"], "%Y-%m-%dT00:00:00Z")
     assert price_time == day
-    result = float(item["price"])
-    log.info(f"got price {result}")
-    return result
+    return float(item["price"])

--- a/tests/unit/test_split_transfer.py
+++ b/tests/unit/test_split_transfer.py
@@ -14,10 +14,6 @@ from src.utils.print_store import PrintStore
 
 ONE_ETH = 10**18
 
-# TODO - these tests aren't entirely deterministic because they make requests to CoinPaprika API for COW and ETH prices.
-#  We should be able to mock the return values of price fetching:
-#  cf https://github.com/cowprotocol/solver-rewards/pull/179
-
 
 class TestSplitTransfers(unittest.TestCase):
     def setUp(self) -> None:
@@ -245,7 +241,7 @@ class TestSplitTransfers(unittest.TestCase):
                     receiver=self.redirect_map[self.solver].reward_target,
                     # This is the amount of COW deducted based on a "deterministic" price
                     # on the date of the fixed accounting period.
-                    amount_wei=cow_reward - 11528681622554420445184,
+                    amount_wei=cow_reward - 11549056229718590750720,
                 )
             ],
         )
@@ -275,7 +271,7 @@ class TestSplitTransfers(unittest.TestCase):
                     period=self.period,
                     account=self.solver,
                     name=self.solver_name,
-                    wei=1913259812982984448,
+                    wei=1913412838234630144,
                 )
             },
         )


### PR DESCRIPTION
This reverts commit 274a5b1aa8528cb46e6c6e21d0aa0ed066482137.

I don't know what the heck is up with this test, but it seems the numbers have gone back to normal. We should really be mocking this price feed.