### PR TITLE
Parse event logs with ethers.js

### DIFF
--- a/internal_transfers/actions/jest.config.js
+++ b/internal_transfers/actions/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   testEnvironment: "node",
   testRegex: "/tests/.*\\.(test|spec)?\\.(ts|tsx)$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  resolveJsonModule: true,
 };

--- a/internal_transfers/actions/package-lock.json
+++ b/internal_transfers/actions/package-lock.json
@@ -3,6 +3,11 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@adraffy/ens-normalize": {
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.8.9.tgz",
+      "integrity": "sha512-93OmGCV0vO8+JQ3FHG+gZk/MPHzzMPDRiCiFcCQNTCnHaaxsacO3ScTPGlu2wX2dOtgfalbchPcw1cOYYjHCYQ=="
+    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -448,6 +453,11 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@cowprotocol/contracts": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@cowprotocol/contracts/-/contracts-1.3.2.tgz",
+      "integrity": "sha512-B0Z/SwrByyqGh2FcJ7kYRGxBV5iiuFlz50eCjIlFU2M+nPHLfTk/fsgLTJr4qAGaFoGHbzsOm5sd9410RmXFAw=="
+    },
     "@eslint/eslintrc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -829,6 +839,16 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1012,6 +1032,11 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true
+    },
+    "aes-js": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.3.tgz",
+      "integrity": "sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA=="
     },
     "ajv": {
       "version": "6.12.6",
@@ -1532,6 +1557,19 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "ethers": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.0.3.tgz",
+      "integrity": "sha512-ECUt+AlY80eLA/XvOgy4/K5Pq5BsMzlKKcSuUXOgp4k6d3tcDphEiz+Fs3zut/zYQVgqLgm3f8YtCJEEtzl8kA==",
+      "requires": {
+        "@adraffy/ens-normalize": "1.8.9",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "aes-js": "4.0.0-beta.3",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      }
     },
     "execa": {
       "version": "5.1.1",
@@ -3137,6 +3175,11 @@
         }
       }
     },
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3252,6 +3295,11 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       }
+    },
+    "ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/internal_transfers/actions/package.json
+++ b/internal_transfers/actions/package.json
@@ -15,7 +15,9 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@tenderly/actions": "^0.1.0"
+    "@cowprotocol/contracts": "^1.3.2",
+    "@tenderly/actions": "^0.1.0",
+    "ethers": "^6.0.3"
   },
   "private": true
 }

--- a/internal_transfers/actions/src/parse.ts
+++ b/internal_transfers/actions/src/parse.ts
@@ -4,9 +4,7 @@ import { transferInvolves } from "./utils";
 import { ethers } from "ethers";
 import { abi as SETTLEMENT_ABI } from "@cowprotocol/contracts/lib/contracts/GPv2Settlement.json";
 import { abi as IERC20_ABI } from "@cowprotocol/contracts/lib/contracts/IERC20.json";
-
-export const SETTLEMENT_CONTRACT_ADDRESS =
-  "0x9008D19f58AAbD9eD0D60971565AA8510560ab41";
+import { address as SETTLEMENT_CONTRACT_ADDRESS } from "@cowprotocol/contracts/deployments/mainnet/GPv2Settlement.json";
 
 export interface ClassifiedEvents {
   trades: TradeEvent[];

--- a/internal_transfers/actions/src/parse.ts
+++ b/internal_transfers/actions/src/parse.ts
@@ -1,15 +1,12 @@
 import { SettlementEvent, TradeEvent, TransferEvent } from "./models";
 import { Log } from "@tenderly/actions";
-import { addressFromBytes32, transferInvolves } from "./utils";
+import { transferInvolves } from "./utils";
+import { ethers } from "ethers";
+import { abi as SETTLEMENT_ABI } from "@cowprotocol/contracts/lib/contracts/GPv2Settlement.json";
+import { abi as IERC20_ABI } from "@cowprotocol/contracts/lib/contracts/IERC20.json";
 
 export const SETTLEMENT_CONTRACT_ADDRESS =
-  "0x9008d19f58aabd9ed0d60971565aa8510560ab41";
-export const SETTLEMENT_EVENT_TOPIC =
-  "0x40338ce1a7c49204f0099533b1e9a7ee0a3d261f84974ab7af36105b8c4e9db4";
-export const TRANSFER_EVENT_TOPIC =
-  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
-export const TRADE_EVENT_TOPIC =
-  "0xa07a543ab8a018198e99ca0184c93fe9050a79400a0a723441f84de1d972cc17";
+  "0x9008D19f58AAbD9eD0D60971565AA8510560ab41";
 
 export interface ClassifiedEvents {
   trades: TradeEvent[];
@@ -23,32 +20,42 @@ export function partitionEventLogs(logs: Log[]): ClassifiedEvents {
     trades: [],
     settlements: [],
   };
+  const settlementInterface = new ethers.Interface(SETTLEMENT_ABI);
+  const erc20Interface = new ethers.Interface(IERC20_ABI);
   logs.forEach((log, index) => {
-    const topics = log.topics;
-    const eventTopic = topics[0];
-
-    if (eventTopic === TRANSFER_EVENT_TOPIC) {
+    // We are only interested in Transfer Events from erc20 contracts
+    // along with Settlement and Trade Events from the Settlement contract
+    // All other event emissions can be ignored for our purposes.
+    const transferEventLog = erc20Interface.parseLog(log);
+    const settlementEventLog = settlementInterface.parseLog(log);
+    if (transferEventLog != null) {
+      const { from, to } = transferEventLog.args;
       const transfer: TransferEvent = {
-        to: addressFromBytes32(topics[2]),
-        from: addressFromBytes32(topics[1]),
-        amount: BigInt(log?.data),
+        from: from,
+        to: to,
+        amount: BigInt(transferEventLog.args[2]),
       };
       // Is a "relevant" transfer (involving settlement contract)
       if (transferInvolves(transfer, SETTLEMENT_CONTRACT_ADDRESS)) {
         result.transfers.push(transfer);
       }
-    } else if (eventTopic === TRADE_EVENT_TOPIC) {
-      result.trades.push({
-        owner: addressFromBytes32(topics[1]),
-      });
-    } else if (eventTopic === SETTLEMENT_EVENT_TOPIC) {
-      result.settlements.push({
-        solver: addressFromBytes32(topics[1]),
-        log_index: index,
-      });
+    } else if (settlementEventLog != null) {
+      // Relevant Event Types
+      if (settlementEventLog.name == "Trade") {
+        result.trades.push({
+          owner: settlementEventLog.args[0],
+        });
+      } else if (settlementEventLog.name == "Settlement") {
+        result.settlements.push({
+          solver: settlementEventLog.args[0],
+          log_index: index,
+        });
+      } else {
+        // Placeholder for other Settlement Contract Events (e.g. Interaction)
+      }
     } else {
-      // Other, currently ignored, event topic.
-      // Examples here include WETH deposit/withdrawals
+      // Placeholder for any event emitted not by erc20 token or Settlement contract.
+      // Examples here include WETH deposit/withdrawals, AMM Swaps etc.
     }
   });
   return result;

--- a/internal_transfers/actions/src/parse.ts
+++ b/internal_transfers/actions/src/parse.ts
@@ -31,8 +31,8 @@ export function partitionEventLogs(logs: Log[]): ClassifiedEvents {
     if (transferEventLog != null) {
       const { from, to } = transferEventLog.args;
       const transfer: TransferEvent = {
-        from: from,
-        to: to,
+        from,
+        to,
         amount: BigInt(transferEventLog.args[2]),
       };
       // Is a "relevant" transfer (involving settlement contract)

--- a/internal_transfers/actions/src/parse.ts
+++ b/internal_transfers/actions/src/parse.ts
@@ -42,12 +42,14 @@ export function partitionEventLogs(logs: Log[]): ClassifiedEvents {
     } else if (settlementEventLog != null) {
       // Relevant Event Types
       if (settlementEventLog.name == "Trade") {
+        const { owner } = settlementEventLog.args;
         result.trades.push({
-          owner: settlementEventLog.args[0],
+          owner,
         });
       } else if (settlementEventLog.name == "Settlement") {
+        const { solver } = settlementEventLog.args;
         result.settlements.push({
-          solver: settlementEventLog.args[0],
+          solver,
           log_index: index,
         });
       } else {

--- a/internal_transfers/actions/src/parse.ts
+++ b/internal_transfers/actions/src/parse.ts
@@ -28,12 +28,12 @@ export function partitionEventLogs(logs: Log[]): ClassifiedEvents {
     // All other event emissions can be ignored for our purposes.
     const transferEventLog = erc20Interface.parseLog(log);
     const settlementEventLog = settlementInterface.parseLog(log);
-    if (transferEventLog != null) {
-      const { from, to } = transferEventLog.args;
+    if (transferEventLog != null && transferEventLog.name === "Transfer") {
+      const { from, to, value } = transferEventLog.args;
       const transfer: TransferEvent = {
         from,
         to,
-        amount: BigInt(transferEventLog.args[2]),
+        amount: BigInt(value),
       };
       // Is a "relevant" transfer (involving settlement contract)
       if (transferInvolves(transfer, SETTLEMENT_CONTRACT_ADDRESS)) {

--- a/internal_transfers/actions/src/utils.ts
+++ b/internal_transfers/actions/src/utils.ts
@@ -1,9 +1,5 @@
 import { TransferEvent } from "./models";
 
-export function addressFromBytes32(hexStr: string): string {
-  return "0x" + hexStr.slice(-40);
-}
-
 export function transferInvolves(
   transfer: TransferEvent,
   address: string

--- a/internal_transfers/actions/tests/parse.spec.ts
+++ b/internal_transfers/actions/tests/parse.spec.ts
@@ -1,33 +1,32 @@
-import {
-  partitionEventLogs,
-  SETTLEMENT_CONTRACT_ADDRESS,
-  SETTLEMENT_EVENT_TOPIC,
-  TRADE_EVENT_TOPIC,
-  TRANSFER_EVENT_TOPIC,
-} from "../src/parse";
+import { partitionEventLogs, SETTLEMENT_CONTRACT_ADDRESS } from "../src/parse";
+
+const SETTLEMENT_EVENT_TOPIC =
+  "0x40338ce1a7c49204f0099533b1e9a7ee0a3d261f84974ab7af36105b8c4e9db4";
+const TRANSFER_EVENT_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const TRADE_EVENT_TOPIC =
+  "0xa07a543ab8a018198e99ca0184c93fe9050a79400a0a723441f84de1d972cc17";
 
 const TOKEN_ADDRESS = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
 
 function addressToTopic(address: string): string {
   return "0x000000000000000000000000" + address.slice(2);
 }
-
 describe("partitionEventLogs(logs)", () => {
-  test("partitions event logs single Trade Event", () => {
-    const tradeOwner = "0xd5553c9726ea28e7ebedfe9879cf8ab4d061dbf0";
-    const trade_log = {
+  test("single Trade Event", () => {
+    const tradeOwner = "0xd5553C9726EA28e7EbEDfe9879cF8aB4d061dbf0";
+    const tradeLog = {
       address: SETTLEMENT_CONTRACT_ADDRESS,
+      data: "0x0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000003432b6a60d23ca0dfca7761b7ab56459d9c964d000000000000000000000000000000000000000000000006c6b935b8bbd400000000000000000000000000000000000000000000000000019753399721b8078ee000000000000000000000000000000000000000000000000604fbfc634eef00000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000038bf293f652b46fe85a15838d7ff736add1b6098ed1c143f3902869d325f9e0069e2b424053b9ebfcedf89ecb8bf2972974e98700c63af639e0000000000000000",
       topics: [TRADE_EVENT_TOPIC, addressToTopic(tradeOwner)],
-      data: "0x",
     };
-    const { trades, transfers, settlements } = partitionEventLogs([trade_log]);
+    const { trades, transfers, settlements } = partitionEventLogs([tradeLog]);
 
     expect(trades).toStrictEqual([{ owner: tradeOwner }]);
     expect(transfers).toStrictEqual([]);
     expect(settlements).toStrictEqual([]);
   });
-
-  test("partitions event logs single relevant Transfer Event", () => {
+  test("single relevant Transfer Event", () => {
     const address = "0x0000000000000000000000000000000000000001";
     const relevant_transfer_log = {
       address: TOKEN_ADDRESS,
@@ -59,8 +58,8 @@ describe("partitionEventLogs(logs)", () => {
     expect(transfers[0].amount.toString()).toBe(BigInt(4096).toString());
     expect(settlements).toStrictEqual([]);
   });
-  test("partitions event logs with single Settlement Event", () => {
-    const solverAddress = "0xb20b86c4e6deeb432a22d773a221898bbbd03036";
+  test("single Settlement Event", () => {
+    const solverAddress = "0xb20B86C4e6DEEB432A22D773a221898bBBD03036";
     const settlement_log = {
       address: SETTLEMENT_CONTRACT_ADDRESS,
       topics: [SETTLEMENT_EVENT_TOPIC, addressToTopic(solverAddress)],
@@ -76,8 +75,7 @@ describe("partitionEventLogs(logs)", () => {
       { solver: solverAddress, log_index: 0 },
     ]);
   });
-
-  test("partitions event logs with no relevant events", () => {
+  test("no relevant events", () => {
     const irrelevant_event_log = {
       address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
       topics: [

--- a/internal_transfers/actions/tests/parse.spec.ts
+++ b/internal_transfers/actions/tests/parse.spec.ts
@@ -1,5 +1,4 @@
 import { partitionEventLogs } from "../src/parse";
-// @ts-ignore
 import { address as SETTLEMENT_CONTRACT_ADDRESS } from "@cowprotocol/contracts/deployments/mainnet/GPv2Settlement.json";
 
 const SETTLEMENT_EVENT_TOPIC =

--- a/internal_transfers/actions/tests/parse.spec.ts
+++ b/internal_transfers/actions/tests/parse.spec.ts
@@ -1,4 +1,6 @@
-import { partitionEventLogs, SETTLEMENT_CONTRACT_ADDRESS } from "../src/parse";
+import { partitionEventLogs } from "../src/parse";
+// @ts-ignore
+import { address as SETTLEMENT_CONTRACT_ADDRESS } from "@cowprotocol/contracts/deployments/mainnet/GPv2Settlement.json";
 
 const SETTLEMENT_EVENT_TOPIC =
   "0x40338ce1a7c49204f0099533b1e9a7ee0a3d261f84974ab7af36105b8c4e9db4";

--- a/internal_transfers/actions/tests/utils.spec.ts
+++ b/internal_transfers/actions/tests/utils.spec.ts
@@ -1,15 +1,5 @@
-import { addressFromBytes32, transferInvolves } from "../src/utils";
+import { transferInvolves } from "../src/utils";
 import { TransferEvent } from "../src/models";
-
-describe("addressFromBytes32(hexStr)", () => {
-  test("parses address from event topic hex string", () => {
-    const addressTopic =
-      "0x0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41";
-    expect(addressFromBytes32(addressTopic)).toBe(
-      "0x9008d19f58aabd9ed0d60971565aa8510560ab41"
-    );
-  });
-});
 
 describe("transferInvolves(transfer, address)", () => {
   test("correctly returns whether transfer instance involves given address", () => {

--- a/internal_transfers/actions/tsconfig.json
+++ b/internal_transfers/actions/tsconfig.json
@@ -2,6 +2,7 @@
   "compileOnSave": true,
   "compilerOptions": {
     "module": "commonjs",
+    "resolveJsonModule": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "outDir": "out",


### PR DESCRIPTION
As suggested in https://github.com/cowprotocol/solver-rewards/pull/182#discussion_r1100533753 (from PR #182) we introduce transaction log parsing via ethers library with appropriate Contract artifacts. Namely, we introduce dependencies on `@cowprotocol/contracts` which contain the abi files for `GPv2Settlement` and `iERC20` and suffice for us to decode relevant event data from settlement transactions. For us these are `Transfer`, `Settlement` and `Trade`. 

We construct Event types out of each which only keep the parts that matter for our purposes (namely TradeEvent having `owner` as the only relevant field).

Unit Tests are more-or-less the same (except we had to change test addresses to checksum addresses) and we also had to add some non-trivial `data` to our mock `TradeEventLog` since ethers expects to be able to parse even the irrelevant, to us, fields of a Trade.


Note that this also allowed us to remove a utility method that was previously used to manually decode raw transaction data.
 
# Test Plan

Existing Tests