### PR TITLE
[CIP-20] Trial Run Bugs

### DIFF
--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -319,7 +319,7 @@ def construct_payout_dataframe(
     with reward and execution data coming from orderbook.
     """
     # TODO - After CIP-20 phased in, adapt query to return `solver` like all the others
-    slippage_df.rename(columns={"solver_address": "solver"})
+    slippage_df = slippage_df.rename(columns={"solver_address": "solver"})
     # 1. Assert existence of required columns.
     validate_df_columns(payment_df, slippage_df, reward_target_df)
 
@@ -358,7 +358,8 @@ def post_cip20_payouts(
         slippage_df=pandas.DataFrame(dune.get_period_slippage()),
         reward_target_df=pandas.DataFrame(dune.get_vouches()),
     )
-    # TODO - sort by solver first?
+    # Sort by solver before breaking this data frame into Transfer objects.
+    complete_payout_df.sort_values("solver")
     payouts = prepare_transfers(complete_payout_df, dune.period)
-    # TODO - make sure to log Overdrafts
+    # TODO - make sure to log Overdrafts!
     return payouts.transfers

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -111,8 +111,8 @@ if __name__ == "__main__":
         )
     else:
         payout_transfers = dune.get_transfers()
+        Transfer.sort_list(payout_transfers)
 
-    Transfer.sort_list(payout_transfers)
     payout_transfers = list(
         filter(
             lambda payout: payout.amount_wei > args.min_transfer_amount_wei,


### PR DESCRIPTION
Ran into an issue with column naming and result sorting. Also added a convenience method (so we don't have to wait 20 minutes on the slippage query during debugging.


Ran with 

```
python -m src.fetch.transfer_file --start 2023-03-10 --post-cip20 True
```

Note that the trial run was run for slippage query results for `job_id = "01GVTJHS7JY7BJXJEJSA3N85C4"` and the resulting transfer file is:

[transfers-2023-03-10-to-2023-03-17.csv](https://github.com/cowprotocol/solver-rewards/files/11011762/transfers-2023-03-10-to-2023-03-17.csv)

and totals:

```
WARNING Invalid ETH Transfer 0x5B0BFe439ab45A4F002C259b1654ED21c9a42D69 with amount=0
WARNING Invalid ETH Transfer 0x8ccc61dBA297833dbe5D95FD6360f106b9A7576e with amount=0

Total ETH Funds needed: 137.4160
Total COW Funds needed: 477941.6321
```

Note that 477K COW is greater than the PERIOD_BUDGET_COW = 383307