### PR TITLE
[Payout Fix] For Period(04/11-04/18, 2023)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,3 @@ SQLAlchemy>=1.4.41
 sqlalchemy-stubs==0.4
 pandas==1.5.0
 pandas-stubs==1.5.1.221024
-
-# TODO: This is temporary cf - https://github.com/cowprotocol/dune-client/pull/47
-ndjson

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black==22.6.0
 certifi==2022.6.15
 duneapi==8.0.0
-dune-client==0.2.2
+dune-client==1.0.0
 mypy==0.982
 psycopg2-binary==2.9.3
 pylint==2.14.4

--- a/src/models/transfer.py
+++ b/src/models/transfer.py
@@ -7,9 +7,11 @@ from dataclasses import dataclass
 from typing import Optional
 
 import pandas as pd
+
 from dune_client.types import Address
 from eth_typing.encoding import HexStr
 from gnosis.safe.multi_send import MultiSendOperation, MultiSendTx
+from web3 import Web3
 
 from src.abis.load import erc20
 from src.models.slippage import SolverSlippage
@@ -185,7 +187,7 @@ class Transfer:
 
     def as_multisend_tx(self) -> MultiSendTx:
         """Converts Transfer into encoded MultiSendTx bytes"""
-        receiver = self.recipient.address
+        receiver = Web3.toChecksumAddress(self.recipient.address)
         if self.token_type == TokenType.NATIVE:
             return MultiSendTx(
                 operation=MultiSendOperation.CALL,

--- a/src/scripts/payout_fix_2023_04_18.py
+++ b/src/scripts/payout_fix_2023_04_18.py
@@ -22,13 +22,13 @@ NUMERICAL_COLUMNS = [
 if __name__ == "__main__":
     # Saved query Executions. Note that before is no longer
     # re-constructable since the query is based on changed data.
-    exec_id_before = "01GYFEPH4XV8QJTZ2QSEAE3VWK"
-    exec_id_after = "01GYJ7RF07BVWW5SNGYTWYFMG5"
+    EXEC_ID_BEFORE = "01GYFEPH4XV8QJTZ2QSEAE3VWK"
+    EXEC_ID_AFTER = "01GYJ7RF07BVWW5SNGYTWYFMG5"
 
     dune = DuneClient(os.environ["DUNE_API_KEY"])
 
-    before = pandas.read_csv(dune.get_result_csv(exec_id_before).data)
-    after = pandas.read_csv(dune.get_result_csv(exec_id_after).data)
+    before = pandas.read_csv(dune.get_result_csv(EXEC_ID_BEFORE).data)
+    after = pandas.read_csv(dune.get_result_csv(EXEC_ID_AFTER).data)
 
     for number_col in NUMERICAL_COLUMNS:
         before[number_col] = before[number_col].replace("<nil>", 0)

--- a/src/scripts/payout_fix_2023_04_18.py
+++ b/src/scripts/payout_fix_2023_04_18.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
                 amount_wei=row["owed_eth"] * 1e18,
             ),
             axis=1,
-        )
+        ).values
     )
 
     cow_transfers = list(
@@ -79,7 +79,7 @@ if __name__ == "__main__":
                 amount_wei=row["owed_cow"] * 1e18,
             ),
             axis=1,
-        )
+        ).values
     )
 
     manual_propose(eth_transfers + cow_transfers, AccountingPeriod("2023-04-11"))

--- a/src/scripts/payout_fix_2023_04_18.py
+++ b/src/scripts/payout_fix_2023_04_18.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
 
     # Filter all owed worth at least ~1 USD.
     # TODO - use current prices to determine amount.
-    # https://github.com/cowprotocol/solver-rewards/issues/256
+    #  https://github.com/cowprotocol/solver-rewards/issues/256
     owed_eth = merged[merged["owed_eth"] > 0.001]
     owed_cow = merged[merged["owed_cow"] > 10]
 

--- a/src/scripts/payout_fix_2023_04_18.py
+++ b/src/scripts/payout_fix_2023_04_18.py
@@ -1,0 +1,62 @@
+"""
+For the Accounting Period April 11 - 18, 2023 there was a bug
+in the backend services attributing incorrect solver reward values
+for a substantial number of market orders:
+
+cf. <INCLUDE LINK TO BUG AND FIX>
+
+This script
+- fetches the difference between ETH & COW Payments made before and after the fix,
+- takes the difference (ignoring what is owed to us) and
+- constructs a CSV transfer file making up for anything we owe solvers.
+"""
+import os
+import pandas
+from dune_client.client import DuneClient
+
+NUMERICAL_COLUMNS = [
+    "eth_transfer",
+    "cow_transfer",
+]
+
+if __name__ == "__main__":
+    # Saved query Executions. Note that before is no longer
+    # re-constructable since the query is based on changed data.
+    exec_id_before = "01GYFEPH4XV8QJTZ2QSEAE3VWK"
+    exec_id_after = "01GYJ7RF07BVWW5SNGYTWYFMG5"
+
+    dune = DuneClient(os.environ["DUNE_API_KEY"])
+
+    before = pandas.read_csv(dune.get_result_csv(exec_id_before).data)
+    after = pandas.read_csv(dune.get_result_csv(exec_id_after).data)
+
+    for number_col in NUMERICAL_COLUMNS:
+        before[number_col] = before[number_col].replace("<nil>", 0)
+        after[number_col] = after[number_col].replace("<nil>", 0)
+        before[number_col] = pandas.to_numeric(before[number_col])
+        after[number_col] = pandas.to_numeric(after[number_col])
+
+    before = before[
+        [
+            "solver",
+            "name",
+            "reward_target",
+            "eth_transfer",
+            "cow_transfer",
+        ]
+    ].add_suffix("_before")
+    after = after[
+        [
+            "solver",
+            "eth_transfer",
+            "cow_transfer",
+        ]
+    ].add_suffix("_after")
+
+    merged = pandas.merge(
+        before, after, left_on="solver_before", right_on="solver_after", how="left"
+    )
+
+    merged["owed_eth"] = merged["eth_transfer_after"] - merged["eth_transfer_before"]
+    merged["owed_cow"] = merged["cow_transfer_after"] - merged["cow_transfer_before"]
+    print(merged)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -4,6 +4,7 @@ import pandas as pd
 from dune_client.types import Address
 from eth_typing import HexStr
 from gnosis.safe.multi_send import MultiSendTx, MultiSendOperation
+from web3 import Web3
 
 from src.abis.load import erc20
 from src.constants import COW_TOKEN_ADDRESS
@@ -445,20 +446,22 @@ class TestTransfer(unittest.TestCase):
         self.assertEqual(expected, Transfer.from_dataframe(transfer_df))
 
     def test_basic_as_multisend_tx(self):
-        receiver = Address("0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1")
-        native_transfer = Transfer(token=None, recipient=receiver, amount_wei=16)
+        receiver = Web3.toChecksumAddress("0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1")
+        native_transfer = Transfer(
+            token=None, recipient=Address(receiver), amount_wei=16
+        )
         self.assertEqual(
             native_transfer.as_multisend_tx(),
             MultiSendTx(
                 operation=MultiSendOperation.CALL,
-                to=receiver.address,
+                to=receiver,
                 value=16,
                 data=HexStr("0x"),
             ),
         )
         erc20_transfer = Transfer(
             token=Token(COW_TOKEN_ADDRESS),
-            recipient=receiver,
+            recipient=Address(receiver),
             amount_wei=15,
         )
         self.assertEqual(
@@ -467,7 +470,7 @@ class TestTransfer(unittest.TestCase):
                 operation=MultiSendOperation.CALL,
                 to=COW_TOKEN_ADDRESS.address,
                 value=0,
-                data=erc20().encodeABI(fn_name="transfer", args=[receiver.address, 15]),
+                data=erc20().encodeABI(fn_name="transfer", args=[receiver, 15]),
             ),
         )
 


### PR DESCRIPTION
In response to [this slack thread](https://cowservices.slack.com/archives/C0361CDD1FZ/p1681945529126919) started by @nlordell from last week's oncall. We provide a script to generate the payout fix from previous week.

Given the Input files (taken from Dune Exports):

- [oldrewards-01GYFEPH4XV8QJTZ2QSEAE3VWK.csv](https://github.com/cowprotocol/solver-rewards/files/11316041/oldrewards-01GYFEPH4XV8QJTZ2QSEAE3VWK.csv)
- [newrewards-01GYJ7RF07BVWW5SNGYTWYFMG5.csv](https://github.com/cowprotocol/solver-rewards/files/11316040/newrewards-01GYJ7RF07BVWW5SNGYTWYFMG5.csv)

Note also that you can fetch metadata on these executions (like which query and which parameters) as follows;

```sh
export DUNE_API_KEY=
export JOB_ID=01GYFEPH4XV8QJTZ2QSEAE3VWK
export OPERATION={status, results}
curl -X GET "https://api.dune.com/api/v1/execution/${JOB_ID}/${OPERATION}" -H x-dune-api-key:${DUNE_API_KEY} | jq
```
although I, unfortunately, just realized that the parameters are not shown (just the query ID).


This code generates the following two files:
1. Intermediary CSV with before and after values:

[transfers.csv](https://github.com/cowprotocol/solver-rewards/files/11316023/transfers.csv)

2. Final CSV Airdrop File:

[transfers-2023-04-11-to-2023-04-18.csv](https://github.com/cowprotocol/solver-rewards/files/11316025/transfers-2023-04-11-to-2023-04-18.csv)
