### PR TITLE
Use sort key and overwrite recipient on redirect

### DIFF
--- a/src/models/overdraft.py
+++ b/src/models/overdraft.py
@@ -28,7 +28,7 @@ class Overdraft:
         cls, transfer: Transfer, slippage: SolverSlippage, period: AccountingPeriod
     ) -> Overdraft:
         """Constructs an overdraft instance based on Transfer & Slippage"""
-        assert transfer.solver == slippage.solver_address
+        assert transfer.recipient == slippage.solver_address
         assert transfer.token_type == TokenType.NATIVE
         overdraft = transfer.amount_wei + slippage.amount_wei
         assert overdraft < 0, "This is why we are here."

--- a/src/models/split_transfers.py
+++ b/src/models/split_transfers.py
@@ -61,7 +61,7 @@ class SplitTransfers:
         penalty_total = 0
         while self.unprocessed_native:
             transfer = self.unprocessed_native.pop(0)
-            solver = transfer.solver
+            solver = transfer.recipient
             slippage: Optional[SolverSlippage] = indexed_slippage.get(solver)
             if slippage is not None:
                 assert (
@@ -99,7 +99,7 @@ class SplitTransfers:
         price_day = self.period.end - timedelta(days=1)
         while self.unprocessed_cow:
             transfer = self.unprocessed_cow.pop(0)
-            solver = transfer.solver
+            solver = transfer.recipient
             # Remove the element if it exists (assuming it won't have to be reinserted)
             overdraft = self.overdrafts.pop(solver, None)
             if overdraft is not None:

--- a/src/models/transfer.py
+++ b/src/models/transfer.py
@@ -231,6 +231,10 @@ class Transfer:
                 else Category.COW_REDIRECT,
             )
             # This is the only place where recipient can be overwritten
+            # sort_key is not updated here because sorted transfers should be
+            # grouped by "initial recipient" before they were redirected.
+            # This is a business requirement for making non-consolidated
+            # multisend transaction validation more visually straight-forward.
             self._recipient = redirect_address
 
     @classmethod

--- a/tests/e2e/test_transfer_file.py
+++ b/tests/e2e/test_transfer_file.py
@@ -24,12 +24,14 @@ class TestPrices(unittest.TestCase):
         mixed_transfers = [
             Transfer(
                 token=None,
-                solver=barn_zerox,
+                recipient=barn_zerox,
                 amount_wei=185360274773133130,
             ),
-            Transfer(token=None, solver=other_solver, amount_wei=1 * ONE_ETH),
-            Transfer(token=cow_token, solver=barn_zerox, amount_wei=600 * ONE_ETH),
-            Transfer(token=cow_token, solver=other_solver, amount_wei=2000 * ONE_ETH),
+            Transfer(token=None, recipient=other_solver, amount_wei=1 * ONE_ETH),
+            Transfer(token=cow_token, recipient=barn_zerox, amount_wei=600 * ONE_ETH),
+            Transfer(
+                token=cow_token, recipient=other_solver, amount_wei=2000 * ONE_ETH
+            ),
         ]
         slippages = SplitSlippages.from_data_set(
             [
@@ -58,7 +60,7 @@ class TestPrices(unittest.TestCase):
             [
                 Transfer(
                     token=cow_token,
-                    solver=other_solver,
+                    recipient=other_solver,
                     amount_wei=845094377028141056000,
                 )
             ],

--- a/tests/unit/test_multisend.py
+++ b/tests/unit/test_multisend.py
@@ -23,7 +23,7 @@ class TestMultiSend(unittest.TestCase):
             "0xA03be496e67Ec29bC62F01a428683D7F9c204930"
         )
         big_native_transfer = Transfer(
-            token=None, solver=Address.zero(), amount_wei=many_eth
+            token=None, recipient=Address.zero(), amount_wei=many_eth
         ).as_multisend_tx()
 
         with self.assertRaises(ValueError):
@@ -41,7 +41,7 @@ class TestMultiSend(unittest.TestCase):
         transactions = [
             Transfer(
                 token=None,
-                solver=Address.zero(),
+                recipient=Address.zero(),
                 amount_wei=eth_balance + 1,  # More ETH than account has!
             ).as_multisend_tx()
         ]
@@ -73,7 +73,7 @@ class TestMultiSend(unittest.TestCase):
         )
 
         native_transfer = Transfer(
-            token=None, solver=receiver, amount_wei=16
+            token=None, recipient=receiver, amount_wei=16
         ).as_multisend_tx()
         self.assertEqual(
             build_encoded_multisend([native_transfer], client=self.client),
@@ -86,7 +86,7 @@ class TestMultiSend(unittest.TestCase):
         )
         erc20_transfer = Transfer(
             token=cow_token,
-            solver=receiver,
+            recipient=receiver,
             amount_wei=15,
         ).as_multisend_tx()
         self.assertEqual(

--- a/tests/unit/test_split_transfer.py
+++ b/tests/unit/test_split_transfer.py
@@ -41,13 +41,15 @@ class TestSplitTransfers(unittest.TestCase):
         eth_transfers = [
             Transfer(
                 token=None,
-                solver=solvers[i],
+                recipient=solvers[i],
                 amount_wei=eth_amounts[i],
             )
             for i in range(len(solvers))
         ]
         cow_transfers = [
-            Transfer(token=self.cow_token, solver=solvers[i], amount_wei=cow_rewards[i])
+            Transfer(
+                token=self.cow_token, recipient=solvers[i], amount_wei=cow_rewards[i]
+            )
             for i in range(len(solvers))
         ]
         accounting = SplitTransfers(
@@ -75,11 +77,11 @@ class TestSplitTransfers(unittest.TestCase):
         mixed_transfers = [
             Transfer(
                 token=None,
-                solver=self.solver,
+                recipient=self.solver,
                 amount_wei=amount_of_transfer,
             ),
             Transfer(
-                token=self.cow_token, solver=self.solver, amount_wei=600 * ONE_ETH
+                token=self.cow_token, recipient=self.solver, amount_wei=600 * ONE_ETH
             ),
         ]
 
@@ -98,7 +100,9 @@ class TestSplitTransfers(unittest.TestCase):
     def test_process_rewards(self):
         cow_reward = 600 * ONE_ETH
         mixed_transfers = [
-            Transfer(token=self.cow_token, solver=self.solver, amount_wei=cow_reward),
+            Transfer(
+                token=self.cow_token, recipient=self.solver, amount_wei=cow_reward
+            ),
         ]
         accounting = SplitTransfers(self.period, mixed_transfers, PrintStore())
         reward_target = Address.from_int(7)
@@ -122,7 +126,7 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 redirected_transfer(
                     token=None,
-                    solver=self.solver,
+                    recipient=self.solver,
                     amount_wei=slippage_amount,
                     redirect=redirect_map[self.solver].reward_target,
                 )
@@ -133,7 +137,7 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 redirected_transfer(
                     token=self.cow_token,
-                    solver=self.solver,
+                    recipient=self.solver,
                     amount_wei=cow_reward,
                     redirect=redirect_map[self.solver].reward_target,
                 )
@@ -158,13 +162,13 @@ class TestSplitTransfers(unittest.TestCase):
                 # The ETH Spent
                 Transfer(
                     token=None,
-                    solver=self.solver,
+                    recipient=self.solver,
                     amount_wei=eth_amount,
                 ),
                 # The redirected positive slippage
                 redirected_transfer(
                     token=None,
-                    solver=self.solver,
+                    recipient=self.solver,
                     amount_wei=slippage_amount,
                     redirect=self.redirect_map[self.solver].reward_target,
                 ),
@@ -175,7 +179,7 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 redirected_transfer(
                     token=self.cow_token,
-                    solver=self.solver,
+                    recipient=self.solver,
                     amount_wei=cow_reward,
                     redirect=self.redirect_map[self.solver].reward_target,
                 ),
@@ -201,7 +205,7 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 Transfer(
                     token=None,
-                    solver=self.solver,
+                    recipient=self.solver,
                     # Slippage is negative (so it is added here)
                     amount_wei=eth_amount + slippage_amount,
                 ),
@@ -212,7 +216,7 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 redirected_transfer(
                     token=self.cow_token,
-                    solver=self.solver,
+                    recipient=self.solver,
                     amount_wei=cow_reward,
                     redirect=self.redirect_map[self.solver].reward_target,
                 ),
@@ -242,7 +246,7 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 redirected_transfer(
                     token=self.cow_token,
-                    solver=self.solver,
+                    recipient=self.solver,
                     # This is the amount of COW deducted based on a "deterministic" price
                     # on the date of the fixed accounting period.
                     amount_wei=cow_reward - 11549056229718590750720,
@@ -307,12 +311,12 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 Transfer(
                     token=None,
-                    solver=self.solver,
+                    recipient=self.solver,
                     amount_wei=eth_amount,
                 ),
                 Transfer(
                     token=None,
-                    solver=self.solver,
+                    recipient=self.solver,
                     amount_wei=slippage_amount,
                 ),
             ],
@@ -322,7 +326,7 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 Transfer(
                     token=self.cow_token,
-                    solver=self.solver,
+                    recipient=self.solver,
                     amount_wei=cow_reward,
                 ),
             ],
@@ -370,12 +374,12 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 Transfer(
                     token=None,
-                    solver=solvers[0],
+                    recipient=solvers[0],
                     amount_wei=eth_amounts[0],
                 ),
                 Transfer(
                     token=None,
-                    solver=solvers[1],
+                    recipient=solvers[1],
                     amount_wei=eth_amounts[1],
                 ),
             ],
@@ -385,13 +389,13 @@ class TestSplitTransfers(unittest.TestCase):
             [
                 redirected_transfer(
                     token=self.cow_token,
-                    solver=solvers[0],
+                    recipient=solvers[0],
                     amount_wei=cow_rewards[0],
                     redirect=reward_target,
                 ),
                 redirected_transfer(
                     token=self.cow_token,
-                    solver=solvers[1],
+                    recipient=solvers[1],
                     amount_wei=cow_rewards[1],
                     redirect=reward_target,
                 ),

--- a/tests/unit/util_methods.py
+++ b/tests/unit/util_methods.py
@@ -1,10 +1,9 @@
 from src.models.transfer import Transfer
 
 
-def redirected_transfer(token, solver, amount_wei, redirect) -> Transfer:
+def redirected_transfer(token, recipient, amount_wei, redirect) -> Transfer:
     # simple way to set up a transfer object with non-empty
     # redirect target field (for testing)
-    transfer = Transfer(token, solver, amount_wei)
-
-    transfer._redirect_target = redirect
+    transfer = Transfer(token, recipient, amount_wei)
+    transfer._recipient = redirect
     return transfer


### PR DESCRIPTION
Closes #195 

We simplify the logic of `Transfer`sorting by removing terms like `solver` and `redirect` in favour of `recipient` and `sort_key`.

Now the recipient will be the initially the solver, but gets updated upon redirect (leaving the sort key the same).