### PR TITLE
[Easy] Variable Rename

### DIFF
--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -72,7 +72,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         payment_eth: int,
         secondary_reward_eth: int,
         slippage_eth: int,
-        reward_cow: int,
+        primary_reward_cow: int,
         secondary_reward_cow: int,
     ):
         assert exec_cost >= 0, f"invalid execution cost {exec_cost}"
@@ -85,7 +85,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         self.exec_cost = exec_cost
         self.payment_eth = payment_eth
         self.slippage_eth = slippage_eth
-        self.reward_cow = reward_cow
+        self.primary_reward_cow = primary_reward_cow
         self.secondary_reward_eth = secondary_reward_eth
         self.secondary_reward_cow = secondary_reward_cow
 
@@ -109,7 +109,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             reward_target=Address(reward_target),
             payment_eth=int(frame["payment_eth"]),
             slippage_eth=slippage,
-            reward_cow=int(frame["reward_cow"]),
+            primary_reward_cow=int(frame["reward_cow"]),
             exec_cost=int(frame["execution_cost_eth"]),
             secondary_reward_eth=int(frame["secondary_reward_eth"]),
             secondary_reward_cow=int(frame["secondary_reward_cow"]),
@@ -121,7 +121,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
 
     def total_cow_reward(self) -> int:
         """Total outgoing COW token reward"""
-        return self.reward_cow + self.secondary_reward_cow
+        return self.primary_reward_cow + self.secondary_reward_cow
 
     def total_eth_reward(self) -> int:
         """Total outgoing ETH reward"""
@@ -140,21 +140,23 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         """
         # We do not handle overdraft scenario here!
         assert not self.is_overdraft()
-        reward_eth = int(self.total_eth_reward())
-        reward_cow = int(self.total_cow_reward())
+        total_eth_reward = int(self.total_eth_reward())
+        total_cow_reward = int(self.total_cow_reward())
 
         reimbursement_eth = int(self.exec_cost + self.slippage_eth)
         # We do not have access to token conversion here, but we do have other converted values
         # x_eth:x_cow = y_eth:y_cow --> y_cow = y_eth * x_cow / x_eth
         reimbursement_cow = (
-            (reimbursement_eth * reward_cow) // reward_eth if reward_eth != 0 else 0
+            (reimbursement_eth * total_cow_reward) // total_eth_reward
+            if total_eth_reward != 0
+            else 0
         )
 
-        if reimbursement_eth > 0 > reward_cow:
+        if reimbursement_eth > 0 > total_cow_reward:
             # If the total payment is positive but the total rewards are negative,
             # pay the total payment in ETH. The total payment corresponds to reimbursement,
             # reduced by the negative reward.
-            # That assertion was not necessary because:
+            # Note that;
             # reimbursement_eth + reward_eth
             # = self.total_eth_reward() + self.exec_cost + self.slippage_eth
             # = self.payment_eth + self.secondary_reward_eth + self.slippage_eth
@@ -165,14 +167,14 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
                     Transfer(
                         token=None,
                         recipient=self.solver,
-                        amount_wei=reimbursement_eth + reward_eth,
+                        amount_wei=reimbursement_eth + total_eth_reward,
                     )
                 ]
-                if reimbursement_eth + reward_eth > 0
+                if reimbursement_eth + total_eth_reward > 0
                 else []
             )
 
-        if reimbursement_eth < 0 < reward_cow:
+        if reimbursement_eth < 0 < total_cow_reward:
             # If the total payment is positive but the total reimbursement is negative,
             # pay the total payment in COW. The total payment corresponds to a payment of rewards,
             # reduced by the negative reimbursement.
@@ -181,10 +183,10 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
                     Transfer(
                         token=Token(COW_TOKEN_ADDRESS),
                         recipient=self.solver,
-                        amount_wei=reimbursement_cow + reward_cow,
+                        amount_wei=reimbursement_cow + total_cow_reward,
                     )
                 ]
-                if reimbursement_cow + reward_cow > 0
+                if reimbursement_cow + total_cow_reward > 0
                 else []
             )
 
@@ -206,12 +208,12 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
                 Transfer(
                     token=Token(COW_TOKEN_ADDRESS),
                     recipient=self.reward_target,
-                    amount_wei=reward_cow,
+                    amount_wei=total_cow_reward,
                 )
             )
         except AssertionError:
             logging.warning(
-                f"Invalid COW Transfer {self.solver} with amount={reward_cow}"
+                f"Invalid COW Transfer {self.solver} with amount={total_cow_reward}"
             )
 
         return result

--- a/tests/unit/test_payouts.py
+++ b/tests/unit/test_payouts.py
@@ -347,7 +347,7 @@ class TestRewardAndPenaltyDatum(unittest.TestCase):
             reward_target=self.reward_target,
             payment_eth=payment,
             exec_cost=cost,
-            reward_cow=(payment - cost) * self.conversion_rate,
+            primary_reward_cow=(payment - cost) * self.conversion_rate,
             secondary_reward_eth=participation,
             secondary_reward_cow=participation * self.conversion_rate,
             slippage_eth=slippage,


### PR DESCRIPTION
Previously we had two things called `reward_cow` the field on the object and a variable within the transfer creation logic. One of these was mislabeled representation of `primary_reward_cow` while the other was actually a representation of the `total_reward_cow` (which is the sum of primary and secondary rewards).

This was discovered while implementing the dashboard query for validation (see here https://dune.com/queries/2249337). In order to avoid confusion (and potential bugs) we fix this here.