### PR TITLE
[Easy] constant erc20 contract instance

### DIFF
--- a/src/models/transfer.py
+++ b/src/models/transfer.py
@@ -17,6 +17,8 @@ from src.models.token import TokenType, Token
 from src.models.vouch import Vouch
 from src.utils.print_store import Category, PrintStore
 
+ERC20_CONTRACT = erc20()
+
 
 @dataclass
 class CSVTransfer:
@@ -197,7 +199,7 @@ class Transfer:
                 operation=MultiSendOperation.CALL,
                 to=str(self.token.address),
                 value=0,
-                data=erc20().encodeABI(
+                data=ERC20_CONTRACT.encodeABI(
                     fn_name="transfer", args=[receiver, self.amount_wei]
                 ),
             )


### PR DESCRIPTION
We were seeing this multiple times in our logs (when creating an ERC20 contract instance) because we were creating a new contract instance for each token transfer in the payout script. This reduces it to 1 call.

```
WARNING src.abis.load Using a fallback (dummy) web3 instance with no actual connection!
```
<img width="842" alt="Screenshot 2023-03-27 at 12 37 53" src="https://user-images.githubusercontent.com/11778116/227918403-9f6c07a3-80f8-4255-b072-72827ab4b855.png">

