### PR TITLE
[Slippage] Account for Phantom Transfers

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,4 +1,4 @@
--- https://github.com/cowprotocol/solver-rewards/pull/217
+-- https://github.com/cowprotocol/solver-rewards/pull/259
 with
 batch_meta as (
     select b.block_time,
@@ -16,8 +16,8 @@ batch_meta as (
     where b.block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
     and (b.solver_address = from_hex('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
     and (b.tx_hash = from_hex('{{TxHash}}') or '{{TxHash}}' = '0x')
-),
-filtered_trades as (
+)
+,filtered_trades as (
     select t.tx_hash,
            t.block_number,
            trader                                       as trader_in,
@@ -164,7 +164,7 @@ incoming_and_outgoing as (
         case
             when t.symbol = 'ETH' then 'WETH'
             when t.symbol is not null then t.symbol
-            else cast(t.token as varchar)
+            else cast(i.token as varchar)
         end                                     as symbol,
           case
               when token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
@@ -183,185 +183,51 @@ incoming_and_outgoing as (
             on i.token = t.contract_address
             and blockchain = 'ethereum'
     where tx_hash not in (select tx_hash from excluded_batches)
-      -- We exclude settlements that have zero AMM interactions and settle several trades,
-      -- as our query is not good enough to handle these cases accurately.
-      -- Settlements with dex_swaps = 0 and num_trades = 0 can be handled in the following
-      -- and we want to consider them in order to filter out illegal behaviour
-      and ((dex_swaps = 0 and num_trades < 2) or dex_swaps > 0)
-)
-
--- Clearing Prices query here: https://dune.com/queries/1571457
-,pre_clearing_prices as (
-    select
-        call_tx_hash as tx_hash,
-        price,
-        token
-    from gnosis_protocol_v2_ethereum.GPv2Settlement_call_settle
-      CROSS JOIN UNNEST(clearingPrices) WITH ORDINALITY AS p (price, i)
-      CROSS JOIN UNNEST(tokens) WITH ORDINALITY AS t (token, j)
-    where call_block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
-      and call_success = true
-      and i = j
-)
-,clearing_prices as (
-    select
-        tx_hash,
-        case
-            when token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-                then 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
-            else token
-        end as token,
-        cast(avg(price) as int256) as clearing_price
-    from pre_clearing_prices
-    group by tx_hash, token
-)
-,potential_buffer_trades as (
-    select block_time,
-          tx_hash,
-          dex_swaps,
-          solver_address,
-          symbol,
-          token,
-          sum(amount) as amount
-    from incoming_and_outgoing io
-    group by tx_hash,
-             dex_swaps,
-             solver_address,
-             symbol,
-             token,
-             block_time
-    -- exclude 0 to prevent zero division
-    having sum(amount) != cast(0 as int256)
-)
-,valued_potential_buffered_trades as (
-    select t.*,
-          cast(amount * clearing_price as double)            as clearing_value,
-          cast(amount as double) / pow(10, decimals) * price as usd_value
-    from potential_buffer_trades t
-    -- The following joins require the uniqueness of the prices per join,
-    -- otherwise duplicated internal trades will be found.
-    -- For clearing prices, it is given by construction and
-    -- for prices.usd, one can see that the primary key of the table is
-    -- (contract, minute) as seen here: https://dune.xyz/queries/510124
-    left outer join clearing_prices cp
-        on t.tx_hash = cp.tx_hash
-        and t.token = cp.token
-    left outer join prices.usd pusd
-        on pusd.minute between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
-        and pusd.contract_address = t.token
-        and blockchain = 'ethereum'
-        and date_trunc('minute', block_time) = pusd.minute
-)
-,internal_buffer_trader_solvers as (
-    -- See the resulting list at: https://dune.com/queries/908642
-    select address
-    from cow_protocol_ethereum.solvers
-    -- Exclude Single Order Solvers
-    where name not in (
-        'Gnosis_1inch',
-        'Gnosis_0x',
-        'Gnosis_ParaSwap',
-        'Baseline',
-        'Gnosis_BalancerSOR'
-    )
-    -- Exclude services and test solvers
-    and environment not in ('service', 'test')
 )
 -- -- V3 PoC Query For Token List: https://dune.com/queries/2259926
 ,token_list as (
     SELECT from_hex(address_str) as address
     FROM ( VALUES {{TokenList}} ) as _ (address_str)
 )
-,buffer_trades as (
-    Select a.block_time as block_time,
-          a.tx_hash,
-          a.solver_address,
-          a.symbol,
-          a.token       as token_from,
-          b.token       as token_to,
-          -a.amount as amount_from,
-          -b.amount as amount_to,
-          abs((a.clearing_value + b.clearing_value) /(abs(a.clearing_value) + abs(b.clearing_value))) as matchablity_clearing_prices,
-          abs((a.usd_value + b.usd_value) / (abs(a.usd_value) + abs(b.usd_value))) as matchability_prices_dune,
-          'INTERNAL_TRADE'   as transfer_type
-    from valued_potential_buffered_trades a
-             full outer join valued_potential_buffered_trades b
-                             on a.tx_hash = b.tx_hash
-    where (
-              case
-                  -- in order to classify as buffer trade, the positive surplus must be in an allow_listed token
-                  when ((a.amount > cast(0 as int256) and b.amount < cast(0 as int256) and a.token in (select * from token_list))
-                      or (b.amount > cast(0 as int256) and a.amount < cast(0 as int256) and b.token in (select * from token_list)))
-                      and
-                      -- We know that settlements - with at least one amm interaction - have internal buffer trades only if
-                      -- the solution must come from a internal_buffer_trader_solvers solver
-                      (a.solver_address in (select * from internal_buffer_trader_solvers)
-                          or a.dex_swaps = 0)
-                      then
-                      case
-                          when a.clearing_value is not null and b.clearing_value is not null
-                              -- If clearing prices are use, the price of internal trades are usually pretty close to
-                              -- the clearing prices. But they don't have to be the same, as internal trades are usually settled
-                              -- at the effective rate of an AMM. One example with deviating prices, is the tx:
-                              -- 0x9a318d1abd997bcf8afed55b2946a7b1bd919d227f094cdcc99d8d6155808d7c. It
-                              -- scores a matchablity of 0.021.
-                              -- Another example is xd2e1eeef702d562491d6b68683772fec1b119df18e338b50f45ed4751c89e406 with a
-                              -- matchablity of 0.02 for USDC to ETH trade
-                              -- But for higher values, one more commonly find examples, where solvers sell a little bit too much
-                              -- of the selling token and hence also receive a little bit too much of the buying token
-                              -- One could see this as an internal buffer trade, but since this is not good for the protocol's buffers
-                              -- we will not evaluate this as buffer trade, but rather as positive and negative slippage at the same time:
-                              -- One example is: 0x63e234a1a0d657f5725817f8d829c4e14d8194fdc49b5bc09322179ff99619e7 with a matchablity of 0.26
-                              -- selling too much USDC and receiving too much ETH
-                              then (abs((a.clearing_value + b.clearing_value) / (abs(a.clearing_value) + abs(b.clearing_value))) < 0.025
-                              and a.token != b.token
-                            )
-                          else
-                              case
-                                  when a.usd_value is not null and b.usd_value is not null
-                                      -- If prices from the prices.usd dune table are used, the prices can also be off from time to time.
-                                      -- On the one hand side, we don't wanna allow to high deviations. E.g. for
-                                      -- 0x9a318d1abd997bcf8afed55b2946a7b1bd919d227f094cdcc99d8d6155808d7c a matchability of 0.26 is calculated
-                                      -- for a slippage of WETH and the LDO deficit. (In this example the internal trade is only STRONG -> LDO)
-                                      -- On the other hand, real internal trades like the CRV to USDT internal trade of 0xc15dda7c10eb317c0ad177316020ec4baa13babb0713b73480feef14045603f4
-                                      -- also score a matchablilty of 0.027
-                                      -- As a compromise 0.025 was chosen
-                                      then (abs((a.usd_value + b.usd_value) /
-                                                (abs(a.usd_value) + abs(b.usd_value))) <
-                                            0.025
-                                      and a.token != b.token
-                                      and abs(a.usd_value) > 10 -- we don't want small slippage values to be recognized as internal swaps
-                                      )
-                                  else
-                                      false
-                                  end
-                          end
-                  else
-                      false
-                  end
-              )
+,block_range as (
+  select min(number) as start_block,
+       max(number) as end_block
+  from ethereum.blocks
+  where time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
 )
-,incoming_and_outgoing_with_buffer_trades as (
-select * from (
-    select block_time,
-          tx_hash,
-          solver_address,
-          symbol,
-          token,
-          amount,
-          transfer_type
-    from incoming_and_outgoing
-    union all
-    select block_time,
-          tx_hash,
-          solver_address,
-          symbol,
-          token_from as token,
-          amount_from as amount,
-          transfer_type
-    from buffer_trades
-) as _
-order by block_time
+,internalized_imbalances as (
+  select  b.block_time,
+          b.tx_hash,
+          b.solver_address,
+          t.symbol,
+          from_hex(i.token) as token,
+          cast(cast(i.amount as varchar) as int256) as amount,
+          'PHANTOM_TRANSFER' as transfer_type
+    from cowswap.raw_internal_imbalance i
+    inner join cow_protocol_ethereum.batches b
+        on i.block_number = b.block_number
+        and from_hex(i.tx_hash) = b.tx_hash
+    join tokens.erc20 t
+        on contract_address = from_hex(token)
+        and blockchain = 'ethereum'
+    where i.block_number between (select start_block from block_range) and (select end_block from block_range)
+    and ('{{SolverAddress}}' = '0x' or b.solver_address = from_hex('{{SolverAddress}}'))
+    and ('{{TxHash}}' = '0x' or b.tx_hash = from_hex('{{TxHash}}'))
+)
+,incoming_and_outgoing_with_internalized_imbalances as (
+    select * from (
+        select block_time,
+              tx_hash,
+              solver_address,
+              symbol,
+              token,
+              amount,
+              transfer_type
+        from incoming_and_outgoing
+        union all
+        select * from internalized_imbalances
+    ) as _
+    order by block_time
 )
 ,final_token_balance_sheet as (
     select
@@ -372,13 +238,9 @@ order by block_time
         tx_hash,
         date_trunc('hour', block_time) as hour
     from
-        incoming_and_outgoing_with_buffer_trades
+        incoming_and_outgoing_with_internalized_imbalances
     group by
-        symbol,
-        token,
-        solver_address,
-        tx_hash,
-        block_time
+        symbol, token, solver_address, tx_hash, block_time
     having
         sum(amount) != cast(0 as int256)
 )
@@ -479,7 +341,7 @@ order by block_time
         on token = p.contract_address
         and p.hour = ftbs.hour
     left join eth_prices ep
-        on  ftbs.hour = ep.hour
+        on ftbs.hour = ep.hour
     group by
         ftbs.hour,
         solver_address,

--- a/src/queries.py
+++ b/src/queries.py
@@ -58,11 +58,11 @@ QUERIES = {
     "PERIOD_SLIPPAGE": QueryData(
         name="Solver Slippage for Period",
         filepath="period_slippage.sql",
-        q_id=2259597,
+        q_id=2421375,
     ),
     "DASHBOARD_SLIPPAGE": QueryData(
-        name="Dashboard Slippage for Period",
+        name="Period Solver Rewards",
         filepath="not currently stored in project",
-        q_id=2283297,
+        q_id=2510345,
     ),
 }


### PR DESCRIPTION
This is the Final piece of the new slippage accounting project. We update the Slippage query to make use of the phantom transfers table.

In the query we see a URL to [this PoC Query](https://dune.com/queries/2421375?StartTime_d83555=2023-01-01+00%3A00%3A00&EndTime_d83555=2023-01-02+00%3A00%3A00&CTE_NAME_e15077=incoming_and_outgoing_with_internalized_imbalances&sidebar=none) with some manually set values (just to demonstrate that it works). We need to populate the community sources with dune-sync before we can actually land this.

BTW -- It looks like this will also improve our query performance (from 4 minutes down to 30 seconds).

Note that this PR only introduces a change to the query, but not actually making use of it yet in the payout script.