### PR TITLE
[WIP] Test Demonstrating Bogus Slippage

### DIFF
--- a/tests/queries/test_slippage_investigation.py
+++ b/tests/queries/test_slippage_investigation.py
@@ -188,6 +188,34 @@ class TestDuneAnalytics(unittest.TestCase):
             ],
         )
 
+    def test_slippage_0xb0eb23(self):
+        """
+        Bad Slippage Calculation (on dashboard and in our Slippage Query -- but not in Token Imbalance)
+        https://cowservices.slack.com/archives/C037UV49JLR/p1677580069637059?thread_ts=1677571577.413889&cid=C037UV49JLR
+        """
+        period = AccountingPeriod("2023-02-21", 1)
+        # Unusual Slippage query shows 900$ in slippage!
+        tx_hash = "0xb0eb23b6864a5dd2447140a06174537f8b5ad7d70e5f2d8af76ddc8d62fbf21a"
+        result = exec_or_get(
+            self.dune,
+            query=self.slippage_query_for(period, tx_hash),
+            result_id="01GTBSD5J7P0CTSXJHCSG3TB2X",
+        )
+        self.assertEqual(result.query_id, self.slippage_query.v2_query.query_id)
+        self.assertEqual(
+            result.get_rows(),
+            [
+                {
+                    "eth_slippage_wei": -588897866192248800,
+                    "hour": "2023-02-21T09:00:00Z",
+                    "num_entries": 2,
+                    "solver_address": "0xc9ec550bea1c64d779124b23a26292cc223327b6",
+                    "tx_hash": "0xb0eb23b6864a5dd2447140a06174537f8b5ad7d70e5f2d8af76ddc8d62fbf21a",
+                    "usd_value": -991.142590701977,
+                }
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Something is being computed wrong in our slippage query and it appears to be related to ETH/WETH transfers again:

Using [this query](https://dune.com/queries/1995951?CTE_NAME_e15077=incoming_and_outgoing_with_buffer_trades&StartTime_d83555=2023-02-20+00%3A00%3A00&EndTime_d83555=2023-02-22+00%3A00%3A00&TxHash_t6c1ea=0xb0eb23b6864a5dd2447140a06174537f8b5ad7d70e5f2d8af76ddc8d62fbf21a)

We see that the Final Token Balance Sheet does not contain WETH stuff (which was definitely part of it)
![Screenshot 2023-02-28 at 11 49 40](https://user-images.githubusercontent.com/11778116/221833539-e2f681cd-8f1a-4d83-88b6-858bf7a55847.png)

## References
- [Etherscan](https://etherscan.io/tx/0xb0eb23b6864a5dd2447140a06174537f8b5ad7d70e5f2d8af76ddc8d62fbf21a)

- [Token Imbalances](https://dune.com/queries/1380984?TxHash=0xb0eb23b6864a5dd2447140a06174537f8b5ad7d70e5f2d8af76ddc8d62fbf21a&TxHash_t6c1ea=0xb0eb23b6864a5dd2447140a06174537f8b5ad7d70e5f2d8af76ddc8d62fbf21a)

<img width="750" alt="Screenshot 2023-02-28 at 11 56 00" src="https://user-images.githubusercontent.com/11778116/221833893-66b20efb-aa07-4250-8092-dfacd5de4537.png">

- Buffer Trade Classification
![Screenshot 2023-02-28 at 11 56 27](https://user-images.githubusercontent.com/11778116/221834004-872e1bc6-6c60-4324-b582-507a54867ba5.png)

- [Unusual Slippage for Batch](https://dune.com/queries/1688044?StartTime_d83555=2023-02-20+00%3A00%3A00&EndTime_d83555=2023-02-22+00%3A00%3A00&TxHash_t6c1ea=0xb0eb23b6864a5dd2447140a06174537f8b5ad7d70e5f2d8af76ddc8d62fbf21a)
