### PR TITLE
[Easy/CIP-20] Flip the default runtime switch

### DIFF
--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -102,16 +102,17 @@ if __name__ == "__main__":
         category=Category.GENERAL,
     )
 
-    if args.post_cip20:
+    if args.pre_cip20:
+        payout_transfers = dune.get_transfers()
+        Transfer.sort_list(payout_transfers)
+
+    else:
         payout_transfers = post_cip20_payouts(
             args.dune,
             orderbook=MultiInstanceDBFetcher(
                 [os.environ["PROD_DB_URL"], os.environ["BARN_DB_URL"]]
             ),
         )
-    else:
-        payout_transfers = dune.get_transfers()
-        Transfer.sort_list(payout_transfers)
 
     payout_transfers = list(
         filter(

--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -18,7 +18,7 @@ class ScriptArgs:
     dune: DuneFetcher
     post_tx: bool
     dry_run: bool
-    post_cip20: bool
+    pre_cip20: bool
     consolidate_transfers: bool
     min_transfer_amount_wei: int
 
@@ -44,10 +44,10 @@ def generic_script_init(description: str) -> ScriptArgs:
         default=False,
     )
     parser.add_argument(
-        "--post-cip20",
+        "--pre-cip20",
         type=bool,
-        help="Flag payout should be made according to pre or post CIP 20 "
-        "(temporary during switch over)",
+        help="Flag payout should be made according to pre or post CIP-20. "
+        "Default is set to the current reward scheme",
         default=False,
     )
     parser.add_argument(
@@ -85,7 +85,7 @@ def generic_script_init(description: str) -> ScriptArgs:
             period=AccountingPeriod(args.start),
             dune_version=args.dune_version,
         ),
-        post_cip20=args.post_cip20,
+        pre_cip20=args.pre_cip20,
         post_tx=args.post_tx,
         dry_run=args.dry_run,
         consolidate_transfers=args.consolidate_transfers,


### PR DESCRIPTION
This PR makes it so that the standard run of this script uses "post CIP20" logic. Merging this into main means that our Monday morning dry-run will run the correct path without the need for redeployment and tagging the main branch will trigger the production service to do the same (i.e. no need to reconfigure existing deployments).