### PR TITLE
Try More Simulation Blocks and Write Default on Failure

### DIFF
--- a/internal_transfers/actions/src/accounting.ts
+++ b/internal_transfers/actions/src/accounting.ts
@@ -91,7 +91,7 @@ export async function simulateSolverSolution(
     const failedSimulation = {
       simulationID: `failed all ${numAttempts} simulation attempts`,
       blockNumber: -1,
-      gasUsed: -1,
+      gasUsed: 0,
       logs: [],
       ethDelta: new Map(),
     };

--- a/internal_transfers/actions/src/accounting.ts
+++ b/internal_transfers/actions/src/accounting.ts
@@ -86,14 +86,16 @@ export async function simulateSolverSolution(
       reduced,
     };
   } catch (error: any) {
-    // If we fail this many simulations, we will just have to assume there is none.
     console.error(error.errorMessage);
+    // Sometimes (rarely) we can't simulate both components of the solver competition data.
+    // When this happens, it is assumed that there were no internalized transfers
+    // and write a kind of placeholder/trivial record as follows:
     const failedSimulation = {
       simulationID: `failed all ${numAttempts} simulation attempts`,
-      blockNumber: -1,
-      gasUsed: 0,
-      logs: [],
-      ethDelta: new Map(),
+      blockNumber: -1, // easily identifiable "trivial simulation record"
+      gasUsed: 0, // 0 gasUsed will not affect aggregate sums on gas consumption.
+      logs: [], // implies no token transfers.
+      ethDelta: new Map(), // implies no eth balance diff.
     };
     return {
       txHash: transaction.hash,

--- a/internal_transfers/actions/src/pipeline.ts
+++ b/internal_transfers/actions/src/pipeline.ts
@@ -39,6 +39,8 @@ export async function preliminaryPipelineTask(
   if (trades.length > 0) {
     await insertTxReceipt(db, txReceipt);
   } else {
+    // E.g. Fee Withdrawal:
+    // https://etherscan.io/tx/0x72971bf0203c472c58ba0970c9cd99c14c153badac787186f3856b416a6ff59c
     console.log("No trades in batch");
   }
 

--- a/internal_transfers/actions/src/pipeline.ts
+++ b/internal_transfers/actions/src/pipeline.ts
@@ -35,7 +35,13 @@ export async function preliminaryPipelineTask(
   numConfirmationBlocks: number = 70
 ): Promise<MinimalTxData[]> {
   const txReceipt = await getTxDataFromHash(provider, txHash);
-  await insertTxReceipt(db, txReceipt);
+  const { trades } = partitionEventLogs(txReceipt.logs);
+  if (trades.length > 0) {
+    await insertTxReceipt(db, txReceipt);
+  } else {
+    console.log("No trades in batch");
+  }
+
   return getUnprocessedReceipts(
     db,
     txReceipt.blockNumber - numConfirmationBlocks


### PR DESCRIPTION
Previously we were attempting simulation on only 3 block and throwing an error if no non passed. This PR adjusts two things

1. try all blocks between `simBlock` and actual `minedBlock`
2. Write default instead of throwing error in case of failed transactions.


This change fixes both of the following cases:

```
--FAILED (on all blocks from simBlock to txMined block)
0x9D5F8748D29893438B01A1CA9EE21A192A760997BCDA1987A9A368DCD733A0D6
```

```
PASSES SIM ON TX BLOCK ONLY (4 blocks away from simBlock)
0xF51DB3F7BB5018CD846DB1AFCFF0F62E068317450E872DC1DB006247E6E1771C (edited) 
```