### PR TITLE
[DB] Insert Pipeline Results as Single DB Transaction

### DIFF
--- a/internal_transfers/actions/src/database.ts
+++ b/internal_transfers/actions/src/database.ts
@@ -7,7 +7,6 @@ import DatabaseSchema from "./__generated__";
 import { EventMeta, SettlementEvent, TokenImbalance } from "./models";
 import { SettlementSimulationData } from "./accounting";
 import { SimulationData } from "./simulate/interface";
-// import { IsolationLevel } from "@databases/pg";
 
 export { sql };
 const { settlements, internalized_imbalances, settlement_simulations } =
@@ -90,10 +89,6 @@ export async function insertPipelineResults(
       await insertSettlementSimulations(db, simulationDatum);
       await insertSettlementEvent(db, eventMeta, settlementEvent);
     }
-    // {
-    //   isolationLevel: IsolationLevel.SERIALIZABLE,
-    //   retrySerializationFailures: true,
-    // }
   );
 }
 

--- a/internal_transfers/actions/src/database.ts
+++ b/internal_transfers/actions/src/database.ts
@@ -76,20 +76,24 @@ async function insertSettlementSimulations(
     winning_settlement: datum.winningSettlement,
   });
 }
+
+export interface SlippagePipelineResults {
+  settlementSimulations: SettlementSimulationData;
+  imbalances: TokenImbalance[];
+  eventMeta: EventMeta;
+  settlementEvent: SettlementEvent;
+}
 export async function insertPipelineResults(
   db: ConnectionPool,
-  simulationDatum: SettlementSimulationData,
-  imbalances: TokenImbalance[],
-  eventMeta: EventMeta,
-  settlementEvent: SettlementEvent
+  pipelineResults: SlippagePipelineResults
 ) {
-  await db.tx(
-    async (db) => {
-      await insertTokenImbalances(db, eventMeta.txHash, imbalances);
-      await insertSettlementSimulations(db, simulationDatum);
-      await insertSettlementEvent(db, eventMeta, settlementEvent);
-    }
-  );
+  const { eventMeta, settlementEvent, imbalances, settlementSimulations } =
+    pipelineResults;
+  await db.tx(async (db) => {
+    await insertTokenImbalances(db, eventMeta.txHash, imbalances);
+    await insertSettlementSimulations(db, settlementSimulations);
+    await insertSettlementEvent(db, eventMeta, settlementEvent);
+  });
 }
 
 function hexToBytea(hexString: string): Buffer {

--- a/internal_transfers/actions/src/simulate/tenderly.ts
+++ b/internal_transfers/actions/src/simulate/tenderly.ts
@@ -55,7 +55,6 @@ export class TenderlySimulator implements TransactionSimulator {
     if (!isTenderlySimulationResponse(response.data)) {
       throw Error(`Invalid Response ${JSON.stringify(response.data)}`);
     }
-    console.log(JSON.stringify(response.data));
     return parseTenderlySimulation(response.data);
   }
 }

--- a/internal_transfers/actions/tests/database.spec.ts
+++ b/internal_transfers/actions/tests/database.spec.ts
@@ -234,7 +234,7 @@ describe("All Database Tests", () => {
       expect(results.length).toEqual(1);
       expect(results[0]).toEqual({ count: 2n });
 
-      // Idempotency & insertion works ONLY IF ALL three insertions pass!
+      // insertion works ONLY IF ALL three insertions pass!
       await expect(insertPipelineResults(db, testResults)).rejects.toThrow(
         'duplicate key value violates unique constraint "internalized_imbalances_pkey"'
       );

--- a/internal_transfers/actions/tests/database.spec.ts
+++ b/internal_transfers/actions/tests/database.spec.ts
@@ -22,7 +22,10 @@ const dbURL: string =
   "postgresql://postgres:postgres@localhost:5432/postgres";
 const db = getDB(dbURL);
 
-describe("test database insertion methods", () => {
+const largeBigInt =
+  115792089237316195423570985008687907853269984665640564039457584007913129639935n;
+const tinyBigInt = 1n;
+describe("All Database Tests", () => {
   beforeEach(async () => {
     await db.query(sql`TRUNCATE TABLE settlements;`);
     await db.query(sql`TRUNCATE TABLE internalized_imbalances;`);
@@ -33,249 +36,241 @@ describe("test database insertion methods", () => {
     await (db as ConnectionPool).dispose();
   });
 
-  test("insertSettlementEvent(txHash, solver)", async () => {
-    const txHash =
-      "0x45f52ee09622eac16d0fe27b90a76749019b599c9566f10e21e8d0955a0e428e";
-    const solver = "0xc9ec550bea1c64d779124b23a26292cc223327b6";
+  describe("test database insertion methods", () => {
+    test("insertSettlementEvent(txHash, solver) succeeds and fails second attempt", async () => {
+      const txHash =
+        "0x45f52ee09622eac16d0fe27b90a76749019b599c9566f10e21e8d0955a0e428e";
+      const solver = "0xc9ec550bea1c64d779124b23a26292cc223327b6";
 
-    await insertSettlementEvent(
-      db,
-      { txHash: txHash, blockNumber: 0 },
-      { solver: solver, logIndex: 0 }
-    );
+      await insertSettlementEvent(
+        db,
+        { txHash: txHash, blockNumber: 0 },
+        { solver: solver, logIndex: 0 }
+      );
 
-    const results = await db.query(sql`SELECT *
-                                           from settlements;`);
-    expect(results).toStrictEqual([
-      {
-        block_number: BigInt(0),
-        log_index: BigInt(0),
-        solver: hexToBytea(solver),
-        tx_hash: hexToBytea(txHash),
-      },
-    ]);
-  });
-  test("insertImbalances(txHash, imbalances)", async () => {
-    const txHash = "0x4321";
-    const token1 = "0x12";
-    const token2 = "0x34";
-    const imbalances = [
-      {
-        token: token1,
-        amount:
-          115792089237316195423570985008687907853269984665640564039457584007913129639935n,
-      },
-      { token: token2, amount: 5678n },
-    ];
-    await insertTokenImbalances(db, txHash, imbalances);
+      const results = await db.query(sql`SELECT * from settlements;`);
+      expect(results).toStrictEqual([
+        {
+          block_number: BigInt(0),
+          log_index: BigInt(0),
+          solver: hexToBytea(solver),
+          tx_hash: hexToBytea(txHash),
+        },
+      ]);
+    });
+    test("insertImbalances(txHash, imbalances) succeeds and fails second attempt", async () => {
+      const txHash = "0x4321";
+      const token1 = "0x12";
+      const token2 = "0x34";
+      const imbalances = [
+        {
+          token: token1,
+          amount:
+            115792089237316195423570985008687907853269984665640564039457584007913129639935n,
+        },
+        { token: token2, amount: 5678n },
+      ];
+      await insertTokenImbalances(db, txHash, imbalances);
 
-    let results = await db.query(sql`SELECT *
-                                         from internalized_imbalances;`);
-    const expectedResults = [
-      {
-        token: hexToBytea(token1),
-        amount:
-          "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-        tx_hash: hexToBytea(txHash),
-      },
-      {
-        token: hexToBytea(token2),
-        amount: "5678",
-        tx_hash: hexToBytea(txHash),
-      },
-    ];
-    expect(results).toStrictEqual(expectedResults);
+      let results = await db.query(sql`SELECT * from internalized_imbalances;`);
+      const expectedResults = [
+        {
+          token: hexToBytea(token1),
+          amount:
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          tx_hash: hexToBytea(txHash),
+        },
+        {
+          token: hexToBytea(token2),
+          amount: "5678",
+          tx_hash: hexToBytea(txHash),
+        },
+      ];
+      expect(results).toStrictEqual(expectedResults);
 
-    await expect(insertTokenImbalances(db, txHash, imbalances)).rejects.toThrow(
-      'duplicate key value violates unique constraint "internalized_imbalances_pkey"'
-    );
-  });
-  test("insertSimulations(datum) & idempotent", async () => {
-    const blockNumber = 1;
-    const gasUsed = 2;
-    const simulationID = "sim-id";
-    const largeBigInt = 99999999999999999999999999999999999999999999999999n;
-    const exampleLog = {
-      address: ethers.ZeroAddress,
-      // The indexed topics from the event log
-      topics: [ethers.ZeroHash, ethers.ZeroHash],
-      data: ethers.ZeroHash,
-    };
-    const exampleEthDelta = new Map([["0x2", largeBigInt]]);
-    const dummySimData: SettlementSimulationData = {
-      txHash: ethers.ZeroHash,
-      full: {
-        simulationID,
-        gasUsed,
-        blockNumber,
-        // Note there are 2 logs here!
-        logs: [exampleLog, exampleLog],
-        ethDelta: exampleEthDelta,
-      },
-      reduced: {
-        simulationID,
-        gasUsed,
-        blockNumber,
-        // and only 1 log here!
-        logs: [exampleLog],
-        ethDelta: exampleEthDelta,
-      },
-      winningSettlement: {
-        solver: ethers.ZeroAddress,
-        simulationBlock: blockNumber,
-        reducedCallData: "0xca11da7a",
-        fullCallData: "0xca11da7a000000",
-      },
-    };
-    await insertSettlementSimulations(db, dummySimData);
-
-    let results = await db.query(sql`SELECT *
-                                         from settlement_simulations;`);
-    const expected = [
-      {
-        complete: {
-          blockNumber: blockNumber,
-          ethDelta: bigIntMapToJSON(exampleEthDelta),
+      await expect(
+        insertTokenImbalances(db, txHash, imbalances)
+      ).rejects.toThrow(
+        'duplicate key value violates unique constraint "internalized_imbalances_pkey"'
+      );
+    });
+    test("insertSimulations(datum) works and fails second attempt", async () => {
+      const blockNumber = 1;
+      const gasUsed = 2;
+      const simulationID = "sim-id";
+      const largeBigInt = 99999999999999999999999999999999999999999999999999n;
+      const exampleLog = {
+        address: ethers.ZeroAddress,
+        // The indexed topics from the event log
+        topics: [ethers.ZeroHash, ethers.ZeroHash],
+        data: ethers.ZeroHash,
+      };
+      const exampleEthDelta = new Map([["0x2", largeBigInt]]);
+      const dummySimData: SettlementSimulationData = {
+        txHash: ethers.ZeroHash,
+        full: {
+          simulationID,
+          gasUsed,
+          blockNumber,
+          // Note there are 2 logs here!
           logs: [exampleLog, exampleLog],
+          ethDelta: exampleEthDelta,
         },
         reduced: {
-          blockNumber: blockNumber,
-          ethDelta: bigIntMapToJSON(exampleEthDelta),
+          simulationID,
+          gasUsed,
+          blockNumber,
+          // and only 1 log here!
           logs: [exampleLog],
+          ethDelta: exampleEthDelta,
         },
-        tx_hash: hexToBytea(ethers.ZeroHash),
-        winning_settlement: {
-          fullCallData: "0xca11da7a000000",
-          reducedCallData: "0xca11da7a",
-          simulationBlock: blockNumber,
+        winningSettlement: {
           solver: ethers.ZeroAddress,
+          simulationBlock: blockNumber,
+          reducedCallData: "0xca11da7a",
+          fullCallData: "0xca11da7a000000",
         },
-      },
-    ];
-    expect(results).toStrictEqual(expected);
+      };
+      await insertSettlementSimulations(db, dummySimData);
 
-    await expect(insertSettlementSimulations(db, dummySimData)).rejects.toThrow(
-      'duplicate key value violates unique constraint "settlement_simulations_pkey"'
-    );
+      let results = await db.query(sql`SELECT * from settlement_simulations;`);
+      const expected = [
+        {
+          complete: {
+            blockNumber: blockNumber,
+            ethDelta: bigIntMapToJSON(exampleEthDelta),
+            logs: [exampleLog, exampleLog],
+          },
+          reduced: {
+            blockNumber: blockNumber,
+            ethDelta: bigIntMapToJSON(exampleEthDelta),
+            logs: [exampleLog],
+          },
+          tx_hash: hexToBytea(ethers.ZeroHash),
+          winning_settlement: {
+            fullCallData: "0xca11da7a000000",
+            reducedCallData: "0xca11da7a",
+            simulationBlock: blockNumber,
+            solver: ethers.ZeroAddress,
+          },
+        },
+      ];
+      expect(results).toStrictEqual(expected);
+
+      await expect(
+        insertSettlementSimulations(db, dummySimData)
+      ).rejects.toThrow(
+        'duplicate key value violates unique constraint "settlement_simulations_pkey"'
+      );
+    });
   });
-  test("insertPipelineResults", async () => {
-    const txHash = "0x4321";
-    const solver = "0xc9ec550bea1c64d779124b23a26292cc223327b6";
-    const eventMeta = { txHash: txHash, blockNumber: 0 };
-    const settlementEvent = { solver: solver, logIndex: 0 };
 
-    const token1 = "0x12";
-    const token2 = "0x34";
-    const imbalances = [
-      {
-        token: token1,
-        amount:
-          115792089237316195423570985008687907853269984665640564039457584007913129639935n,
-      },
-      { token: token2, amount: 5678n },
-    ];
-    const blockNumber = 1;
-    const gasUsed = 2;
-    const simulationID = "sim-id";
-    const largeBigInt = 99999999999999999999999999999999999999999999999999n;
-    const exampleLog = {
-      address: ethers.ZeroAddress,
-      // The indexed topics from the event log
-      topics: [ethers.ZeroHash, ethers.ZeroHash],
-      data: ethers.ZeroHash,
-    };
-    const exampleEthDelta = new Map([["0x2", largeBigInt]]);
-    const simulationDatum: SettlementSimulationData = {
-      txHash,
-      full: {
-        simulationID,
-        gasUsed,
-        blockNumber,
-        // Note there are 2 logs here!
-        logs: [exampleLog, exampleLog],
+  describe("insertPipelineResults", () => {
+    beforeEach(async () => {
+      await db.query(sql`TRUNCATE TABLE settlements;`);
+      await db.query(sql`TRUNCATE TABLE internalized_imbalances;`);
+      await db.query(sql`TRUNCATE TABLE settlement_simulations;`);
+    });
+
+    function getTestData() {
+      const txHash = "0x4321";
+      const solver = "0xc9ec550bea1c64d779124b23a26292cc223327b6";
+      const token1 = "0x12";
+      const token2 = "0x34";
+      const simulationBlock = 1;
+      const exampleLog = {
+        address: ethers.ZeroAddress,
+        // The indexed topics from the event log
+        topics: [ethers.ZeroHash, ethers.ZeroHash],
+        data: ethers.ZeroHash,
+      };
+      const exampleEthDelta = new Map([["0x2", largeBigInt]]);
+      const simulationCommon = {
+        simulationID: "whatever-string",
+        gasUsed: 2,
+        blockNumber: simulationBlock,
         ethDelta: exampleEthDelta,
-      },
-      reduced: {
-        simulationID,
-        gasUsed,
-        blockNumber,
-        // and only 1 log here!
-        logs: [exampleLog],
-        ethDelta: exampleEthDelta,
-      },
-      winningSettlement: {
-        solver: ethers.ZeroAddress,
-        simulationBlock: blockNumber,
-        reducedCallData: "0xca11da7a",
-        fullCallData: "0xca11da7a000000",
-      },
-    };
-    // insertion works.
-    await insertPipelineResults(
-      db,
-      simulationDatum,
-      imbalances,
-      eventMeta,
-      settlementEvent
-    );
-    const recordCountQuery = sql`select count(*)
-                from internalized_imbalances i
-                       join settlements s
-                            on i.tx_hash = s.tx_hash
-                       join settlement_simulations ss
-                            on i.tx_hash = ss.tx_hash`;
-    let results = await db.query(recordCountQuery);
-    expect(results.length).toEqual(1);
-    expect(results[0]).toEqual({ count: 2n });
+      };
+      return {
+        eventMeta: { txHash: txHash, blockNumber: 0 },
+        settlementSimulations: {
+          txHash,
+          full: {
+            ...simulationCommon,
+            // Note there are 2 logs here!
+            logs: [exampleLog, exampleLog],
+          },
+          reduced: {
+            ...simulationCommon,
+            // and only 1 log here!
+            logs: [exampleLog],
+          },
+          winningSettlement: {
+            solver: ethers.ZeroAddress,
+            simulationBlock,
+            reducedCallData: "0xca11da7a",
+            fullCallData: "0xca11da7a000000",
+          },
+        },
+        settlementEvent: { solver: solver, logIndex: 0 },
+        imbalances: [
+          { token: token1, amount: largeBigInt },
+          { token: token2, amount: tinyBigInt },
+        ],
+      };
+    }
 
-    // Idempotency & insertion works ONLY IF ALL three insertions pass!
-    await expect(
-      insertPipelineResults(
-        db,
-        simulationDatum,
-        imbalances,
-        eventMeta,
-        settlementEvent
-      )
-    ).rejects.toThrow(
-      'duplicate key value violates unique constraint "internalized_imbalances_pkey"'
-    );
-    results = await db.query(recordCountQuery);
-    expect(results.length).toEqual(1);
-    expect(results[0]).toEqual({ count: 2n });
-    await expect(
-      insertPipelineResults(db, simulationDatum, [], eventMeta, settlementEvent)
-    ).rejects.toThrow(
-      'duplicate key value violates unique constraint "settlement_simulations_pkey"'
-    );
-    results = await db.query(recordCountQuery);
-    expect(results.length).toEqual(1);
-    expect(results[0]).toEqual({ count: 2n });
+    test("insertion works and fails second attempt", async () => {
+      // insertion works.
+      const testResults = getTestData();
+      await insertPipelineResults(db, testResults);
+      const recordCountQuery = sql`select count(*)
+                                 from internalized_imbalances i
+                                        join settlements s
+                                             on i.tx_hash = s.tx_hash
+                                        join settlement_simulations ss
+                                             on i.tx_hash = ss.tx_hash`;
+      let results = await db.query(recordCountQuery);
+      expect(results.length).toEqual(1);
+      expect(results[0]).toEqual({ count: 2n });
 
-    const newTxHash = "0x11";
-    eventMeta.txHash = newTxHash;
-    simulationDatum.txHash = newTxHash;
-    await expect(
-      insertPipelineResults(db, simulationDatum, [], eventMeta, settlementEvent)
-    ).rejects.toThrow(
-      'duplicate key value violates unique constraint "settlements_pkey"'
-    );
-    results = await db.query(recordCountQuery);
-    expect(results.length).toEqual(1);
-    expect(results[0]).toEqual({ count: 2n });
+      // Idempotency & insertion works ONLY IF ALL three insertions pass!
+      await expect(insertPipelineResults(db, testResults)).rejects.toThrow(
+        'duplicate key value violates unique constraint "internalized_imbalances_pkey"'
+      );
+    });
+    test("insertion fails if only imbalances differs", async () => {
+      let testResults = getTestData();
+      await insertPipelineResults(db, testResults);
+      testResults.imbalances = [];
+      await expect(insertPipelineResults(db, testResults)).rejects.toThrow(
+        'duplicate key value violates unique constraint "settlement_simulations_pkey"'
+      );
+    });
+    test("insertion fails if imbalances is settlement Event is same", async () => {
+      let testResults = getTestData();
+      await insertPipelineResults(db, testResults);
+      testResults.imbalances = [];
+      const newTxHash = "0x11";
+      testResults.eventMeta.txHash = newTxHash;
+      testResults.settlementSimulations.txHash = newTxHash;
+      await expect(insertPipelineResults(db, testResults)).rejects.toThrow(
+        'duplicate key value violates unique constraint "settlements_pkey"'
+      );
+    });
 
-    eventMeta.blockNumber += 1; // Different.
+    test("insertion works again if all three insertions pass", async () => {
+      let testResults = getTestData();
+      await insertPipelineResults(db, testResults);
 
-    await insertPipelineResults(
-      db,
-      simulationDatum,
-      imbalances,
-      eventMeta,
-      settlementEvent
-    );
-    results = await db.query(recordCountQuery);
-    expect(results.length).toEqual(1);
-    expect(results[0]).toEqual({ count: 4n });
+      // Changing sufficient information so that all three insertions succeed
+      testResults.imbalances = [];
+      const newTxHash = "0x11";
+      testResults.eventMeta.txHash = newTxHash;
+      testResults.settlementSimulations.txHash = newTxHash;
+      testResults.eventMeta.blockNumber += 1; // Different Block Number ==> different Settlement Event
+      await insertPipelineResults(db, testResults);
+    });
   });
 });
 


### PR DESCRIPTION
After our pipeline has succeeded, we want to write to three different tables in a fail safe way (i.e. all or nothing). For this purpose we implement a method that commits all three insertions to the DB in such a  fail safe way -- as a single database transaction.

Note that we had to remove the "insertOrIgnore" functionality on a few tables because we do not want such operations to "fail silently".

TODO - write some doc strings on the new functionality.


## Test Plan 

New unit tests thoroughly covers the use case.