### PR TITLE
[Easy] Token Imbalance Arithmetic

### DIFF
--- a/internal_transfers/actions/src/imbalance.ts
+++ b/internal_transfers/actions/src/imbalance.ts
@@ -1,0 +1,29 @@
+import { TokenImbalance } from "./models";
+import { ImbalanceMap } from "./utils";
+
+/**
+ * Difference operator on two token imbalance mappings.
+ * More generally, this computes the difference of two mappings of type { string => bigint }.
+ * Example: ({ "a": 1, "b": 2 }, { "b": 3, "c": 4 }) --> { "a": 1, "b": -1, "c": -4 }
+ * @param mapA positive term - being subtracted from
+ * @param mapB negative term - being subtracted
+ * @return mapA - mapB as a list of TokenImbalance
+ */
+export function imbalanceMapDiff(
+  mapA: ImbalanceMap,
+  mapB: ImbalanceMap
+): TokenImbalance[] {
+  const keySet = new Set([...mapA.keys(), ...mapB.keys()]);
+  let diffMap: ImbalanceMap = new Map<string, bigint>();
+  for (const token of keySet) {
+    const difference = (mapA.get(token) ?? 0n) - (mapB.get(token) ?? 0n);
+    if (difference !== 0n) {
+      // No point in recording zeros!
+      diffMap.set(token, difference);
+    }
+  }
+  return Array.from(diffMap).map(([token, amount]) => ({
+    token,
+    amount,
+  }));
+}

--- a/internal_transfers/actions/src/imbalance.ts
+++ b/internal_transfers/actions/src/imbalance.ts
@@ -1,5 +1,35 @@
-import { TokenImbalance } from "./models";
-import { ImbalanceMap } from "./utils";
+import { TokenImbalance, TransferEvent } from "./models";
+
+export type ImbalanceMap = Map<string, bigint>;
+
+/**
+ * Aggregation operator transforming a list of `TransferEvent` into an
+ * aggregation of token imbalances as an `ImbalanceMap`.
+ * Imbalances are defined in reference to `focalAccount`
+ * @param transfers - a list of token transfers
+ * @param focalAccount - account for which the "imbalance" is referring to.
+ */
+export function aggregateTransfers(
+  transfers: TransferEvent[],
+  focalAccount: string
+): ImbalanceMap {
+  let accumulator: ImbalanceMap = new Map<string, bigint>();
+  transfers.map((transfer) => {
+    const { to, from, amount, token } = transfer;
+
+    const currVal = accumulator.get(token) ?? 0n;
+    if (to.toLowerCase() == focalAccount.toLowerCase()) {
+      // Incoming Transfer
+      accumulator.set(token, currVal + amount);
+    } else if (from.toLowerCase() == focalAccount.toLowerCase()) {
+      // Outgoing Transfer
+      accumulator.set(token, currVal - amount);
+    } else {
+      // Irrelevant transfer.
+    }
+  });
+  return accumulator;
+}
 
 /**
  * Difference operator on two token imbalance mappings.

--- a/internal_transfers/actions/src/utils.ts
+++ b/internal_transfers/actions/src/utils.ts
@@ -1,36 +1,5 @@
 import { TransferEvent } from "./models";
 
-export type ImbalanceMap = Map<string, bigint>;
-
-/**
- * Aggregation operator transforming a list of `TransferEvent` into an
- * aggregation of token imbalances as an `ImbalanceMap`.
- * Imbalances are defined in reference to `focalAccount`
- * @param transfers - a list of token transfers
- * @param focalAccount - account for which the "imbalance" is referring to.
- */
-export function aggregateTransfers(
-  transfers: TransferEvent[],
-  focalAccount: string
-): ImbalanceMap {
-  let accumulator: ImbalanceMap = new Map<string, bigint>();
-  transfers.map((transfer) => {
-    const { to, from, amount, token } = transfer;
-
-    const currVal = accumulator.get(token) ?? 0n;
-    if (to.toLowerCase() == focalAccount.toLowerCase()) {
-      // Incoming Transfer
-      accumulator.set(token, currVal + amount);
-    } else if (from.toLowerCase() == focalAccount.toLowerCase()) {
-      // Outgoing Transfer
-      accumulator.set(token, currVal - amount);
-    } else {
-      // Irrelevant transfer.
-    }
-  });
-  return accumulator;
-}
-
 export function transferInvolves(
   transfer: TransferEvent,
   address: string

--- a/internal_transfers/actions/src/utils.ts
+++ b/internal_transfers/actions/src/utils.ts
@@ -1,10 +1,19 @@
-import { TokenImbalance, TransferEvent } from "./models";
+import { TransferEvent } from "./models";
 
+export type ImbalanceMap = Map<string, bigint>;
+
+/**
+ * Aggregation operator transforming a list of `TransferEvent` into an
+ * aggregation of token imbalances as an `ImbalanceMap`.
+ * Imbalances are defined in reference to `focalAccount`
+ * @param transfers - a list of token transfers
+ * @param focalAccount - account for which the "imbalance" is referring to.
+ */
 export function aggregateTransfers(
   transfers: TransferEvent[],
   focalAccount: string
-): TokenImbalance[] {
-  let accumulator = new Map<string, bigint>();
+): ImbalanceMap {
+  let accumulator: ImbalanceMap = new Map<string, bigint>();
   transfers.map((transfer) => {
     const { to, from, amount, token } = transfer;
 
@@ -19,10 +28,7 @@ export function aggregateTransfers(
       // Irrelevant transfer.
     }
   });
-  return Array.from(accumulator).map(([token, amount]) => ({
-    token,
-    amount,
-  }));
+  return accumulator;
 }
 
 export function transferInvolves(

--- a/internal_transfers/actions/tests/imbalance.spec.ts
+++ b/internal_transfers/actions/tests/imbalance.spec.ts
@@ -1,5 +1,40 @@
-import { imbalanceMapDiff } from "../src/imbalance";
+import { aggregateTransfers, imbalanceMapDiff } from "../src/imbalance";
+import { TransferEvent } from "../src/models";
+import { address as SETTLEMENT_CONTRACT_ADDRESS } from "@cowprotocol/contracts/deployments/mainnet/GPv2Settlement.json";
 
+const TOKEN_ADDRESS = "SuperToken!";
+describe("aggregateTransfers(transfers, focalAccount)", () => {
+  test("works in generic setting", () => {
+    const address = "0x0000000000000000000000000000000000000001";
+    const transferEvents: TransferEvent[] = [
+      // Incoming
+      {
+        amount: BigInt("100"),
+        from: address,
+        to: SETTLEMENT_CONTRACT_ADDRESS,
+        token: TOKEN_ADDRESS,
+      },
+      // Outgoing
+      {
+        amount: BigInt("200"),
+        from: SETTLEMENT_CONTRACT_ADDRESS,
+        to: address,
+        token: TOKEN_ADDRESS,
+      },
+      // Irrelevant
+      {
+        amount: BigInt("300"),
+        from: address,
+        to: address,
+        token: TOKEN_ADDRESS,
+      },
+    ];
+
+    expect(
+      aggregateTransfers(transferEvents, SETTLEMENT_CONTRACT_ADDRESS)
+    ).toEqual(new Map([[TOKEN_ADDRESS, BigInt("-100")]]));
+  });
+});
 describe("imbalanceMapDiff(mapA, mapB)", () => {
   test("map difference returns expected values in generic setting", () => {
     const mapA = new Map([

--- a/internal_transfers/actions/tests/imbalance.spec.ts
+++ b/internal_transfers/actions/tests/imbalance.spec.ts
@@ -1,0 +1,48 @@
+import { imbalanceMapDiff } from "../src/imbalance";
+
+describe("imbalanceMapDiff(mapA, mapB)", () => {
+  test("map difference returns expected values in generic setting", () => {
+    const mapA = new Map([
+      ["a", 1n],
+      ["b", 2n],
+    ]);
+    const mapB = new Map([
+      ["b", 3n],
+      ["c", 4n],
+    ]);
+
+    expect(imbalanceMapDiff(mapA, mapB)).toEqual([
+      {
+        amount: 1n,
+        token: "a",
+      },
+      {
+        amount: -1n,
+        token: "b",
+      },
+      {
+        amount: -4n,
+        token: "c",
+      },
+    ]);
+
+    expect(imbalanceMapDiff(new Map(), new Map())).toEqual([]);
+  });
+
+  test("map difference returns expected values on empty", () => {
+    expect(imbalanceMapDiff(new Map(), new Map())).toEqual([]);
+    const testMap = new Map([["x", 1n]]);
+    expect(imbalanceMapDiff(testMap, new Map())).toEqual([
+      {
+        amount: 1n,
+        token: "x",
+      },
+    ]);
+    expect(imbalanceMapDiff(new Map(), testMap)).toEqual([
+      {
+        amount: -1n,
+        token: "x",
+      },
+    ]);
+  });
+});

--- a/internal_transfers/actions/tests/imbalance.spec.ts
+++ b/internal_transfers/actions/tests/imbalance.spec.ts
@@ -80,4 +80,9 @@ describe("imbalanceMapDiff(mapA, mapB)", () => {
       },
     ]);
   });
+
+  test("map difference excludes zeros", () => {
+    const testMap = new Map([["x", 1n]]);
+    expect(imbalanceMapDiff(testMap, testMap)).toEqual([]);
+  });
 });

--- a/internal_transfers/actions/tests/utils.spec.ts
+++ b/internal_transfers/actions/tests/utils.spec.ts
@@ -1,40 +1,5 @@
-import { aggregateTransfers, transferInvolves } from "../src/utils";
+import { transferInvolves } from "../src/utils";
 import { TransferEvent } from "../src/models";
-import { address as SETTLEMENT_CONTRACT_ADDRESS } from "@cowprotocol/contracts/deployments/mainnet/GPv2Settlement.json";
-
-const TOKEN_ADDRESS = "SuperToken!";
-describe("aggregateTransfers(transfers, focalAccount)", () => {
-  test("works in generic setting", () => {
-    const address = "0x0000000000000000000000000000000000000001";
-    const transferEvents: TransferEvent[] = [
-      // Incoming
-      {
-        amount: BigInt("100"),
-        from: address,
-        to: SETTLEMENT_CONTRACT_ADDRESS,
-        token: TOKEN_ADDRESS,
-      },
-      // Outgoing
-      {
-        amount: BigInt("200"),
-        from: SETTLEMENT_CONTRACT_ADDRESS,
-        to: address,
-        token: TOKEN_ADDRESS,
-      },
-      // Irrelevant
-      {
-        amount: BigInt("300"),
-        from: address,
-        to: address,
-        token: TOKEN_ADDRESS,
-      },
-    ];
-
-    expect(
-      aggregateTransfers(transferEvents, SETTLEMENT_CONTRACT_ADDRESS)
-    ).toEqual(new Map([[TOKEN_ADDRESS, BigInt("-100")]]));
-  });
-});
 describe("transferInvolves(transfer, address)", () => {
   test("correctly returns whether transfer instance involves given address", () => {
     const address1 = "0x0000000000000000000000000000000000000001";

--- a/internal_transfers/actions/tests/utils.spec.ts
+++ b/internal_transfers/actions/tests/utils.spec.ts
@@ -32,12 +32,7 @@ describe("aggregateTransfers(transfers, focalAccount)", () => {
 
     expect(
       aggregateTransfers(transferEvents, SETTLEMENT_CONTRACT_ADDRESS)
-    ).toEqual([
-      {
-        token: TOKEN_ADDRESS,
-        amount: BigInt("-100"),
-      },
-    ]);
+    ).toEqual(new Map([[TOKEN_ADDRESS, BigInt("-100")]]));
   });
 });
 describe("transferInvolves(transfer, address)", () => {


### PR DESCRIPTION
Another Intermediary PR before #231 that implements the functionality of taking the difference of two sets of token imbalances. This is needed in order to compute `internalizedImbalance` from `FullCallData` and `ActualCallData`.

Here we also move a previously declared "utility" method into the new found "imbalance.ts" file. Test is moved accordingly and also doc strings are included on both functions. 

##    ⚠️ **!Attention!**  ⚠️ 
For easier review of the actual logic introduced here, please review the [first commit](https://github.com/cowprotocol/solver-rewards/pull/234/commits/b0eecd21fb81c3c3a6d4700b42c84c5d9f212eac) The second commit makes the diff harder to see (since some functionality was moved into a new file while being slightly altered).

## Test Plan

Existing and new tests.