### PR TITLE
Insert Settlement & Mark Processed

### DIFF
--- a/internal_transfers/actions/src/database.ts
+++ b/internal_transfers/actions/src/database.ts
@@ -55,7 +55,7 @@ export async function markReceiptProcessed(db: Queryable, hash: string) {
   const updateQuery = sql`UPDATE tx_receipts SET processed = true where hash = ${pgHash(
     hash
   )};`;
-  await db.query(updateQuery);
+  return db.query(updateQuery);
 }
 
 export async function recordExists(
@@ -142,8 +142,7 @@ export async function insertPipelineResults(
     await insertTokenImbalances(db, eventMeta.txHash, imbalances);
     await insertSettlementSimulations(db, settlementSimulations);
     await insertSettlementEvent(db, eventMeta, settlementEvent);
-    // TODO - markReceiptProcessed in follow up PR.
-    // await markReceiptProcessed(db, eventMeta.txHash);
+    await markReceiptProcessed(db, eventMeta.txHash);
   });
   console.log(`wrote ${imbalances.length} imbalances for ${eventMeta.txHash}`);
 }

--- a/internal_transfers/actions/src/database.ts
+++ b/internal_transfers/actions/src/database.ts
@@ -132,6 +132,18 @@ export interface SlippagePipelineResults {
   eventMeta: EventMeta;
   settlementEvent: SettlementEvent;
 }
+
+export async function insertSettlementAndMarkProcessed(
+  db: ConnectionPool,
+  eventMeta: EventMeta,
+  settlementEvent: SettlementEvent
+) {
+  await db.tx(async (db) => {
+    await insertSettlementEvent(db, eventMeta, settlementEvent);
+    await markReceiptProcessed(db, eventMeta.txHash);
+  });
+}
+
 export async function insertPipelineResults(
   db: ConnectionPool,
   pipelineResults: SlippagePipelineResults
@@ -141,8 +153,7 @@ export async function insertPipelineResults(
   await db.tx(async (db) => {
     await insertTokenImbalances(db, eventMeta.txHash, imbalances);
     await insertSettlementSimulations(db, settlementSimulations);
-    await insertSettlementEvent(db, eventMeta, settlementEvent);
-    await markReceiptProcessed(db, eventMeta.txHash);
+    await insertSettlementAndMarkProcessed(db, eventMeta, settlementEvent);
   });
   console.log(`wrote ${imbalances.length} imbalances for ${eventMeta.txHash}`);
 }

--- a/internal_transfers/actions/src/database.ts
+++ b/internal_transfers/actions/src/database.ts
@@ -55,7 +55,7 @@ export async function markReceiptProcessed(db: Queryable, hash: string) {
   const updateQuery = sql`UPDATE tx_receipts SET processed = true where hash = ${pgHash(
     hash
   )};`;
-  return db.query(updateQuery);
+  await db.query(updateQuery);
 }
 
 export async function recordExists(

--- a/internal_transfers/actions/src/pipeline.ts
+++ b/internal_transfers/actions/src/pipeline.ts
@@ -2,8 +2,10 @@ import { partitionEventLogs } from "./parse";
 import {
   getUnprocessedReceipts,
   insertPipelineResults,
+  insertSettlementAndMarkProcessed,
   insertSettlementEvent,
   insertTxReceipt,
+  markReceiptProcessed,
   recordExists,
 } from "./database";
 import {
@@ -88,7 +90,7 @@ export async function internalizedTokenImbalance(
         settlementEvent,
       });
     } else {
-      await insertSettlementEvent(db, eventMeta, settlementEvent);
+      await insertSettlementAndMarkProcessed(db, eventMeta, settlementEvent);
     }
   }
 }

--- a/internal_transfers/actions/src/pipeline.ts
+++ b/internal_transfers/actions/src/pipeline.ts
@@ -3,9 +3,7 @@ import {
   getUnprocessedReceipts,
   insertPipelineResults,
   insertSettlementAndMarkProcessed,
-  insertSettlementEvent,
   insertTxReceipt,
-  markReceiptProcessed,
   recordExists,
 } from "./database";
 import {
@@ -65,7 +63,7 @@ export async function internalizedTokenImbalance(
   console.log(`processing settlement transaction with hash: ${txData.hash}`);
   // Duplication Guard!
   if (await recordExists(db, txHash)) {
-    console.warn(`record exists for tx: ${txHash}`);
+    console.warn(`event record exists for tx: ${txHash}`);
     return;
   }
 

--- a/internal_transfers/actions/tests/database.spec.ts
+++ b/internal_transfers/actions/tests/database.spec.ts
@@ -27,10 +27,14 @@ const dbURL: string =
   "postgresql://postgres:postgres@localhost:5432/postgres";
 const db = getDB(dbURL);
 async function truncateTables() {
-  await db.query(sql`TRUNCATE TABLE settlements;`);
-  await db.query(sql`TRUNCATE TABLE internalized_imbalances;`);
-  await db.query(sql`TRUNCATE TABLE settlement_simulations;`);
-  await db.query(sql`TRUNCATE TABLE tx_receipts;`);
+  for (const table_name of [
+    "settlements",
+    "internalized_imbalances",
+    "settlement_simulations",
+    "tx_receipts",
+  ]) {
+    await db.query(sql`TRUNCATE TABLE ${table_name};`);
+  }
 }
 
 const largeBigInt =

--- a/internal_transfers/actions/tests/database.spec.ts
+++ b/internal_transfers/actions/tests/database.spec.ts
@@ -27,14 +27,10 @@ const dbURL: string =
   "postgresql://postgres:postgres@localhost:5432/postgres";
 const db = getDB(dbURL);
 async function truncateTables() {
-  for (const table_name of [
-    "settlements",
-    "internalized_imbalances",
-    "settlement_simulations",
-    "tx_receipts",
-  ]) {
-    await db.query(sql`TRUNCATE TABLE ${table_name};`);
-  }
+  await db.query(sql`TRUNCATE TABLE settlements;`);
+  await db.query(sql`TRUNCATE TABLE internalized_imbalances;`);
+  await db.query(sql`TRUNCATE TABLE settlement_simulations;`);
+  await db.query(sql`TRUNCATE TABLE tx_receipts;`);
 }
 
 const largeBigInt =


### PR DESCRIPTION
Part of #177 

Doing a TODO to mark data as process when simulation is inserted. This happens in both cases of the pipeline (when there is an is not a simulation to go with it).

## Test Plan

Every component is tested individually. Could also add a test fot `insertSettlementAndMarkProcessed` although it just runs both, tested methods, together.