### PR TITLE
Deterministic Slippage

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,4 +1,4 @@
--- https://github.com/cowprotocol/solver-rewards/pull/215
+-- https://github.com/cowprotocol/solver-rewards/pull/216
 with
 batch_meta as (
     select b.block_time,

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,4 +1,4 @@
--- https://github.com/cowprotocol/solver-rewards/pull/188
+-- https://github.com/cowprotocol/solver-rewards/pull/215
 with
 batch_meta as (
     select b.block_time,
@@ -120,13 +120,16 @@ eth_transfers as (
     and not array_contains(traders_out, to)
 ),
 pre_batch_transfers as (
-    select * from user_in
-    union all
-    select * from user_out
-    union all
-    select * from other_transfers
-    union all
-    select * from eth_transfers
+    select * from (
+        select * from user_in
+        union all
+        select * from user_out
+        union all
+        select * from other_transfers
+        union all
+        select * from eth_transfers
+        ) as _
+    order by tx_hash
 ),
 batch_transfers as (
     select
@@ -343,6 +346,7 @@ buffer_trades as (
               )
 ),
 incoming_and_outgoing_with_buffer_trades as (
+select * from (
     select block_time,
           tx_hash,
           solver_address,
@@ -360,6 +364,8 @@ incoming_and_outgoing_with_buffer_trades as (
           amount_from as amount,
           transfer_type
     from buffer_trades
+) as _
+order by block_time
 ),
 final_token_balance_sheet as (
     select
@@ -444,6 +450,7 @@ intrinsic_prices as (
         AND units_sold > 0
     ) as combined
     GROUP BY hour, contract_address, decimals
+    order by hour
 ),
 -- Price Construction: https://dune.com/queries/1579091?
 prices as (

--- a/src/queries.py
+++ b/src/queries.py
@@ -96,6 +96,6 @@ QUERIES = {
         name="Solver Slippage for Period",
         filepath="period_slippage.sql",
         v1_id=1728478,
-        v2_id=1995951,
+        v2_id=2259497,
     ),
 }

--- a/tests/queries/test_slippage_investigation.py
+++ b/tests/queries/test_slippage_investigation.py
@@ -65,11 +65,7 @@ class TestDuneAnalytics(unittest.TestCase):
             ],
             dune_version=DuneVersion.V2,
         )
-        results = exec_or_get(
-            self.dune,
-            query,
-            result_id="01GW9JK5K0JMXEFYETHX8YQ3YA"
-        )
+        results = exec_or_get(self.dune, query, result_id="01GW9JK5K0JMXEFYETHX8YQ3YA")
         self.assertEqual(results.query_id, self.slippage_query.v2_query.query_id)
         slippage_per_tx = results.get_rows()
 
@@ -99,11 +95,7 @@ class TestDuneAnalytics(unittest.TestCase):
             ],
             dune_version=DuneVersion.V2,
         )
-        results = exec_or_get(
-            self.dune,
-            query,
-            result_id="01GW9JNPSPJTADDYTW2HEAD4J2"
-        )
+        results = exec_or_get(self.dune, query, result_id="01GW9JNPSPJTADDYTW2HEAD4J2")
         self.assertEqual(results.query_id, self.slippage_query.v2_query.query_id)
         tx_slippage = results.get_rows()[0]
         self.assertEqual(tx_slippage["eth_slippage_wei"], 71151929005056890)
@@ -130,11 +122,7 @@ class TestDuneAnalytics(unittest.TestCase):
             ],
             dune_version=DuneVersion.V2,
         )
-        results = exec_or_get(
-            self.dune,
-            query,
-            result_id="01GW9QA64YYRRKXQDTAN8QMYAS"
-        )
+        results = exec_or_get(self.dune, query, result_id="01GW9QA64YYRRKXQDTAN8QMYAS")
         self.assertEqual(results.query_id, self.slippage_query.v2_query.query_id)
         tx_slippage = results.get_rows()[0]
         self.assertEqual(tx_slippage["eth_slippage_wei"], 148427839329771500)


### PR DESCRIPTION
Closes #191

There are 5 occurrences of UNION in the slippage query. We wrap around each of these unions and impose a sort condition on each. According to the logic described in the related issue, this will make our arithmetic deterministic.

## Test Plan

We rerun some test queries to ensure no regression. Had to change a few very minor valuations (all around or less than < 10^3 WEI)