### PR TITLE
[Refactor] Pre ETH (un)wrap Event Parsing

### DIFF
--- a/internal_transfers/actions/src/models.ts
+++ b/internal_transfers/actions/src/models.ts
@@ -20,6 +20,11 @@ export interface EventLog {
 export interface TradeEvent {
   owner: string;
 }
+
+export function isTradeEvent(event: any): event is TradeEvent {
+  const castEvent = event as TradeEvent;
+  return castEvent.owner !== undefined;
+}
 export interface TransferEvent {
   token: string;
   to: string;
@@ -34,6 +39,11 @@ export interface EventMeta {
 export interface SettlementEvent {
   solver: string;
   logIndex: number;
+}
+
+export function isSettlementEvent(event: any): event is SettlementEvent {
+  const castEvent = event as SettlementEvent;
+  return castEvent.solver !== undefined && castEvent.logIndex !== undefined;
 }
 
 export interface WinningSettlementData {

--- a/internal_transfers/actions/src/parse.ts
+++ b/internal_transfers/actions/src/parse.ts
@@ -1,4 +1,10 @@
-import { SettlementEvent, TradeEvent, TransferEvent } from "./models";
+import {
+  isSettlementEvent,
+  isTradeEvent,
+  SettlementEvent,
+  TradeEvent,
+  TransferEvent,
+} from "./models";
 import { Log } from "@tenderly/actions";
 import { transferInvolves } from "./utils";
 import { ethers } from "ethers";
@@ -6,6 +12,8 @@ import { abi as SETTLEMENT_ABI } from "@cowprotocol/contracts/lib/contracts/GPv2
 import { abi as IERC20_ABI } from "@cowprotocol/contracts/lib/contracts/IERC20.json";
 import { address as SETTLEMENT_CONTRACT_ADDRESS } from "@cowprotocol/contracts/deployments/mainnet/GPv2Settlement.json";
 
+const settlementInterface = new ethers.Interface(SETTLEMENT_ABI);
+const erc20Interface = new ethers.Interface(IERC20_ABI);
 export interface ClassifiedEvents {
   trades: TradeEvent[];
   transfers: TransferEvent[];
@@ -18,39 +26,26 @@ export function partitionEventLogs(logs: Log[]): ClassifiedEvents {
     trades: [],
     settlements: [],
   };
-  const settlementInterface = new ethers.Interface(SETTLEMENT_ABI);
-  const erc20Interface = new ethers.Interface(IERC20_ABI);
+
   logs.forEach((log, index) => {
     // We are only interested in Transfer Events from erc20 contracts
     // along with Settlement and Trade Events from the Settlement contract
     // All other event emissions can be ignored for our purposes.
-    const transferEventLog = erc20Interface.parseLog(log);
-    const settlementEventLog = settlementInterface.parseLog(log);
-    if (transferEventLog != null && transferEventLog.name === "Transfer") {
-      const { from, to, value } = transferEventLog.args;
-      const transfer: TransferEvent = {
-        token: log.address,
-        from,
-        to,
-        amount: BigInt(value),
-      };
-      // Is a "relevant" transfer (involving settlement contract)
+    const possibleSettlementEvent = tryParseSettlementEventLog(log, index);
+    const possibleTransfer = tryParseERC20Transfer(log);
+
+    if (possibleTransfer !== null) {
+      const transfer: TransferEvent = possibleTransfer;
       if (transferInvolves(transfer, SETTLEMENT_CONTRACT_ADDRESS)) {
         result.transfers.push(transfer);
       }
-    } else if (settlementEventLog != null) {
+    } else if (possibleSettlementEvent !== null) {
+      const settlementEventLog = possibleSettlementEvent;
       // Relevant Event Types
-      if (settlementEventLog.name == "Trade") {
-        const { owner } = settlementEventLog.args;
-        result.trades.push({
-          owner,
-        });
-      } else if (settlementEventLog.name == "Settlement") {
-        const { solver } = settlementEventLog.args;
-        result.settlements.push({
-          solver,
-          logIndex: index,
-        });
+      if (isTradeEvent(settlementEventLog)) {
+        result.trades.push(settlementEventLog);
+      } else if (isSettlementEvent(settlementEventLog)) {
+        result.settlements.push(settlementEventLog);
       } else {
         // Placeholder for other Settlement Contract Events (e.g. Interaction)
       }
@@ -60,4 +55,39 @@ export function partitionEventLogs(logs: Log[]): ClassifiedEvents {
     }
   });
   return result;
+}
+
+function tryParseSettlementEventLog(
+  log: Log,
+  index: number
+): SettlementEvent | TradeEvent | null {
+  const settlementEventLog = settlementInterface.parseLog(log);
+  if (settlementEventLog === null) return null;
+  // Relevant Event Types
+  if (settlementEventLog.name == "Trade") {
+    const { owner } = settlementEventLog.args;
+    return { owner } as TradeEvent;
+  } else if (settlementEventLog.name == "Settlement") {
+    const { solver } = settlementEventLog.args;
+    return {
+      solver,
+      logIndex: index,
+    } as SettlementEvent;
+  } else {
+    // Placeholder for other Settlement Contract Events (e.g. Interaction)
+    return null;
+  }
+}
+
+function tryParseERC20Transfer(log: Log): TransferEvent | null {
+  const transferEventLog = erc20Interface.parseLog(log);
+  if (transferEventLog === null || transferEventLog.name !== "Transfer")
+    return null;
+  const { from, to, value } = transferEventLog.args;
+  return {
+    token: log.address,
+    from,
+    to,
+    amount: BigInt(value),
+  };
 }

--- a/internal_transfers/actions/src/parse.ts
+++ b/internal_transfers/actions/src/parse.ts
@@ -57,7 +57,7 @@ export function partitionEventLogs(logs: Log[]): ClassifiedEvents {
   return result;
 }
 
-function tryParseSettlementEventLog(
+export function tryParseSettlementEventLog(
   log: Log,
   index: number
 ): SettlementEvent | TradeEvent | null {
@@ -79,7 +79,7 @@ function tryParseSettlementEventLog(
   }
 }
 
-function tryParseERC20Transfer(log: Log): TransferEvent | null {
+export function tryParseERC20Transfer(log: Log): TransferEvent | null {
   const transferEventLog = erc20Interface.parseLog(log);
   if (transferEventLog === null || transferEventLog.name !== "Transfer")
     return null;


### PR DESCRIPTION
When implementing WETH unwrap even parsing, it was noticed that there was too much logic inside the `partitionEventLogs` method. This PR refactors and offloads some specific event parsing logic to helper methods. Will introduce WETH Event parsing on top of this.