### PR TITLE
[Performance] Slippage in DuneSQL

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,4 +1,4 @@
--- https://github.com/cowprotocol/solver-rewards/pull/216
+-- https://github.com/cowprotocol/solver-rewards/pull/217
 with
 batch_meta as (
     select b.block_time,
@@ -54,7 +54,7 @@ filtered_trades as (
         trader_in        as sender,
         contract_address as receiver,
         sell_token       as token,
-        cast(atoms_sold as uint256)       as amount_wei,
+        cast(atoms_sold as int256)       as amount_wei,
         'IN_USER'        as transfer_type
     from filtered_trades
 )
@@ -63,7 +63,7 @@ filtered_trades as (
           contract_address as sender,
           trader_out       as receiver,
           buy_token        as token,
-          cast(atoms_bought as uint256)            as amount_wei,
+          cast(atoms_bought as int256)            as amount_wei,
           'OUT_USER'       as transfer_type
     from filtered_trades
 )
@@ -72,7 +72,7 @@ filtered_trades as (
           "from"             as sender,
           to                 as receiver,
           t.contract_address as token,
-          value              as amount_wei,
+          cast(value as int256) as amount_wei,
           case
               when to = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
                   then 'IN_AMM'
@@ -102,7 +102,7 @@ filtered_trades as (
         "from" as sender,
         to     as receiver,
         0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee as token,
-        value as amount_wei,
+        cast(value as int256) as amount_wei,
         case
           when 0x9008d19f58aabd9ed0d60971565aa8510560ab41 = to
           then 'AMM_IN'
@@ -173,9 +173,9 @@ incoming_and_outgoing as (
               end                                     as token,
           case
               when receiver = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-                  then cast(cast(amount_wei as varchar) as int256)
+                  then amount_wei
               when sender = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-                  then cast(-1 as int256) * cast(cast(amount_wei as varchar) as int256)
+                  then cast(-1 as int256) * amount_wei
               end                                     as amount,
           transfer_type
     from batch_transfers i
@@ -189,7 +189,6 @@ incoming_and_outgoing as (
       -- and we want to consider them in order to filter out illegal behaviour
       and ((dex_swaps = 0 and num_trades < 2) or dex_swaps > 0)
 )
--- Benchmark takes 3 minuites to get here for ONE DAY interval!
 
 -- Clearing Prices query here: https://dune.com/queries/1571457
 ,pre_clearing_prices as (

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -7,15 +7,15 @@ batch_meta as (
            case
             when dex_swaps = 0
             -- Estimation made here: https://dune.com/queries/1646084
-                then ((gas_used - 73688 - (70528 * num_trades)) / 90000)::int
+                then cast((gas_used - 73688 - (70528 * num_trades)) / 90000 as int)
                 else dex_swaps
            end as dex_swaps,
            num_trades,
            b.solver_address
     from cow_protocol_ethereum.batches b
-    where b.block_time between '{{StartTime}}' and '{{EndTime}}'
-    and (b.solver_address = lower('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
-    and (b.tx_hash = lower('{{TxHash}}') or '{{TxHash}}' = '0x')
+    where b.block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
+    and (b.solver_address = from_hex('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
+    and (b.tx_hash = from_hex('{{TxHash}}') or '{{TxHash}}' = '0x')
 ),
 filtered_trades as (
     select t.tx_hash,
@@ -26,7 +26,7 @@ filtered_trades as (
            buy_token_address                            as buy_token,
            atoms_sold - coalesce(surplus_fee, 0)        as atoms_sold,
            atoms_bought,
-           '0x9008d19f58aabd9ed0d60971565aa8510560ab41' as contract_address
+           0x9008d19f58aabd9ed0d60971565aa8510560ab41 as contract_address
     from cow_protocol_ethereum.trades t
          join cow_protocol_ethereum.batches b
             on t.block_number = b.block_number
@@ -34,48 +34,49 @@ filtered_trades as (
     left outer join cow_protocol_ethereum.order_rewards f
         on f.tx_hash = t.tx_hash
         and f.order_uid = t.order_uid
-    where b.block_time between '{{StartTime}}' and '{{EndTime}}'
-    and t.block_time between '{{StartTime}}' and '{{EndTime}}'
-    and (b.solver_address = lower('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
-    and (t.tx_hash = lower('{{TxHash}}') or '{{TxHash}}' = '0x')
-),
-batchwise_traders as (
+    where b.block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
+    and t.block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
+    and (b.solver_address = from_hex('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
+    and (t.tx_hash = from_hex('{{TxHash}}') or '{{TxHash}}' = '0x')
+)
+,batchwise_traders as (
     select
         tx_hash,
         block_number,
-        collect_set(trader_in) as traders_in,
-        collect_set(trader_out) as traders_out
+        array_agg(trader_in) as traders_in,
+        array_agg(trader_out) as traders_out
     from filtered_trades
     group by tx_hash, block_number
-),
-user_in as (
-    select  tx_hash,
-          trader_in        as sender,
-          contract_address as receiver,
-          sell_token       as token,
-          atoms_sold       as amount_wei,
-          'IN_USER'        as transfer_type
+)
+,user_in as (
+    select
+        tx_hash,
+        trader_in        as sender,
+        contract_address as receiver,
+        sell_token       as token,
+        cast(atoms_sold as uint256)       as amount_wei,
+        'IN_USER'        as transfer_type
     from filtered_trades
-),
-user_out as (
+)
+,user_out as (
     select tx_hash,
           contract_address as sender,
           trader_out       as receiver,
           buy_token        as token,
-          atoms_bought     as amount_wei,
+          cast(atoms_bought as uint256)            as amount_wei,
           'OUT_USER'       as transfer_type
     from filtered_trades
-),
-other_transfers as (
+)
+,other_transfers as (
     select b.tx_hash,
-          from               as sender,
+          "from"             as sender,
           to                 as receiver,
           t.contract_address as token,
           value              as amount_wei,
           case
-              when to = '0x9008d19f58aabd9ed0d60971565aa8510560ab41'
+              when to = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
                   then 'IN_AMM'
-              when from = '0x9008d19f58aabd9ed0d60971565aa8510560ab41'
+              when "from" = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
                   then 'OUT_AMM'
               end            as transfer_type
     from erc20_ethereum.evt_Transfer t
@@ -84,26 +85,26 @@ other_transfers as (
                 and evt_tx_hash = b.tx_hash
              inner join batchwise_traders bt
                 on evt_tx_hash = bt.tx_hash
-    where b.block_time between '{{StartTime}}' and '{{EndTime}}'
-      and '0x9008d19f58aabd9ed0d60971565aa8510560ab41' in (to, from)
-      and not array_contains(traders_in, from)
-      and not array_contains(traders_out, to)
-      and from not in ( -- ETH FLOW ORDERS ARE NOT AMM TRANSFERS!
+    where b.block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
+      and 0x9008d19f58aabd9ed0d60971565aa8510560ab41 in (to, "from")
+      and not contains(traders_in, "from")
+      and not contains(traders_out, to)
+      and "from" not in ( -- ETH FLOW ORDERS ARE NOT AMM TRANSFERS!
           select distinct contract_address
           from cow_protocol_ethereum.CoWSwapEthFlow_evt_OrderPlacement
       )
-      and (t.evt_tx_hash = lower('{{TxHash}}') or '{{TxHash}}' = '0x')
-      and (solver_address = lower('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
-),
-eth_transfers as (
+      and (t.evt_tx_hash = from_hex('{{TxHash}}') or '{{TxHash}}' = '0x')
+      and (solver_address = from_hex('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
+)
+,eth_transfers as (
     select
         bt.tx_hash,
-        from as sender,
-        to as receiver,
-        '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' as token,
-        cast(value as decimal(38, 0)) as amount_wei,
+        "from" as sender,
+        to     as receiver,
+        0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee as token,
+        value as amount_wei,
         case
-          when '0x9008d19f58aabd9ed0d60971565aa8510560ab41' = to
+          when 0x9008d19f58aabd9ed0d60971565aa8510560ab41 = to
           then 'AMM_IN'
           else 'AMM_OUT'
         end as transfer_type
@@ -111,15 +112,15 @@ eth_transfers as (
     inner join ethereum.traces et
         on bt.block_number = et.block_number
         and bt.tx_hash = et.tx_hash
-        and cast(value as decimal(38, 0)) > 0
+        and value > cast(0 as uint256)
         and success = true
-    and '0x9008d19f58aabd9ed0d60971565aa8510560ab41' in (to, from)
+    and 0x9008d19f58aabd9ed0d60971565aa8510560ab41 in (to, "from")
     -- WETH unwraps don't have cancelling WETH transfer.
-    and from != '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+    and "from" != 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
     -- ETH transfers to traders are already part of USER_OUT
-    and not array_contains(traders_out, to)
-),
-pre_batch_transfers as (
+    and not contains(traders_out, to)
+)
+,pre_batch_transfers as (
     select * from (
         select * from user_in
         union all
@@ -130,8 +131,8 @@ pre_batch_transfers as (
         select * from eth_transfers
         ) as _
     order by tx_hash
-),
-batch_transfers as (
+)
+,batch_transfers as (
     select
         block_time,
         block_number,
@@ -147,12 +148,12 @@ batch_transfers as (
     from batch_meta bm
     join pre_batch_transfers pbt
         on bm.tx_hash = pbt.tx_hash
-),
+)
 -- These batches involve a token AXS (Old)
 -- whose transfer function doesn't align with the emitted transfer event.
-excluded_batches as (
+,excluded_batches as (
     select tx_hash from filtered_trades
-    where '0xf5d669627376ebd411e34b98f19c868c8aba5ada' in (buy_token, sell_token)
+    where 0xf5d669627376ebd411e34b98f19c868c8aba5ada in (buy_token, sell_token)
 ),
 incoming_and_outgoing as (
     SELECT
@@ -163,18 +164,18 @@ incoming_and_outgoing as (
         case
             when t.symbol = 'ETH' then 'WETH'
             when t.symbol is not null then t.symbol
-            else token
+            else cast(token as varchar)
         end                                     as symbol,
           case
-              when token = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
-                  then '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+              when token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                  then 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
               else token
               end                                     as token,
           case
-              when receiver = '0x9008d19f58aabd9ed0d60971565aa8510560ab41'
-                  then amount_wei
-              when sender = '0x9008d19f58aabd9ed0d60971565aa8510560ab41'
-                  then -1 * amount_wei
+              when receiver = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+                  then cast(cast(amount_wei as varchar) as int256)
+              when sender = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+                  then cast(-1 as int256) * cast(cast(amount_wei as varchar) as int256)
               end                                     as amount,
           transfer_type
     from batch_transfers i
@@ -187,35 +188,35 @@ incoming_and_outgoing as (
       -- Settlements with dex_swaps = 0 and num_trades = 0 can be handled in the following
       -- and we want to consider them in order to filter out illegal behaviour
       and ((dex_swaps = 0 and num_trades < 2) or dex_swaps > 0)
-),
+)
 -- Benchmark takes 3 minuites to get here for ONE DAY interval!
 
 -- Clearing Prices query here: https://dune.com/queries/1571457
-pre_clearing_prices as (
+,pre_clearing_prices as (
     select
         call_tx_hash as tx_hash,
         price,
         token
     from gnosis_protocol_v2_ethereum.GPv2Settlement_call_settle
-        lateral view posexplode(clearingPrices) as i, price
-        lateral view posexplode(tokens) as j, token
-    where call_block_time between '{{StartTime}}' and '{{EndTime}}'
+      CROSS JOIN UNNEST(clearingPrices) WITH ORDINALITY AS p (price, i)
+      CROSS JOIN UNNEST(tokens) WITH ORDINALITY AS t (token, j)
+    where call_block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
       and call_success = true
       and i = j
-),
-clearing_prices as (
+)
+,clearing_prices as (
     select
         tx_hash,
         case
-            when token = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
-                then '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+            when token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                then 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
             else token
         end as token,
-        avg(price) as clearing_price
+        cast(avg(price) as int256) as clearing_price
     from pre_clearing_prices
     group by tx_hash, token
-),
-potential_buffer_trades as (
+)
+,potential_buffer_trades as (
     select block_time,
           tx_hash,
           dex_swaps,
@@ -231,12 +232,13 @@ potential_buffer_trades as (
              token,
              block_time
              -- exclude 0 to prevent zero division, and exclude very small values for performance
-    having abs(sum(amount)) > 0.0001
-),
-valued_potential_buffered_trades as (
+    having sum(amount) != cast(0 as int256)
+)
+,valued_potential_buffered_trades as (
     select t.*,
-          amount * clearing_price            as clearing_value,
-          amount / pow(10, decimals) * price as usd_value
+    -- TODO: Not happy about this cast!
+          cast(amount * clearing_price as double)            as clearing_value,
+          cast(amount as double) / pow(10, decimals) * price as usd_value
     from potential_buffer_trades t
     -- The following joins require the uniqueness of the prices per join,
     -- otherwise duplicated internal trades will be found.
@@ -247,12 +249,12 @@ valued_potential_buffered_trades as (
         on t.tx_hash = cp.tx_hash
         and t.token = cp.token
     left outer join prices.usd pusd
-        on pusd.minute between '{{StartTime}}' and '{{EndTime}}'
+        on pusd.minute between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
         and pusd.contract_address = t.token
         and blockchain = 'ethereum'
         and date_trunc('minute', block_time) = pusd.minute
-),
-internal_buffer_trader_solvers as (
+)
+,internal_buffer_trader_solvers as (
     -- See the resulting list at: https://dune.com/queries/908642
     select address
     from cow_protocol_ethereum.solvers
@@ -266,23 +268,21 @@ internal_buffer_trader_solvers as (
     )
     -- Exclude services and test solvers
     and environment not in ('service', 'test')
-),
--- V2 PoC Query For Token List: https://dune.com/queries/1576758?d=1
-token_list as (
-    SELECT lower(address_str) as address
-  FROM (
-      VALUES {{TokenList}}
-    ) as _ (address_str)
-),
-buffer_trades as (
+)
+-- -- V3 PoC Query For Token List: https://dune.com/queries/2259926
+,token_list as (
+    SELECT from_hex(address_str) as address
+    FROM ( VALUES {{TokenList}} ) as _ (address_str)
+)
+,buffer_trades as (
     Select a.block_time as block_time,
           a.tx_hash,
           a.solver_address,
           a.symbol,
           a.token       as token_from,
           b.token       as token_to,
-          -1 * a.amount as amount_from,
-          -1 * b.amount as amount_to,
+          -a.amount as amount_from,
+          -b.amount as amount_to,
           abs((a.clearing_value + b.clearing_value) /(abs(a.clearing_value) + abs(b.clearing_value))) as matchablity_clearing_prices,
           abs((a.usd_value + b.usd_value) / (abs(a.usd_value) + abs(b.usd_value))) as matchability_prices_dune,
           'INTERNAL_TRADE'   as transfer_type
@@ -292,8 +292,8 @@ buffer_trades as (
     where (
               case
                   -- in order to classify as buffer trade, the positive surplus must be in an allow_listed token
-                  when ((a.amount > 0 and b.amount < 0 and a.token in (select * from token_list))
-                      or (b.amount > 0 and a.amount < 0 and b.token in (select * from token_list)))
+                  when ((a.amount > cast(0 as int256) and b.amount < cast(0 as int256) and a.token in (select * from token_list))
+                      or (b.amount > cast(0 as int256) and a.amount < cast(0 as int256) and b.token in (select * from token_list)))
                       and
                       -- We know that settlements - with at least one amm interaction - have internal buffer trades only if
                       -- the solution must come from a internal_buffer_trader_solvers solver
@@ -301,8 +301,7 @@ buffer_trades as (
                           or a.dex_swaps = 0)
                       then
                       case
-                          when a.clearing_value is not null and
-                              b.clearing_value is not null
+                          when a.clearing_value is not null and b.clearing_value is not null
                               -- If clearing prices are use, the price of internal trades are usually pretty close to
                               -- the clearing prices. But they don't have to be the same, as internal trades are usually settled
                               -- at the effective rate of an AMM. One example with deviating prices, is the tx:
@@ -316,10 +315,9 @@ buffer_trades as (
                               -- we will not evaluate this as buffer trade, but rather as positive and negative slippage at the same time:
                               -- One example is: 0x63e234a1a0d657f5725817f8d829c4e14d8194fdc49b5bc09322179ff99619e7 with a matchablity of 0.26
                               -- selling too much USDC and receiving too much ETH
-                              then (abs((a.clearing_value + b.clearing_value) /
-                                        (abs(a.clearing_value) + abs(b.clearing_value))) <
-                                    0.025
-                              and a.token != b.token)
+                              then (abs((a.clearing_value + b.clearing_value) / (abs(a.clearing_value) + abs(b.clearing_value))) < 0.025
+                              and a.token != b.token
+                            )
                           else
                               case
                                   when a.usd_value is not null and b.usd_value is not null
@@ -344,8 +342,8 @@ buffer_trades as (
                       false
                   end
               )
-),
-incoming_and_outgoing_with_buffer_trades as (
+)
+,incoming_and_outgoing_with_buffer_trades as (
 select * from (
     select block_time,
           tx_hash,
@@ -366,8 +364,8 @@ select * from (
     from buffer_trades
 ) as _
 order by block_time
-),
-final_token_balance_sheet as (
+)
+,final_token_balance_sheet as (
     select
         solver_address,
         sum(amount) token_imbalance_wei,
@@ -384,17 +382,14 @@ final_token_balance_sheet as (
         tx_hash,
         block_time
     having
-        sum(amount) != 0
-),
-
--- Benchmark: 4 minutes for 1 day (non-pro account)
--- select * from final_token_balance_sheet limit 10
-token_times as (
+        sum(amount) != cast(0 as int256)
+)
+,token_times as (
     select hour, token
     from final_token_balance_sheet
     group by hour, token
-),
-precise_prices as (
+)
+,precise_prices as (
     select
         contract_address,
         decimals,
@@ -403,7 +398,7 @@ precise_prices as (
     from
         prices.usd pusd
     inner join token_times tt
-        on minute between date(hour) and date(hour) + interval '1 day' -- query execution speed optimization since minute is indexed
+        on minute between date(hour) and date(hour) + interval '1' day -- query execution speed optimization since minute is indexed
         and date_trunc('hour', minute) = hour
         and contract_address = token
         and blockchain = 'ethereum'
@@ -411,20 +406,8 @@ precise_prices as (
         contract_address,
         decimals,
         date_trunc('hour', minute)
-),
---! THIS TABLE DOES NOT EXIST ON V2 (at least not yet!)
--- median_prices as (
---     select
---         contract_address,
---         decimals,
---         tt.hour,
---         median_price
---     from
---         prices.prices_from_dex_data musd
---         inner join token_times tt on musd.hour = tt.hour
---         and contract_address = token
--- ),
-intrinsic_prices as (
+)
+,intrinsic_prices as (
     select
         contract_address,
         decimals,
@@ -437,7 +420,7 @@ intrinsic_prices as (
             date_trunc('hour', block_time) as hour,
             usd_value / units_bought as price
         FROM cow_protocol_ethereum.trades
-        WHERE block_time between '{{StartTime}}' and '{{EndTime}}'
+        WHERE block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
         AND units_bought > 0
     UNION
         select
@@ -446,56 +429,51 @@ intrinsic_prices as (
             date_trunc('hour', block_time) as hour,
             usd_value / units_sold as price
         FROM cow_protocol_ethereum.trades
-        WHERE block_time between '{{StartTime}}' and '{{EndTime}}'
+        WHERE block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
         AND units_sold > 0
     ) as combined
     GROUP BY hour, contract_address, decimals
     order by hour
-),
--- Price Construction: https://dune.com/queries/1579091?
-prices as (
+)
+-- -- Price Construction: https://dune.com/queries/1579091?
+,prices as (
     select
         tt.hour as hour,
         tt.token as contract_address,
         COALESCE(
             precise.decimals,
-            -- median.decimals,
             intrinsic.decimals
         ) as decimals,
         COALESCE(
             precise.price,
-            -- median_price,
             intrinsic.price
         ) as price
     from token_times tt
     LEFT JOIN precise_prices precise
         ON precise.hour = tt.hour
         AND precise.contract_address = token
-    -- LEFT JOIN prices.prices_from_dex_data median
-    --     ON median.hour = tt.hour
-    --     and median.contract_address = token
     LEFT JOIN intrinsic_prices intrinsic
         ON intrinsic.hour = tt.hour
         and intrinsic.contract_address = token
-),
--- ETH Prices: https://dune.com/queries/1578626?d=1
-eth_prices as (
+)
+-- -- ETH Prices: https://dune.com/queries/1578626?d=1
+,eth_prices as (
     select
         date_trunc('hour', minute) as hour,
         avg(price) as eth_price
     from prices.usd
     where blockchain = 'ethereum'
-    and contract_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-    and minute between '{{StartTime}}' and '{{EndTime}}'
+    and contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+    and minute between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
     group by date_trunc('hour', minute)
-),
-results_per_tx as (
+)
+,results_per_tx as (
     select
         ftbs.hour,
         tx_hash,
         solver_address,
-        sum(token_imbalance_wei * price / pow(10, p.decimals)) as usd_value,
-        sum(token_imbalance_wei * price / pow(10, p.decimals) / eth_price) * pow(10, 18) as eth_slippage_wei,
+        sum(cast(token_imbalance_wei as double) * price / pow(10, p.decimals)) as usd_value,
+        sum(cast(token_imbalance_wei as double) * price / pow(10, p.decimals) / eth_price) * pow(10, 18) as eth_slippage_wei,
         count(*) as num_entries
     from
         final_token_balance_sheet ftbs
@@ -510,15 +488,16 @@ results_per_tx as (
         tx_hash
     having
         bool_and(price is not null)
-),
-results as (
+)
+,results as (
     select
         solver_address,
         concat(environment, '-', name) as solver_name,
         sum(usd_value) as usd_value,
         sum(eth_slippage_wei) as eth_slippage_wei,
         concat(
-            '<a href="https://dune.com/queries/1995951?SolverAddress=', solver_address,
+            '<a href="https://dune.com/queries/2259597?SolverAddress=',
+            cast(solver_address as varchar),
             '&CTE_NAME=results_per_tx',
             '&StartTime={{StartTime}}',
             '&EndTime={{EndTime}}',
@@ -530,6 +509,6 @@ results as (
         on address = solver_address
     group by
         solver_address,
-        solver_name
+        concat(environment, '-', name)
 )
 select * from {{CTE_NAME}}

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -230,12 +230,11 @@ incoming_and_outgoing as (
              symbol,
              token,
              block_time
-             -- exclude 0 to prevent zero division, and exclude very small values for performance
+    -- exclude 0 to prevent zero division
     having sum(amount) != cast(0 as int256)
 )
 ,valued_potential_buffered_trades as (
     select t.*,
-    -- TODO: Not happy about this cast!
           cast(amount * clearing_price as double)            as clearing_value,
           cast(amount as double) / pow(10, decimals) * price as usd_value
     from potential_buffer_trades t

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -164,7 +164,7 @@ incoming_and_outgoing as (
         case
             when t.symbol = 'ETH' then 'WETH'
             when t.symbol is not null then t.symbol
-            else cast(token as varchar)
+            else cast(t.token as varchar)
         end                                     as symbol,
           case
               when token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee

--- a/src/queries.py
+++ b/src/queries.py
@@ -96,6 +96,6 @@ QUERIES = {
         name="Solver Slippage for Period",
         filepath="period_slippage.sql",
         v1_id=1728478,
-        v2_id=2259497,
+        v2_id=2259597,
     ),
 }

--- a/tests/queries/test_slippage_investigation.py
+++ b/tests/queries/test_slippage_investigation.py
@@ -56,16 +56,10 @@ class TestDuneAnalytics(unittest.TestCase):
         period = AccountingPeriod("2022-06-07", 1)
         query = QUERIES["PERIOD_SLIPPAGE"].with_params(
             period.as_query_params()
-            + [
-                # Default values (on the query definition) do not need to be provided!
-                # QueryParameter.text_type("TxHash", "0x")
-                # QueryParameter.text_type("Solver", "0x")
-                # QueryParameter.text_type("TokenList", ",".join(get_trusted_tokens())),
-                QueryParameter.text_type("CTE_NAME", "results_per_tx")
-            ],
+            + [QueryParameter.text_type("CTE_NAME", "results_per_tx")],
             dune_version=DuneVersion.V2,
         )
-        results = exec_or_get(self.dune, query, result_id="01GW9JK5K0JMXEFYETHX8YQ3YA")
+        results = exec_or_get(self.dune, query, result_id="01GW9SVRHYWWXV62R3FVZMQNEW")
         self.assertEqual(results.query_id, self.slippage_query.v2_query.query_id)
         slippage_per_tx = results.get_rows()
 
@@ -95,10 +89,10 @@ class TestDuneAnalytics(unittest.TestCase):
             ],
             dune_version=DuneVersion.V2,
         )
-        results = exec_or_get(self.dune, query, result_id="01GW9JNPSPJTADDYTW2HEAD4J2")
+        results = exec_or_get(self.dune, query, result_id="01GW9SXZP72S2Z0TFWG6VCMTWS")
         self.assertEqual(results.query_id, self.slippage_query.v2_query.query_id)
         tx_slippage = results.get_rows()[0]
-        self.assertEqual(tx_slippage["eth_slippage_wei"], 71151929005056890)
+        self.assertEqual(tx_slippage["eth_slippage_wei"], 71151929005061256)
         self.assertAlmostEqual(
             tx_slippage["usd_value"], 83.37280645114296, delta=0.00001
         )
@@ -122,10 +116,10 @@ class TestDuneAnalytics(unittest.TestCase):
             ],
             dune_version=DuneVersion.V2,
         )
-        results = exec_or_get(self.dune, query, result_id="01GW9QA64YYRRKXQDTAN8QMYAS")
+        results = exec_or_get(self.dune, query, result_id="01GW9T7R10PDK7P5SRNBM3Z8J2")
         self.assertEqual(results.query_id, self.slippage_query.v2_query.query_id)
         tx_slippage = results.get_rows()[0]
-        self.assertEqual(tx_slippage["eth_slippage_wei"], 148427839329771500)
+        self.assertEqual(tx_slippage["eth_slippage_wei"], 148427839329771600)
         self.assertAlmostEqual(
             tx_slippage["usd_value"], 177.37732880251593, delta=0.000000001
         )
@@ -150,19 +144,19 @@ class TestDuneAnalytics(unittest.TestCase):
         result_0x3b2e = exec_or_get(
             self.dune,
             query=self.slippage_query_for(period, tx_hash),
-            result_id="01GW9J1Y7YVS0RQQQS3GJS9JPD",
+            result_id="01GW9T9X9EYRA48JYJKWMBQG4X",
         )
         self.assertEqual(result_0x3b2e.query_id, self.slippage_query.v2_query.query_id)
         self.assertEqual(
             result_0x3b2e.get_rows(),
             [
                 {
-                    "eth_slippage_wei": -4703807.681117931,
-                    "hour": "2023-02-01T01:00:00Z",
+                    "eth_slippage_wei": -4703808.820628837,
+                    "hour": "2023-02-01 01:00:00.000 UTC",
                     "num_entries": 2,
                     "solver_address": "0xc9ec550bea1c64d779124b23a26292cc223327b6",
                     "tx_hash": tx_hash,
-                    "usd_value": -7.454727687586665e-09,
+                    "usd_value": -7.454729493515833e-09,
                 }
             ],
         )
@@ -174,19 +168,19 @@ class TestDuneAnalytics(unittest.TestCase):
         result_0x7a00 = exec_or_get(
             self.dune,
             query=self.slippage_query_for(period, tx_hash),
-            result_id="01GW9J45HQ7K7HAS983G0KZT1T",
+            result_id="01GW9TAM3SJY5XP4DR0XB9SM24",
         )
         self.assertEqual(result_0x7a00.query_id, self.slippage_query.v2_query.query_id)
         self.assertEqual(
             result_0x7a00.get_rows(),
             [
                 {
-                    "eth_slippage_wei": -407937248.98733044,
-                    "hour": "2023-02-01T01:00:00Z",
-                    "num_entries": 2,
+                    "eth_slippage_wei": -407937294.96877956,
+                    "hour": "2023-02-01 01:00:00.000 UTC",
+                    "num_entries": 3,
                     "solver_address": "0xc9ec550bea1c64d779124b23a26292cc223327b6",
                     "tx_hash": tx_hash,
-                    "usd_value": -6.46510510417176e-07,
+                    "usd_value": -6.465105832898793e-07,
                 }
             ],
         )


### PR DESCRIPTION
I was able to semi-quickly migrate this query (as it does not have so many complex functions). Performance went from 30-40 minutes to ~3 minutes. I think its worth it.


PoC Query: https://dune.com/queries/2259597

## Test Plan

Note that tests were adjusted to account for this and it also lead to a "bug report" (on the Dune Spark side).

https://github.com/duneanalytics/spellbook/issues/3038

** I think we should still do a full week run on this before actually accepting the changes.


Just Tested this on last week's slippage (results are good):

- [V3 Result](https://dune.com/queries/2259597?StartTime_d83555=2023-03-21+00%3A00%3A00&EndTime_d83555=2023-03-28+00%3A00%3A00)
- [V2 Result](https://dune.com/queries/2259497?StartTime_d83555=2023-03-21+00%3A00%3A00&EndTime_d83555=2023-03-28+00%3A00%3A00)

**CSV Files**

[V3-Slippage.01GWP6CMJWHA81VFC05XB39F2N.csv](https://github.com/cowprotocol/solver-rewards/files/11098067/V3-Slippage.01GWP6CMJWHA81VFC05XB39F2N.csv)
[V2-Slippage.01GWP6D1BFR1DWMYBF6F49YEMN.csv](https://github.com/cowprotocol/solver-rewards/files/11098069/V2-Slippage.01GWP6D1BFR1DWMYBF6F49YEMN.csv)

**Quick Look at difference (very little)**

<img width="644" alt="Screenshot 2023-03-29 at 10 15 38" src="https://user-images.githubusercontent.com/11778116/228470807-e4714a0f-a25a-4574-85e6-353444bbfe17.png">
<img width="695" alt="Screenshot 2023-03-29 at 10 16 13" src="https://user-images.githubusercontent.com/11778116/228470823-9c326730-3f62-431a-b01c-37b7d4e17b4d.png">


