### PR TITLE
[HotFix] Deduplicate BatchMeta table

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -509,7 +509,14 @@ results as (
         solver_address,
         concat(environment, '-', name) as solver_name,
         sum(usd_value) as usd_value,
-        sum(eth_slippage_wei) as eth_slippage_wei
+        sum(eth_slippage_wei) as eth_slippage_wei,
+        concat(
+            '<a href="https://dune.com/queries/1995951?SolverAddress=', solver_address,
+            '&CTE_NAME=results_per_tx',
+            '&StartTime={{StartTime}}',
+            '&EndTime={{EndTime}}',
+            '" target="_blank">link</a>'
+        ) as batchwise_breakdown
     from
         results_per_tx rpt
     join cow_protocol_ethereum.solvers

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,9 +1,9 @@
--- https://github.com/cowprotocol/solver-rewards/pull/180
+-- https://github.com/cowprotocol/solver-rewards/pull/186
 with
 batch_meta as (
-    select t.block_time,
-           t.block_number,
-           t.tx_hash,
+    select b.block_time,
+           b.block_number,
+           b.tx_hash,
            case
             when dex_swaps = 0
             -- Estimation made here: https://dune.com/queries/1646084
@@ -12,14 +12,10 @@ batch_meta as (
            end as dex_swaps,
            num_trades,
            b.solver_address
-    from cow_protocol_ethereum.trades t
-    join cow_protocol_ethereum.batches b
-        on t.block_number = b.block_number
-        and t.tx_hash = b.tx_hash
+    from cow_protocol_ethereum.batches b
     where b.block_time between '{{StartTime}}' and '{{EndTime}}'
-    and t.block_time between '{{StartTime}}' and '{{EndTime}}'
     and (b.solver_address = lower('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
-    and (t.tx_hash = lower('{{TxHash}}') or '{{TxHash}}' = '0x')
+    and (b.tx_hash = lower('{{TxHash}}') or '{{TxHash}}' = '0x')
 ),
 filtered_trades as (
     select t.tx_hash,

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,4 +1,4 @@
--- https://github.com/cowprotocol/solver-rewards/pull/186
+-- https://github.com/cowprotocol/solver-rewards/pull/188
 with
 batch_meta as (
     select b.block_time,

--- a/src/queries.py
+++ b/src/queries.py
@@ -96,6 +96,6 @@ QUERIES = {
         name="Solver Slippage for Period",
         filepath="period_slippage.sql",
         v1_id=1728478,
-        v2_id=1956003,
+        v2_id=1995951,
     ),
 }

--- a/tests/queries/test_slippage_investigation.py
+++ b/tests/queries/test_slippage_investigation.py
@@ -146,13 +146,11 @@ class TestDuneAnalytics(unittest.TestCase):
         """
         period = AccountingPeriod("2023-02-01", 1)
         # Previously having -210 USD negative slippage.
+        tx_hash = "0x3b2e9675b6d71a34e9b7f4abb4c9e80922be311076fcbb345d7da9d91a05e048"
         result_0x3b2e = exec_or_get(
             self.dune,
-            query=self.slippage_query_for(
-                period,
-                "0x3b2e9675b6d71a34e9b7f4abb4c9e80922be311076fcbb345d7da9d91a05e048",
-            ),
-            result_id="01GRA2NSAVSQZH6B8BPHR0FAN8",
+            query=self.slippage_query_for(period, tx_hash),
+            result_id="01GS59V171HPZTVJJ2K1VKQD31",
         )
         self.assertEqual(result_0x3b2e.query_id, self.slippage_query.v2_query.query_id)
         self.assertEqual(
@@ -163,18 +161,17 @@ class TestDuneAnalytics(unittest.TestCase):
                     "hour": "2023-02-01T01:00:00Z",
                     "num_entries": 2,
                     "solver_address": "0xc9ec550bea1c64d779124b23a26292cc223327b6",
+                    "tx_hash": tx_hash,
                     "usd_value": -7.454727687586665e-09,
                 }
             ],
         )
         # Previously having -150 USD slippage
+        tx_hash = "0x7a007eb8ad25f5f1f1f36459998ae758b0e699ca69cc7b4c38354d42092651bf"
         result_0x7a00 = exec_or_get(
             self.dune,
-            query=self.slippage_query_for(
-                period,
-                "0x7a007eb8ad25f5f1f1f36459998ae758b0e699ca69cc7b4c38354d42092651bf",
-            ),
-            result_id="01GRA2Y006E4FGZMWSTACMHZDY",
+            query=self.slippage_query_for(period, tx_hash),
+            result_id="01GS5BF01WCHMHJBAS8Q6F0C7W",
         )
         self.assertEqual(result_0x7a00.query_id, self.slippage_query.v2_query.query_id)
         self.assertEqual(
@@ -185,6 +182,7 @@ class TestDuneAnalytics(unittest.TestCase):
                     "hour": "2023-02-01T01:00:00Z",
                     "num_entries": 2,
                     "solver_address": "0xc9ec550bea1c64d779124b23a26292cc223327b6",
+                    "tx_hash": tx_hash,
                     "usd_value": -1.2930210208343511e-06,
                 }
             ],

--- a/tests/queries/test_slippage_investigation.py
+++ b/tests/queries/test_slippage_investigation.py
@@ -178,12 +178,12 @@ class TestDuneAnalytics(unittest.TestCase):
             result_0x7a00.get_rows(),
             [
                 {
-                    "eth_slippage_wei": -815874497.9746609,
+                    "eth_slippage_wei": -407937248.98733044,
                     "hour": "2023-02-01T01:00:00Z",
                     "num_entries": 2,
                     "solver_address": "0xc9ec550bea1c64d779124b23a26292cc223327b6",
-                    "tx_hash": tx_hash,
-                    "usd_value": -1.2930210208343511e-06,
+                    "tx_hash": "0x7a007eb8ad25f5f1f1f36459998ae758b0e699ca69cc7b4c38354d42092651bf",
+                    "usd_value": -6.465105104171756e-07,
                 }
             ],
         )


### PR DESCRIPTION
#180 introduced a regression that led to double counting of slippages per settlement. `batch_meta_table` contained a join between batches and trades, creating one row per trade (not per batch). This table was later joined with the batchwise imbalances, leading to double counting each imbalance by the number of trades (e.g. 3 trades --> $50 slippage becomes $150).

This significantly affected last weeks payout (which we will need to rectify).

This PR removes the join on trades, as all required information is available on batches directly.

### TestPlan

I ran this query against #169 on data from 01-24 until 01-31 ([comparison](https://docs.google.com/spreadsheets/d/1KW7yWO-sbkQZKr3Jy114aqgnQIpqchv9uEib3JRqKms/edit#gid=543426278)) and see the data match.
