### PR TITLE
Add Verification Instructions to Slack Message

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -16,7 +16,9 @@ LOG_CONFIG_FILE = PROJECT_ROOT / Path("logging.conf")
 QUERY_PATH = PROJECT_ROOT / Path("queries")
 DASHBOARD_PATH = PROJECT_ROOT / Path("dashboards/solver-rewards-accounting")
 
-DOCS_URL = "https://www.notion.so/cownation/Solver-Payouts-3dfee64eb3d449ed8157a652cc817a8c"
+DOCS_URL = (
+    "https://www.notion.so/cownation/Solver-Payouts-3dfee64eb3d449ed8157a652cc817a8c"
+)
 
 # Things requiring network
 load_dotenv()

--- a/src/constants.py
+++ b/src/constants.py
@@ -16,6 +16,8 @@ LOG_CONFIG_FILE = PROJECT_ROOT / Path("logging.conf")
 QUERY_PATH = PROJECT_ROOT / Path("queries")
 DASHBOARD_PATH = PROJECT_ROOT / Path("dashboards/solver-rewards-accounting")
 
+DOCS_URL = "https://www.notion.so/cownation/Solver-Payouts-3dfee64eb3d449ed8157a652cc817a8c"
+
 # Things requiring network
 load_dotenv()
 ENV = os.environ

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -21,6 +21,7 @@ from src.utils.print_store import PrintStore
 
 log = set_log(__name__)
 
+
 # TODO - eliminate the use of Address class (or refactor)
 #  because Web3.toChecksumAddress is very SLOW and should be replaced by str.lower()
 class DuneFetcher:

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -20,6 +20,7 @@ from src.constants import (
     AIRDROP_URL,
     SAFE_URL,
     FILE_OUT_DIR,
+    DOCS_URL,
 )
 from src.fetch.payouts import post_cip20_payouts
 from src.models.accounting_period import AccountingPeriod
@@ -74,6 +75,11 @@ def auto_propose(
     if len(transactions) > len(transfers):
         log_saver.print("Prepended WETH unwrap", Category.GENERAL)
 
+    log_saver.print(
+        f"Instructions for verifying the payout transaction can be found at\n{DOCS_URL}",
+        category=Category.GENERAL,
+    )
+
     if not dry_run:
         nonce = post_multisend(
             safe_address=SAFE_ADDRESS,
@@ -98,7 +104,7 @@ if __name__ == "__main__":
     args = generic_script_init(description="Fetch Complete Reimbursement")
     dune = args.dune
     dune.log_saver.print(
-        f"The data aggregated can be visualized at\n" f"{dune.period.dashboard_url()}",
+        f"The data aggregated can be visualized at\n{dune.period.dashboard_url()}",
         category=Category.GENERAL,
     )
 

--- a/tests/e2e/test_prices.py
+++ b/tests/e2e/test_prices.py
@@ -40,7 +40,6 @@ class TestPrices(unittest.TestCase):
         )
 
     def test_eth_in_token(self):
-
         self.assertAlmostEqual(
             eth_in_token(TokenId.COW, ONE_ETH, self.some_date) / 10**18,
             self.eth_price / self.cow_price,
@@ -53,7 +52,6 @@ class TestPrices(unittest.TestCase):
         )
 
     def test_token_in_eth(self):
-
         self.assertAlmostEqual(
             token_in_eth(TokenId.COW, ONE_ETH, self.some_date),
             10**18 * self.cow_price // self.eth_price,


### PR DESCRIPTION
Just a small suggestion - I found it could be nice to also have a link to the verification instructions so you can open everything you need directly from the Slack thread with the payout transaction.

Feel free to close the PR if you don't agree with the change.

### Test Plan

Not sure how to test this change without actually posting something on Slack.