### PR TITLE
[Easy] Remove Simulation TxHash

### DIFF
--- a/internal_transfers/actions/src/simulate/interface.ts
+++ b/internal_transfers/actions/src/simulate/interface.ts
@@ -18,8 +18,6 @@ export interface SimulationParams {
  *  Represents the relevant data returned from a transaction-simulation.
  */
 export interface SimulationData {
-  // # Transaction hash that would have been assigned if this were an actually mined tx.
-  txHash: string;
   // Block on which the simulation was made.
   blockNumber: number;
   // Event Logs emitted within the transaction's simulation.

--- a/internal_transfers/actions/src/simulate/tenderly.ts
+++ b/internal_transfers/actions/src/simulate/tenderly.ts
@@ -101,7 +101,6 @@ export function parseTenderlySimulation(
   if (tx != undefined) {
     return {
       blockNumber: tx.transaction_info.block_number,
-      txHash: tx.hash,
       logs: tx.transaction_info.logs.map((t: { raw: EventLog }) => t.raw) || [],
     };
   }

--- a/internal_transfers/actions/tests/simulate-tenderly.spec.ts
+++ b/internal_transfers/actions/tests/simulate-tenderly.spec.ts
@@ -92,8 +92,7 @@ describe("Tenderly Simulator", () => {
           data: "0xDATA",
           topics: ["0xTOPIC_1"],
         },
-      ],
-      txHash: "0xHASH",
+      ]
     });
   });
   test("isTenderlySimulationResponse() returns false", () => {

--- a/internal_transfers/actions/tests/simulate-tenderly.spec.ts
+++ b/internal_transfers/actions/tests/simulate-tenderly.spec.ts
@@ -92,7 +92,7 @@ describe("Tenderly Simulator", () => {
           data: "0xDATA",
           topics: ["0xTOPIC_1"],
         },
-      ]
+      ],
     });
   });
   test("isTenderlySimulationResponse() returns false", () => {


### PR DESCRIPTION
Closes #230

The Simulation txHash is completely useless for our purposes and to avoid confusion, removed.