### PR TITLE
Slippage Handling

### DIFF
--- a/src/models/split_transfers.py
+++ b/src/models/split_transfers.py
@@ -6,7 +6,6 @@ internal methods are called in the appropriate order.
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Optional
 
 from dune_client.types import Address
 
@@ -62,8 +61,8 @@ class SplitTransfers:
         while self.unprocessed_native:
             transfer = self.unprocessed_native.pop(0)
             solver = transfer.recipient
-            slippage: Optional[SolverSlippage] = indexed_slippage.get(solver)
-            if slippage is not None:
+            try:
+                slippage: SolverSlippage = indexed_slippage.pop(solver)
                 assert (
                     slippage.amount_wei < 0
                 ), f"Expected negative slippage! Got {slippage}"
@@ -83,7 +82,19 @@ class SplitTransfers:
                     # Deduct entire transfer value.
                     penalty_total -= transfer.amount_wei
                     continue
+            except KeyError:
+                pass
             self.eth_transfers.append(transfer)
+
+        if indexed_slippage:
+            # This is the case when solver had Negative Payment
+            # and did not appear in the list of unprocessed_native transfers
+            # slippages were expected drained!
+            # TODO - Deal with this!
+            raise ValueError(
+                "This is a scenario where solver has no payment but also has negative slippage!"
+            )
+
         return penalty_total
 
     def _process_rewards(


### PR DESCRIPTION
While working on CIP-20, it crossed my mind that a solver having no expected reimbursement, but having non-trivial slippage for the week would not wind up paying their slippage penalty (because of the iteration order). Of course this could never actually occur in the old setup since having non-zero slippage implies non-zero successful execution costs for the accounting period. However, in the new (post CIP20 model) it is entirely possible to have negative or zero "remibursement" for the week and thus such an iteration technique would miss slippage accounting. 

This is not an urgent change at all because we will likely not use this code path for CIP-20, but still worth being aware of and "handling" properly.