### PR TITLE
Exclude No Trade Batches

### DIFF
--- a/internal_transfers/actions/src/pipeline.ts
+++ b/internal_transfers/actions/src/pipeline.ts
@@ -39,6 +39,8 @@ export async function preliminaryPipelineTask(
   if (trades.length > 0) {
     await insertTxReceipt(db, txReceipt);
   } else {
+    // E.g. Fee Withdrawal:
+    // https://etherscan.io/tx/0x72971bf0203c472c58ba0970c9cd99c14c153badac787186f3856b416a6ff59c
     console.log("No trades in batch");
   }
 

--- a/internal_transfers/actions/src/pipeline.ts
+++ b/internal_transfers/actions/src/pipeline.ts
@@ -35,7 +35,13 @@ export async function preliminaryPipelineTask(
   numConfirmationBlocks: number = 70
 ): Promise<MinimalTxData[]> {
   const txReceipt = await getTxDataFromHash(provider, txHash);
-  await insertTxReceipt(db, txReceipt);
+  const { trades } = partitionEventLogs(txReceipt.logs);
+  if (trades.length > 0) {
+    await insertTxReceipt(db, txReceipt);
+  } else {
+    console.log("No trades in batch");
+  }
+
   return getUnprocessedReceipts(
     db,
     txReceipt.blockNumber - numConfirmationBlocks


### PR DESCRIPTION
Today we saw a bunch of failures because of [fee withdrawal transaction](https://etherscan.io/tx/0x72971bf0203c472c58ba0970c9cd99c14c153badac787186f3856b416a6ff59c) (a batch with no trades and also no solver competition).

Reported and resolved here in [slack](https://cowservices.slack.com/archives/C0375NV72SC/p1683884659861259).