### PR TITLE
[Bug] Log Index Parsing

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -74,3 +74,5 @@ jobs:
       - name: Tests
         run: npm run test --silent
         working-directory: ./internal_transfers/actions
+        env:
+          NODE_URL: ${{ secrets.NODE_URL }}

--- a/internal_transfers/actions/src/accounting.ts
+++ b/internal_transfers/actions/src/accounting.ts
@@ -2,8 +2,7 @@ import { SETTLEMENT_CONTRACT_ADDRESS } from "./constants";
 import { getSettlementCompetitionData } from "./orderbook";
 import { SimulationData, TransactionSimulator } from "./simulate/interface";
 import { partitionEventLogs } from "./parse";
-import { Log } from "@tenderly/actions";
-import { TokenImbalance, WinningSettlementData } from "./models";
+import { TokenImbalance, WinningSettlementData, EventLog } from "./models";
 import {
   aggregateTransfers,
   ImbalanceMap,
@@ -20,7 +19,7 @@ export interface MinimalTxData {
   readonly blockNumber: number;
   readonly from: string;
   readonly hash: string;
-  readonly logs: Log[];
+  readonly logs: EventLog[];
 }
 
 export function constructImbalanceMap(

--- a/internal_transfers/actions/src/models.ts
+++ b/internal_transfers/actions/src/models.ts
@@ -9,12 +9,14 @@ export interface TokenImbalance {
 }
 
 export interface EventLog {
+  // Block-wise index of Log
+  readonly index: number;
   // The contract address emitting the event
-  address: string;
+  readonly address: string;
   // The indexed topics from the event log
-  topics: string[];
+  readonly topics: string[];
   // The additional (non-indexed event data)
-  data: string;
+  readonly data: string;
 }
 
 export interface TradeEvent {

--- a/internal_transfers/actions/src/parse.ts
+++ b/internal_transfers/actions/src/parse.ts
@@ -1,4 +1,5 @@
 import {
+  EventLog,
   isSettlementEvent,
   isTradeEvent,
   SettlementEvent,
@@ -25,14 +26,14 @@ export interface ClassifiedEvents {
   settlements: SettlementEvent[];
 }
 
-export function partitionEventLogs(logs: Log[]): ClassifiedEvents {
+export function partitionEventLogs(logs: EventLog[]): ClassifiedEvents {
   const result: ClassifiedEvents = {
     transfers: [],
     trades: [],
     settlements: [],
   };
 
-  logs.forEach((log, index) => {
+  logs.forEach((log) => {
     // We are only interested in Transfer Events from erc20 contracts
     // along with Settlement and Trade Events from the Settlement contract
     // All other event emissions can be ignored for our purposes.
@@ -47,7 +48,7 @@ export function partitionEventLogs(logs: Log[]): ClassifiedEvents {
       return;
     }
 
-    const possibleSettlementEvent = tryParseSettlementEventLog(log, index);
+    const possibleSettlementEvent = tryParseSettlementEventLog(log);
     if (possibleSettlementEvent) {
       const settlementEventLog = possibleSettlementEvent;
       // Relevant Event Types
@@ -67,8 +68,7 @@ export function partitionEventLogs(logs: Log[]): ClassifiedEvents {
 }
 
 export function tryParseSettlementEventLog(
-  log: Log,
-  index: number
+  log: EventLog
 ): SettlementEvent | TradeEvent | null {
   const settlementEventLog = settlementInterface.parseLog(log);
   if (settlementEventLog === null) return null;
@@ -80,7 +80,7 @@ export function tryParseSettlementEventLog(
     const { solver } = settlementEventLog.args;
     return {
       solver,
-      logIndex: index,
+      logIndex: log.index,
     } as SettlementEvent;
   } else {
     // Placeholder for other Settlement Contract Events (e.g. Interaction)

--- a/internal_transfers/actions/src/simulate/tenderly.ts
+++ b/internal_transfers/actions/src/simulate/tenderly.ts
@@ -4,7 +4,7 @@ import {
   SimulationParams,
   TransactionSimulator,
 } from "./interface";
-import { EventLog } from "../models";
+import { Log } from "@tenderly/actions";
 
 export class TenderlySimulator implements TransactionSimulator {
   BASE_URL = "https://api.tenderly.co/api";
@@ -87,7 +87,7 @@ interface TenderlyBalanceDiff {
   dirty: bigint;
 }
 interface TenderlyTransactionLog {
-  raw: EventLog;
+  raw: Log;
 }
 
 export function isTenderlySimulationResponse(
@@ -122,7 +122,11 @@ export function parseTenderlySimulation(
       simulationID: `tenderly-${simulation.simulation.id}`,
       blockNumber: tx.transaction_info.block_number,
       gasUsed: simulation.simulation.gas_used,
-      logs: tx.transaction_info.logs.map((t: { raw: EventLog }) => t.raw) || [],
+      logs:
+        tx.transaction_info.logs.map((t: { raw: Log }, index) => ({
+          ...t.raw,
+          index,
+        })) || [],
       ethDelta: new Map(
         balanceDiff.map((t) => [
           t.address.toLowerCase(),

--- a/internal_transfers/actions/src/utils.ts
+++ b/internal_transfers/actions/src/utils.ts
@@ -1,4 +1,4 @@
-import { TransferEvent } from "./models";
+import { EventLog, TransferEvent } from "./models";
 import { MinimalTxData } from "./accounting";
 import { AbstractProvider } from "ethers";
 
@@ -20,13 +20,14 @@ export async function getTxDataFromHash(
     throw new Error(`invalid transaction hash ${txHash} - try again`);
   }
   const { from, hash, blockNumber, logs: readonlyLogs } = transaction;
-  const logs = readonlyLogs.map((log) => {
-    return {
-      ...log,
-      // had to Map it to make a copy of a readonly field.
-      topics: log.topics.map((value) => value),
-    };
-  });
+  const logs: EventLog[] = readonlyLogs.map(
+    ({ index, address, data, topics }) => ({
+      index,
+      address,
+      data,
+      topics: [...topics],
+    })
+  );
 
   return {
     from,

--- a/internal_transfers/actions/src/utils.ts
+++ b/internal_transfers/actions/src/utils.ts
@@ -25,6 +25,7 @@ export async function getTxDataFromHash(
       index,
       address,
       data,
+      // making a copy of a readonly field!
       topics: [...topics],
     })
   );

--- a/internal_transfers/actions/tests/accounting.spec.ts
+++ b/internal_transfers/actions/tests/accounting.spec.ts
@@ -88,6 +88,7 @@ describe("constructImbalanceMap(simulation, focalContract)", () => {
         "0x0e50d5447266171a4daf32880dfef3f55e31b7b80b285d14ddaefa6ad8098221",
       logs: [
         {
+          index: 0,
           address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
           topics: [
             "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
@@ -97,6 +98,7 @@ describe("constructImbalanceMap(simulation, focalContract)", () => {
           data: "0x000000000000000000000000000000000000000000000000000000000000000f", // +15
         },
         {
+          index: 1,
           address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
           topics: [
             "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
@@ -132,6 +134,7 @@ describe("constructImbalanceMap(simulation, focalContract)", () => {
       txHash: "0x",
       logs: [
         {
+          index: 0,
           address: "0xtoken",
           topics: [
             "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",

--- a/internal_transfers/actions/tests/database.spec.ts
+++ b/internal_transfers/actions/tests/database.spec.ts
@@ -105,6 +105,7 @@ describe("All Database Tests", () => {
       const simulationID = "sim-id";
       const largeBigInt = 99999999999999999999999999999999999999999999999999n;
       const exampleLog = {
+        index: 0,
         address: ethers.ZeroAddress,
         // The indexed topics from the event log
         topics: [ethers.ZeroHash, ethers.ZeroHash],
@@ -253,6 +254,7 @@ describe("All Database Tests", () => {
       const token2 = "0x34";
       const simulationBlock = 1;
       const exampleLog = {
+        index: 0,
         address: ethers.ZeroAddress,
         // The indexed topics from the event log
         topics: [ethers.ZeroHash, ethers.ZeroHash],
@@ -364,6 +366,7 @@ describe("jsonFromSettlementData", () => {
       blockNumber,
       logs: [
         {
+          index: 0,
           address: ethers.ZeroAddress,
           // The indexed topics from the event log
           topics: [ethers.ZeroHash],
@@ -379,6 +382,7 @@ describe("jsonFromSettlementData", () => {
       },
       logs: [
         {
+          index: 0,
           address: ethers.ZeroAddress,
           data: ethers.ZeroHash,
           topics: [ethers.ZeroHash],

--- a/internal_transfers/actions/tests/parse.spec.ts
+++ b/internal_transfers/actions/tests/parse.spec.ts
@@ -157,7 +157,9 @@ describe("partitionEventLogs(logs)", () => {
           ],
           data: "0x0000000000000000000000000000000000000000000000001ca811856c2c5a63",
         },
-      ],
+      ].map((value, index) => {
+        return { index, ...value };
+      }),
     };
     const { trades, transfers, settlements } = partitionEventLogs(
       simulationData.logs
@@ -217,30 +219,34 @@ describe("tryParseSettlementEvent(log, index)", () => {
   test("parses Trade Event", () => {
     const tradeOwner = "0xd5553C9726EA28e7EbEDfe9879cF8aB4d061dbf0";
     const tradeLog = {
+      index: 0,
       address: SETTLEMENT_CONTRACT_ADDRESS,
       data: "0x0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000003432b6a60d23ca0dfca7761b7ab56459d9c964d000000000000000000000000000000000000000000000006c6b935b8bbd400000000000000000000000000000000000000000000000000019753399721b8078ee000000000000000000000000000000000000000000000000604fbfc634eef00000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000038bf293f652b46fe85a15838d7ff736add1b6098ed1c143f3902869d325f9e0069e2b424053b9ebfcedf89ecb8bf2972974e98700c63af639e0000000000000000",
       topics: [TRADE_EVENT_TOPIC, addressToTopic(tradeOwner)],
     };
-    const tradeEvent = tryParseSettlementEventLog(tradeLog, 1);
+    const tradeEvent = tryParseSettlementEventLog(tradeLog);
     expect(isTradeEvent(tradeEvent)).toStrictEqual(true);
     expect(isSettlementEvent(tradeEvent)).toStrictEqual(false);
     expect(tradeEvent).toStrictEqual({ owner: tradeOwner });
   });
   test("parses Settlement Event", () => {
     const solver = "0xb20B86C4e6DEEB432A22D773a221898bBBD03036";
+    const logIndex = 1;
     const settlementLog = {
+      index: logIndex,
       address: SETTLEMENT_CONTRACT_ADDRESS,
       topics: [SETTLEMENT_EVENT_TOPIC, addressToTopic(solver)],
       data: "0x",
     };
-    const logIndex = 1;
-    const settlementEvent = tryParseSettlementEventLog(settlementLog, logIndex);
+
+    const settlementEvent = tryParseSettlementEventLog(settlementLog);
     expect(isTradeEvent(settlementEvent)).toStrictEqual(false);
     expect(isSettlementEvent(settlementEvent)).toStrictEqual(true);
     expect(settlementEvent).toStrictEqual({ solver, logIndex });
   });
   test("parses Interaction Event as null", () => {
     const nullEventLog = {
+      index: 0,
       address: SETTLEMENT_CONTRACT_ADDRESS,
       topics: [
         "0xed99827efb37016f2275f98c4bcf71c7551c75d59e9b450f79fa32e60be672c2",
@@ -248,7 +254,7 @@ describe("tryParseSettlementEvent(log, index)", () => {
       ],
       data: "0x0000000000000000000000000000000000000000000000000000000000000000f021092900000000000000000000000000000000000000000000000000000000",
     };
-    const nullEvent = tryParseSettlementEventLog(nullEventLog, 0);
+    const nullEvent = tryParseSettlementEventLog(nullEventLog);
     expect(nullEvent).toStrictEqual(null);
   });
 });

--- a/internal_transfers/actions/tests/simulate-tenderly.spec.ts
+++ b/internal_transfers/actions/tests/simulate-tenderly.spec.ts
@@ -95,6 +95,7 @@ describe("Tenderly Simulator", () => {
       ethDelta: new Map(),
       logs: [
         {
+          index: 0,
           address: "0xADDRESS",
           data: "0xDATA",
           topics: ["0xTOPIC_1"],

--- a/internal_transfers/actions/tests/utils.spec.ts
+++ b/internal_transfers/actions/tests/utils.spec.ts
@@ -1,5 +1,7 @@
-import { transferInvolves } from "../src/utils";
+import { getTxDataFromHash, transferInvolves } from "../src/utils";
 import { TransferEvent } from "../src/models";
+import { ethers } from "ethers";
+import { tryParseSettlementEventLog } from "../src/parse";
 describe("transferInvolves(transfer, address)", () => {
   test("correctly returns whether transfer instance involves given address", () => {
     const address1 = "0x0000000000000000000000000000000000000001";
@@ -14,5 +16,58 @@ describe("transferInvolves(transfer, address)", () => {
     expect(transferInvolves(transfer, address1)).toBe(true);
     expect(transferInvolves(transfer, address2)).toBe(true);
     expect(transferInvolves(transfer, address3)).toBe(false);
+  });
+});
+
+describe("getTxDataFromHash(hash)", () => {
+  test("does its job on basic transaction WETH unwrap", async () => {
+    const provider = ethers.getDefaultProvider(
+      process.env["NODE_URL"] || "NODE_URL"
+    );
+
+    expect(
+      await getTxDataFromHash(
+        provider,
+        "0x2e8e115281bacc9753a31298bc9ef022eeb0f68d4c4762d4b50b757c0665b447"
+      )
+    ).toEqual({
+      blockNumber: 17233653,
+      from: "0xf1E13D28d19F5348A20E46fAC8E36791ca63Aa81",
+      hash: "0x2e8e115281bacc9753a31298bc9ef022eeb0f68d4c4762d4b50b757c0665b447",
+      logs: [
+        {
+          address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          data: "0x00000000000000000000000000000000000000000000000000cd620a04977a9b",
+          index: 305,
+          topics: [
+            "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65",
+            "0x000000000000000000000000f1e13d28d19f5348a20e46fac8e36791ca63aa81",
+          ],
+        },
+      ],
+    });
+  });
+  test("Puts correct index on SettlementEvent logs", async () => {
+    const provider = ethers.getDefaultProvider(
+      process.env["NODE_URL"] || "NODE_URL"
+    );
+
+    const txData1 = await getTxDataFromHash(
+      provider,
+      "0xe08fd9651626cc0827a83721e9b6ef99a8be752d2a88490218f75ba84082a887"
+    );
+    expect(tryParseSettlementEventLog(txData1.logs.pop()!)).toEqual({
+      logIndex: 104,
+      solver: "0x0a308697e1d3a91dcB1e915C51F8944AaEc9015F",
+    });
+
+    const txData2 = await getTxDataFromHash(
+      provider,
+      "0xec894e53627f4b0a05be069a6c0c0cca08efe67f0b12deb85aeaa146f77eb049"
+    );
+    expect(tryParseSettlementEventLog(txData2.logs.pop()!)).toEqual({
+      logIndex: 227,
+      solver: "0x398890BE7c4FAC5d766E1AEFFde44B2EE99F38EF",
+    });
   });
 });


### PR DESCRIPTION
## Explanation of Bug

A previous deployment encountered a [primary-key error](https://jsonblob.com/1106009775560474624) on insertion of settlements with primary key `(blockNumber, LogIndex)` and this was entirely due to the fact that we had been using the transaction-wise log index as opposed to the block-wise log index.

### Example: 

1. Passing Execution [c125a325-69c4-4acc-8b9d-dc0609eb0143](https://dashboard.tenderly.co/gp-v2/solver-slippage/action/4f657ddd-c054-4704-9e1e-50385ad2fc2c/execution/c125a325-69c4-4acc-8b9d-dc0609eb0143) for tx 
[0xe08fd9651626cc0827a83721e9b6ef99a8be752d2a88490218f75ba84082a887](https://etherscan.io/tx/0xe08fd9651626cc0827a83721e9b6ef99a8be752d2a88490218f75ba84082a887)

and

2. Failing Execution [8d30189b-7282-4f63-990a-7d6849c49e62](https://dashboard.tenderly.co/gp-v2/solver-slippage/action/4f657ddd-c054-4704-9e1e-50385ad2fc2c/execution/8d30189b-7282-4f63-990a-7d6849c49e62) for tx [0xec894e53627f4b0a05be069a6c0c0cca08efe67f0b12deb85aeaa146f77eb049](https://etherscan.io/tx/0xec894e53627f4b0a05be069a6c0c0cca08efe67f0b12deb85aeaa146f77eb049)

where both settlements occurred in the same block and had exactly the same settlement event index of 12 (transaction-wise) clashed here. Meanwhile the block- wise log index of these events were 104 and 227 respectively.

Unfortunately, Tenderly does not provide the correct log index in their [web-action payloads](http://jsonblob.com/1103717033526444032) nor in their simulation results... so we are forced to fetch [transaction receipts](http://jsonblob.com/1103716885064859648) from the EVM (basically ignoring the entire payload data except for txHash)


## Solution

Here we introduce a field `index` on our model `EventLog` and populate it with the values contained in `TransactionReceipt`. Having imposed this in our work flow detected several places where the field was required, but not yet available. In particular we are forces to "fudge" the values on the Tenderly Simulation results because they are not provided and they are only hypothetical transactions anyway. This does not affect us in any way because we do not write Settlement Event data for simulated transactions anyway -- furthermore, since we always simulate at slot 0, these fudged values are actually the correct log indices.


## Test Plan

All relevant unit tests have been updated. Along with a couple more for the example provided above.


This is nearly the final PR for Phase 1 of #177 