### PR TITLE
[CIP-20] payment_df script

### DIFF
--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -229,9 +229,6 @@ class TokenConversion:
 
 def extend_payment_df(pdf: DataFrame, converter: TokenConversion) -> DataFrame:
     """
-    TODO: add type: `eth_to_token` is a function with signature (int -> int)
-          add type: `token_to_eth` is a function with signature (int -> int)
-                (one is the compositional the inverse of the other)
     Extending the basic columns returned by SQL Query with some after-math:
     - reward_eth as difference of payment and execution_cost
     - reward_cow as conversion from ETH to cow.

--- a/src/scripts/payment_df.py
+++ b/src/scripts/payment_df.py
@@ -1,0 +1,50 @@
+"""
+Basic Script to Extract the Extended Payment DataFrame for Solver Batch Rewards for a Block Range
+"""
+
+import argparse
+import os
+from datetime import timedelta, datetime
+
+from src.constants import FILE_OUT_DIR
+from src.fetch.payouts import extend_payment_df, TokenConversion
+from src.fetch.prices import eth_in_token, token_in_eth, TokenId
+from src.pg_client import MultiInstanceDBFetcher
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        "Get Payment Dataframe for block range (uses yesterday's prices)"
+    )
+    parser.add_argument(
+        "--start",
+        type=str,
+        help="Start Block Number (block_deadline)",
+        default="0",
+    )
+    parser.add_argument(
+        "--end",
+        type=str,
+        help="End Block Number (block_deadline)",
+        default="999999999",
+    )
+    args = parser.parse_args()
+
+    orderbook = MultiInstanceDBFetcher(
+        db_urls=[os.environ["PROD_DB_URL"], os.environ["BARN_DB_URL"]]
+    )
+
+    yesterday = datetime.today() - timedelta(days=1)
+    yesterday = yesterday.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    start, end = args.start, args.end
+
+    payment_df = extend_payment_df(
+        pdf=orderbook.get_solver_rewards(start, end),
+        # provide token conversion functions (ETH <--> COW)
+        converter=TokenConversion(
+            eth_to_token=lambda t: eth_in_token(TokenId.COW, t, yesterday),
+            token_to_eth=lambda t: token_in_eth(TokenId.COW, t, yesterday),
+        ),
+    )
+    out_path = FILE_OUT_DIR / f"payments-{start}-{end}-{yesterday.date()}.csv"
+    payment_df.to_csv(out_path, index=False)

--- a/src/scripts/payment_df.py
+++ b/src/scripts/payment_df.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
         "--end",
         type=str,
         help="End Block Number (block_deadline)",
-        default="999999999",
+        default="16875871",
     )
     args = parser.parse_args()
 

--- a/src/scripts/payment_df.py
+++ b/src/scripts/payment_df.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         "--start",
         type=str,
         help="Start Block Number (block_deadline)",
-        default="0",
+        default="16865181",
     )
     parser.add_argument(
         "--end",


### PR DESCRIPTION
This script gives an aggregated account of the Solver Performance for a block range.


## Example

Using [this Dune Query](https://dune.com/queries/1541504?StartTime_d83555=2023-03-20+00%3A00%3A00&EndTime_d83555=2023-03-21+12%3A00%3A00) you can get the block range for the first 12 hours of CIP-20 Batch Rewards launch

```
start_block | end_block
16865181 | 16875871
```


We run the script here as:

```
python -m src.scripts.payment_df --start 16865181 --end 16875871
```

and get the following output:

[payments-16865181-16875871-2023-03-20.csv](https://github.com/cowprotocol/solver-rewards/files/11028058/payments-16865181-16875871-2023-03-20.csv)

[Here it is](https://docs.google.com/spreadsheets/d/1hdAv-PxBLLVAJLL498QeX0nQ28mOZjD7BvmsMLKxyQc/edit?usp=sharing) in Google Sheets: 

## Additional Notes

Note that we should not put much more effort into refining this script because we will soon have all this information available in Dune (where we can create dashboards and things).

