### PR TITLE
[CIP-20] Batch Reward Query

### DIFF
--- a/queries/orderbook/batch_rewards.sql
+++ b/queries/orderbook/batch_rewards.sql
@@ -63,25 +63,26 @@ WITH observed_settlements AS (SELECT
                               participants                                                                                 as participating_solvers
                        FROM reward_data),
 
-     participation_data as (select tx_hash,
+     participation_data as (SELECT tx_hash,
                                    unnest(participating_solvers) as participant
-                            from reward_per_tx),
-     participation_counts as (select participant as solver,
+                            FROM reward_per_tx),
+     participation_counts as (SELECT participant as solver,
                                      count(*)    as num_participating_batches
-                              from participation_data
-                              group by participant),
-     primary_rewards as (select rpt.solver,
+                              FROM participation_data
+                              GROUP BY participant),
+     primary_rewards as (SELECT rpt.solver,
                                 SUM(capped_reward)  as total_reward_eth,
                                 SUM(execution_cost) as total_exececution_cost_eth
-                         from reward_per_tx rpt
-                         group by solver)
+                         FROM reward_per_tx rpt
+                         GROUP BY solver)
 
-select concat('0x', encode(pc.solver, 'hex')) as solver,
-       coalesce(total_reward_eth, 0)          as total_reward_eth,
+SELECT concat('0x', encode(pc.solver, 'hex'))                as solver,
+       coalesce(total_reward_eth, 0) / pow(10, 18)           as total_reward_eth,
+       coalesce(total_exececution_cost_eth, 0) / pow(10, 18) as total_exececution_cost_eth,
        num_participating_batches
-from participation_counts pc
-       left outer join primary_rewards pr
-                       on pr.solver = pc.solver;
+FROM participation_counts pc
+       LEFT OUTER JOIN primary_rewards pr
+                       ON pr.solver = pc.solver;
 
 
 

--- a/queries/orderbook/batch_rewards.sql
+++ b/queries/orderbook/batch_rewards.sql
@@ -51,25 +51,27 @@ WITH observed_settlements AS (SELECT
                                             ON os.auction_id = ss.auction_id),
 
      reward_per_tx as (SELECT tx_hash,
-                                       solver,
-                                       execution_cost,
-                                       surplus,
-                                       fee,
-                                       surplus + fee - reference_score                                                              as uncapped_reward_eth,
-                                       -- Uncapped Reward = CLAMP_[-E, E + exec_cost](uncapped_reward_eth)
-                                       LEAST(GREATEST(-{{EPSILON}}, surplus + fee - reference_score), {{EPSILON}} + execution_cost) as capped_reward,
-                                       winning_score,
-                                       reference_score,
-                                       participants                                                                                 as participating_solvers
-                                FROM reward_data),
+                              solver,
+                              execution_cost,
+                              surplus,
+                              fee,
+                              surplus + fee - reference_score                                                              as uncapped_reward_eth,
+                              -- Uncapped Reward = CLAMP_[-E, E + exec_cost](uncapped_reward_eth)
+                              LEAST(GREATEST(-{{EPSILON}}, surplus + fee - reference_score), {{EPSILON}} + execution_cost) as capped_reward,
+                              winning_score,
+                              reference_score,
+                              participants                                                                                 as participating_solvers
+                       FROM reward_data),
 
-     participation_data as (select tx_hash, unnest(participating_solvers) as participant
+     participation_data as (select tx_hash,
+                                   unnest(participating_solvers) as participant
                             from reward_per_tx),
-     participation_counts as (select participant as solver, count(*) as num_participating_batches
+     participation_counts as (select participant as solver,
+                                     count(*)    as num_participating_batches
                               from participation_data
                               group by participant),
      primary_rewards as (select rpt.solver,
-                                SUM(capped_reward) as total_reward_eth,
+                                SUM(capped_reward)  as total_reward_eth,
                                 SUM(execution_cost) as total_exececution_cost_eth
                          from reward_per_tx rpt
                          group by solver)

--- a/queries/orderbook/batch_rewards.sql
+++ b/queries/orderbook/batch_rewards.sql
@@ -1,0 +1,80 @@
+WITH observed_settlements AS (SELECT
+                                -- settlement
+                                tx_hash,
+                                solver,
+                                -- settlement_observations
+                                block_number,
+                                effective_gas_price * gas_used AS execution_cost,
+                                surplus,
+                                fee,
+                                -- auction_transaction
+                                auction_id
+                              FROM settlement_observations so
+                                     JOIN settlements s
+                                          ON s.block_number = so.block_number
+                                            AND s.log_index = so.log_index
+                                     JOIN auction_transaction at
+                                          ON s.tx_from = at.tx_from
+                                            AND s.tx_nonce = at.tx_nonce
+                              WHERE block_number > {{start_block}} AND block_number <= {{end_block}}),
+
+     reward_data AS (SELECT
+                       -- observations
+                       tx_hash,
+                       coalesce(
+                               solver,
+                         -- This is the winning solver (i.e. last entry of participants array)
+                               participants[array_length(participants, 1)]
+                         )                                    as solver,
+                       -- Right-hand terms in coalesces below represent the case when settlement
+                       -- observations are unavailable (i.e. no settlement corresponds to reported scores).
+                       -- In particular, this means that surplus, fee and execution cost are all zero.
+                       -- When there is an absence of settlement block number, we fall back
+                       -- on the block_deadline from the settlement_scores table.
+                       coalesce(block_number, block_deadline) as block_number,
+                       coalesce(execution_cost, 0)            as execution_cost,
+                       coalesce(surplus, 0)                   as surplus,
+                       coalesce(fee, 0)                       as fee,
+                       surplus + fee - reference_score        AS payment,
+                       -- scores
+                       winning_score,
+                       reference_score,
+                       -- participation
+                       participants
+                     FROM settlement_scores ss
+                            -- If there are reported scores,
+                            -- there will always be a record of auction participants
+                            JOIN auction_participants ap
+                                 ON os.auction_id = ap.auction_id
+                       -- outer joins made in order to capture non-existent settlements.
+                            LEFT OUTER JOIN observed_settlements os
+                                            ON os.auction_id = ss.auction_id),
+
+     reward_per_tx as (SELECT tx_hash,
+                              solver,
+                              execution_cost,
+                              surplus,
+                              fee,
+                              surplus + fee - reference_score as reward_eth,
+                              winning_score,
+                              reference_score,
+                              participants                    as participating_solvers
+                       FROM reward_data),
+     participation_data as (select tx_hash, unnest(participating_solvers) as participant
+                            from reward_per_tx),
+     participation_counts as (select participant as solver, count(tx_hash) as num_participating_batches
+                              from participation_data
+                              group by participant),
+     primary_rewards as (select rpt.solver, sum(reward_eth) as total_reward_eth
+                         from reward_per_tx rpt
+                         group by solver)
+
+select concat('0x', encode(pr.solver, 'hex')) as solver,
+       total_reward_eth,
+       num_participating_batches
+from primary_rewards pr
+       join participation_counts pc
+            on pr.solver = pc.solver
+
+
+

--- a/queries/orderbook/batch_rewards.sql
+++ b/queries/orderbook/batch_rewards.sql
@@ -8,7 +8,7 @@ WITH observed_settlements AS (SELECT
                                 surplus,
                                 fee,
                                 -- auction_transaction
-                                auction_id
+                                at.auction_id
                               FROM settlement_observations so
                                      JOIN settlements s
                                           ON s.block_number = so.block_number
@@ -16,73 +16,82 @@ WITH observed_settlements AS (SELECT
                                      JOIN auction_transaction at
                                           ON s.tx_from = at.tx_from
                                             AND s.tx_nonce = at.tx_nonce
-                              WHERE s.block_number > {{start_block}} AND s.block_number <= {{end_block}}),
+                                     JOIN settlement_scores ss
+                                          ON at.auction_id = ss.auction_id
+                              WHERE ss.block_deadline > {{start_block}}
+                                AND ss.block_deadline <= {{end_block}}),
 
+     auction_participation as (SELECT ss.auction_id, array_agg(participant) as participating_solvers
+                               FROM auction_participants
+                                      JOIN settlement_scores ss
+                                           ON auction_participants.auction_id = ss.auction_id
+                               WHERE block_deadline > {{start_block}}
+                                 AND block_deadline <= {{end_block}}
+                               GROUP BY ss.auction_id),
      reward_data AS (SELECT
                        -- observations
                        tx_hash,
-                       coalesce(
-                               solver,
-                         -- This is the winning solver (i.e. last entry of participants array)
-                               participants[array_length(participants, 1)]
-                         )                                    as solver,
-                       -- Right-hand terms in coalesces below represent the case when settlement
-                       -- observations are unavailable (i.e. no settlement corresponds to reported scores).
-                       -- In particular, this means that surplus, fee and execution cost are all zero.
-                       -- When there is an absence of settlement block number, we fall back
-                       -- on the block_deadline from the settlement_scores table.
-                       coalesce(block_number, block_deadline) as block_number,
-                       coalesce(execution_cost, 0)            as execution_cost,
-                       coalesce(surplus, 0)                   as surplus,
-                       coalesce(fee, 0)                       as fee,
-                       surplus + fee - reference_score        AS payment,
+                       ss.auction_id,
+                       -- TODO - Assuming that `solver == winner` when both not null
+                       --  We will need to monitor that `solver == winner`!
+                       coalesce(solver, winner)               as solver,
+                       block_number                           as settlement_block,
+                       block_deadline,
+                       case
+                         when block_number is not null and block_number > block_deadline then 0
+                         else coalesce(execution_cost, 0) end as execution_cost,
+                       case
+                         when block_number is not null and block_number > block_deadline then 0
+                         else coalesce(surplus, 0) end        as surplus,
+                       case
+                         when block_number is not null and block_number > block_deadline then 0
+                         else coalesce(fee, 0) end            as fee,
                        -- scores
                        winning_score,
                        reference_score,
-                       -- participation
-                       participants
+                       -- auction_participation
+                       participating_solvers
                      FROM settlement_scores ss
                             -- If there are reported scores,
                             -- there will always be a record of auction participants
-                            JOIN auction_participants ap
+                            JOIN auction_participation ap
                                  ON ss.auction_id = ap.auction_id
                        -- outer joins made in order to capture non-existent settlements.
                             LEFT OUTER JOIN observed_settlements os
                                             ON os.auction_id = ss.auction_id),
-
-     reward_per_tx as (SELECT tx_hash,
-                              solver,
-                              execution_cost,
-                              surplus,
-                              fee,
-                              surplus + fee - reference_score                                                              as uncapped_reward_eth,
-                              -- Uncapped Reward = CLAMP_[-E, E + exec_cost](uncapped_reward_eth)
-                              LEAST(GREATEST(-{{EPSILON}}, surplus + fee - reference_score), {{EPSILON}} + execution_cost) as capped_reward,
-                              winning_score,
-                              reference_score,
-                              participants                                                                                 as participating_solvers
-                       FROM reward_data),
-
-     participation_data as (SELECT tx_hash,
-                                   unnest(participating_solvers) as participant
-                            FROM reward_per_tx),
-     participation_counts as (SELECT participant as solver,
-                                     count(*)    as num_participating_batches
+     reward_per_auction as (SELECT tx_hash,
+                                   auction_id,
+                                   settlement_block,
+                                   block_deadline,
+                                   solver,
+                                   execution_cost,
+                                   surplus,
+                                   fee,
+                                   surplus + fee - reference_score as uncapped_reward_eth,
+                                   -- Uncapped Reward = CLAMP_[-E, E + exec_cost](uncapped_reward_eth)
+                                   LEAST(GREATEST(-{{EPSILON}}, surplus + fee - reference_score),
+                                     {{EPSILON}} + execution_cost) as capped_reward,
+                                   winning_score,
+                                   reference_score,
+                                   participating_solvers           as participating_solvers
+                            FROM reward_data),
+     participation_data as (SELECT tx_hash, unnest(participating_solvers) as participant
+                            FROM reward_per_auction),
+     participation_counts as (SELECT participant as solver, count(*) as num_participating_batches
                               FROM participation_data
                               GROUP BY participant),
      primary_rewards as (SELECT rpt.solver,
                                 SUM(capped_reward)  as total_reward_eth,
                                 SUM(execution_cost) as total_exececution_cost_eth
-                         FROM reward_per_tx rpt
-                         GROUP BY solver)
+                         FROM reward_per_auction rpt
+                         GROUP BY solver),
+     aggregate_results as (SELECT concat('0x', encode(pc.solver, 'hex'))  as solver,
+                                  coalesce(total_reward_eth, 0)           as total_reward_eth,
+                                  coalesce(total_exececution_cost_eth, 0) as total_execution_cost_eth,
+                                  num_participating_batches
+                           FROM participation_counts pc
+                                  LEFT OUTER JOIN primary_rewards pr
+                                                  ON pr.solver = pc.solver)
 
-SELECT concat('0x', encode(pc.solver, 'hex'))                as solver,
-       coalesce(total_reward_eth, 0) / pow(10, 18)           as total_reward_eth,
-       coalesce(total_exececution_cost_eth, 0) / pow(10, 18) as total_exececution_cost_eth,
-       num_participating_batches
-FROM participation_counts pc
-       LEFT OUTER JOIN primary_rewards pr
-                       ON pr.solver = pc.solver;
-
-
-
+select *
+from aggregate_results;


### PR DESCRIPTION
This query extracts solver reward info from the DB in order to compute the weekly solver rewards. Top half of this query (up till `rewards_per_tx`) has already been reviewed in the  [dune-sync project](https://github.com/cowprotocol/dune-sync/pull/26). Now we aggregate this for the primary and secondary totals for the period.

