### PR TITLE
Parse ETH Transfers

### DIFF
--- a/internal_transfers/actions/src/simulate/interface.ts
+++ b/internal_transfers/actions/src/simulate/interface.ts
@@ -24,6 +24,8 @@ export interface SimulationData {
   blockNumber: number;
   // Event Logs emitted within the transaction's simulation.
   logs: EventLog[];
+  // Difference in ETH balances of all accounts in transactions
+  ethDelta: Map<string, bigint>;
 }
 
 export interface TransactionSimulator {

--- a/internal_transfers/actions/src/simulate/interface.ts
+++ b/internal_transfers/actions/src/simulate/interface.ts
@@ -24,7 +24,7 @@ export interface SimulationData {
   blockNumber: number;
   // Event Logs emitted within the transaction's simulation.
   logs: EventLog[];
-  // Difference in ETH balances of all accounts in transactions
+  // Difference in ETH balances of all accounts in transaction
   ethDelta: Map<string, bigint>;
 }
 

--- a/internal_transfers/actions/src/simulate/tenderly.ts
+++ b/internal_transfers/actions/src/simulate/tenderly.ts
@@ -71,8 +71,16 @@ interface TenderlyTransaction {
 interface TenderlyTransactionInfo {
   block_number: number;
   logs: TenderlyTransactionLog[];
+  balance_diff: TenderlyBalanceDiff[];
 }
 
+interface TenderlyBalanceDiff {
+  address: string;
+  // before
+  original: bigint;
+  // after
+  dirty: bigint;
+}
 interface TenderlyTransactionLog {
   raw: EventLog;
 }
@@ -103,6 +111,12 @@ export function parseTenderlySimulation(
       blockNumber: tx.transaction_info.block_number,
       txHash: tx.hash,
       logs: tx.transaction_info.logs.map((t: { raw: EventLog }) => t.raw) || [],
+      ethDelta: new Map(
+        tx.transaction_info.balance_diff.map((t) => [
+          t.address.toLowerCase(),
+          BigInt(t.dirty - t.original),
+        ])
+      ),
     };
   }
   throw Error(`Invalid simulation data ${JSON.stringify(simulation)}`);

--- a/internal_transfers/actions/tests/accounting.spec.ts
+++ b/internal_transfers/actions/tests/accounting.spec.ts
@@ -44,8 +44,8 @@ describe("getInternalImbalance(transaction, simulator)", () => {
 });
 
 describe("constructImbalanceMap(simulation, focalContract)", () => {
-  test("throws when no competition found", async () => {
-    const simulation = {
+  test("constructs imbalances as expected with ETH Delta", async () => {
+    const simulationWithETH = {
       blockNumber: 16530828,
       txHash:
         "0x0e50d5447266171a4daf32880dfef3f55e31b7b80b285d14ddaefa6ad8098221",
@@ -76,7 +76,7 @@ describe("constructImbalanceMap(simulation, focalContract)", () => {
     };
     await expect(
       constructImbalanceMap(
-        simulation,
+        simulationWithETH,
         "0x9008d19f58aabd9ed0d60971565aa8510560ab41"
       )
     ).toEqual(
@@ -85,7 +85,9 @@ describe("constructImbalanceMap(simulation, focalContract)", () => {
         ["0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", 12345n],
       ])
     );
+  });
 
+  test("constructs imbalances as expected without ETH Delta", async () => {
     const simulationNoEth = {
       blockNumber: 16530828,
       txHash: "0x",
@@ -111,22 +113,5 @@ describe("constructImbalanceMap(simulation, focalContract)", () => {
         "0x9008d19f58aabd9ed0d60971565aa8510560ab41"
       )
     ).toEqual(new Map([["0xtoken", 15n]]));
-  });
-  test("returns early without simulation when fullCallData is undefined", async () => {
-    const invalidSimulator = new TenderlySimulator(
-      "INVALID_USER",
-      "INVALID_PROJECT",
-      "INVALID_KEY"
-    );
-    const uninternalizedSettlement: MinimalTxData = {
-      from: "0xb20b86c4e6deeb432a22d773a221898bbbd03036",
-      hash: "0xf1df7c1d068c2e0f0cf324bb0739a838fff89b4b08bf2aa11a7b4a609a7e20fe",
-      logs: [],
-    };
-    const result = await getInternalizedImbalance(
-      uninternalizedSettlement,
-      invalidSimulator
-    );
-    expect(result).toEqual([]);
   });
 });

--- a/internal_transfers/actions/tests/accounting.spec.ts
+++ b/internal_transfers/actions/tests/accounting.spec.ts
@@ -1,4 +1,8 @@
-import { getInternalizedImbalance, MinimalTxData } from "../src/accounting";
+import {
+  constructImbalanceMap,
+  getInternalizedImbalance,
+  MinimalTxData,
+} from "../src/accounting";
 import { TenderlySimulator } from "../src/simulate/tenderly";
 
 describe("getInternalImbalance(transaction, simulator)", () => {
@@ -19,6 +23,94 @@ describe("getInternalImbalance(transaction, simulator)", () => {
     await expect(
       getInternalizedImbalance(invalidTransaction, invalidSimulator)
     ).rejects.toThrow("No competition found for 0x");
+  });
+  test("returns early without simulation when fullCallData is undefined", async () => {
+    const invalidSimulator = new TenderlySimulator(
+      "INVALID_USER",
+      "INVALID_PROJECT",
+      "INVALID_KEY"
+    );
+    const uninternalizedSettlement: MinimalTxData = {
+      from: "0xb20b86c4e6deeb432a22d773a221898bbbd03036",
+      hash: "0xf1df7c1d068c2e0f0cf324bb0739a838fff89b4b08bf2aa11a7b4a609a7e20fe",
+      logs: [],
+    };
+    const result = await getInternalizedImbalance(
+      uninternalizedSettlement,
+      invalidSimulator
+    );
+    expect(result).toEqual([]);
+  });
+});
+
+describe("constructImbalanceMap(simulation, focalContract)", () => {
+  test("throws when no competition found", async () => {
+    const simulation = {
+      blockNumber: 16530828,
+      txHash:
+        "0x0e50d5447266171a4daf32880dfef3f55e31b7b80b285d14ddaefa6ad8098221",
+      logs: [
+        {
+          address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          topics: [
+            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+            "0x0000000000000000000000005c10c47b2d848e06a5dffa45b3bc10860797cdad",
+            "0x0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41",
+          ],
+          data: "0x000000000000000000000000000000000000000000000000000000000000000f", // +15
+        },
+        {
+          address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          topics: [
+            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+            "0x0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41",
+            "0x0000000000000000000000005c10c47b2d848e06a5dffa45b3bc10860797cdad",
+          ],
+          data: "0x00000000000000000000000000000000000000000000000000000000000000ff", // -255
+        },
+      ],
+      ethDelta: new Map([
+        ["0x9008d19f58aabd9ed0d60971565aa8510560ab41", 12345n],
+        ["0xIrrelevantAccount", 1n],
+      ]),
+    };
+    await expect(
+      constructImbalanceMap(
+        simulation,
+        "0x9008d19f58aabd9ed0d60971565aa8510560ab41"
+      )
+    ).toEqual(
+      new Map([
+        ["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", -240n],
+        ["0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", 12345n],
+      ])
+    );
+
+    const simulationNoEth = {
+      blockNumber: 16530828,
+      txHash: "0x",
+      logs: [
+        {
+          address: "0xtoken",
+          topics: [
+            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+            "0x0000000000000000000000005c10c47b2d848e06a5dffa45b3bc10860797cdad",
+            "0x0000000000000000000000009008d19f58aabd9ed0d60971565aa8510560ab41",
+          ],
+          data: "0x000000000000000000000000000000000000000000000000000000000000000f", // 15n
+        },
+      ],
+      ethDelta: new Map([
+        ["0x9008d19f58aabd9ed0d60971565aa8510560ab41", 0n],
+        ["0xIrrelevantAccount", 1n],
+      ]),
+    };
+    await expect(
+      constructImbalanceMap(
+        simulationNoEth,
+        "0x9008d19f58aabd9ed0d60971565aa8510560ab41"
+      )
+    ).toEqual(new Map([["0xtoken", 15n]]));
   });
   test("returns early without simulation when fullCallData is undefined", async () => {
     const invalidSimulator = new TenderlySimulator(

--- a/internal_transfers/actions/tests/e2e/getInternalImbalance.spec.ts
+++ b/internal_transfers/actions/tests/e2e/getInternalImbalance.spec.ts
@@ -147,4 +147,23 @@ describe.skip("getInternalImbalance(transaction, simulator)", () => {
       },
     ]);
   });
+  test("ETH Transfers - 0x7a007eb", async () => {
+    // Transaction contains ETH transfers (but they were not internalized)
+    // It is non-trivial to find batches with internalized ETH transfers.
+    // However, the tests we have in `accounting.spec` should demonstrate we are prepared to handle them.
+    const transaction = await TxDataFromHash(
+      "0x7a007eb8ad25f5f1f1f36459998ae758b0e699ca69cc7b4c38354d42092651bf"
+    );
+    const imbalance = await getInternalizedImbalance(transaction, simulator);
+    expect(imbalance).toEqual([
+      {
+        amount: -95100807345736279n,
+        token: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      },
+      {
+        amount: 14916332565n,
+        token: "0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5",
+      },
+    ]);
+  });
 });

--- a/internal_transfers/actions/tests/simulate-tenderly.spec.ts
+++ b/internal_transfers/actions/tests/simulate-tenderly.spec.ts
@@ -71,6 +71,7 @@ describe("Tenderly Simulator", () => {
       transaction: {
         hash: "0xHASH",
         transaction_info: {
+          balance_diff: [],
           block_number: 5,
           logs: [
             {
@@ -93,6 +94,7 @@ describe("Tenderly Simulator", () => {
           topics: ["0xTOPIC_1"],
         },
       ],
+      ethDelta: new Map(),
       txHash: "0xHASH",
     });
   });


### PR DESCRIPTION
Closes #237 


In response to @fedgiac [point that we need to recover ETH imbalances](https://github.com/cowprotocol/solver-rewards/pull/231#pullrequestreview-1382891420) from elsewhere, we introduce parsing of ETH imbalance from the simulation `balance_diff` data. 

For clean results we introduce a new helper method `constructImbalanceMap` which does a few things (including accounting for ETH diff). 

# Test Plan

New unit tests are introduced demonstrating that ETH balances are being considered and included. There is also a skipped e2e test (however it is very challenging to actually find a batch that has a non-trivial result - since its not easy to find a batch having an internalized eth transfer).