### PR TITLE
[Bug] Catch Missing Competition

### DIFF
--- a/internal_transfers/actions/index.ts
+++ b/internal_transfers/actions/index.ts
@@ -34,6 +34,6 @@ export const triggerInternalTransfersPipeline: ActionFn = async (
   );
   for (const tx of finalizedTxReceipts) {
     // Theoretically, there are only be 1 or 2 of these to process in a single run.
-    await internalizedTokenImbalance(tx, db, simulator);
+    await internalizedTokenImbalance(tx, db, simulator, provider);
   }
 };

--- a/internal_transfers/actions/src/pipeline.ts
+++ b/internal_transfers/actions/src/pipeline.ts
@@ -39,6 +39,8 @@ export async function preliminaryPipelineTask(
   if (trades.length > 0) {
     await insertTxReceipt(db, txReceipt);
   } else {
+    // E.g. Fee Withdrawal:
+    // https://etherscan.io/tx/0x72971bf0203c472c58ba0970c9cd99c14c153badac787186f3856b416a6ff59c
     console.log("No trades in batch");
   }
 

--- a/internal_transfers/actions/src/pipeline.ts
+++ b/internal_transfers/actions/src/pipeline.ts
@@ -35,7 +35,13 @@ export async function preliminaryPipelineTask(
   numConfirmationBlocks: number = 70
 ): Promise<MinimalTxData[]> {
   const txReceipt = await getTxDataFromHash(provider, txHash);
-  await insertTxReceipt(db, txReceipt);
+  const { trades } = partitionEventLogs(txReceipt.logs);
+  if (trades.length > 0) {
+    await insertTxReceipt(db, txReceipt);
+  } else {
+    console.log("No trades in batch");
+  }
+
   return getUnprocessedReceipts(
     db,
     txReceipt.blockNumber - numConfirmationBlocks

--- a/internal_transfers/actions/tests/e2e/pipeline.spec.ts
+++ b/internal_transfers/actions/tests/e2e/pipeline.spec.ts
@@ -2,24 +2,27 @@ import { TenderlySimulator } from "../../src/simulate/tenderly";
 import { internalizedTokenImbalance } from "../../src/pipeline";
 import { getDB } from "../../src/database";
 import { getTxData } from "./helper";
+import { ethers } from "ethers";
 
-const { TENDERLY_USER, TENDERLY_PROJECT, TENDERLY_ACCESS_KEY } = process.env;
+const { TENDERLY_USER, TENDERLY_PROJECT, TENDERLY_ACCESS_KEY, NODE_URL } =
+  process.env;
 
 const simulator = new TenderlySimulator(
   TENDERLY_USER || "INVALID_USER",
   TENDERLY_PROJECT || "TENDERLY_PROJECT",
   TENDERLY_ACCESS_KEY || "TENDERLY_ACCESS_KEY"
 );
+const provider = ethers.getDefaultProvider(NODE_URL!);
 
 const db = getDB("postgresql://postgres:postgres@localhost:5432/postgres");
 
-describe.skip("Run Full Pipeline", () => {
+describe("Run Full Pipeline", () => {
   test("run pipeline on non-internalized transaction", async () => {
     const notInternalized = await getTxData(
       "0x0f86c06d9ace6a88644db6b654a904aa62c82305023e094ce49650467c91bd6e"
     );
     await expect(
-      internalizedTokenImbalance(notInternalized, db, simulator)
+      internalizedTokenImbalance(notInternalized, db, simulator, provider)
     ).resolves.not.toThrowError();
   }, 300000);
   test("run pipeline on batch with internalized transfers", async () => {
@@ -27,16 +30,25 @@ describe.skip("Run Full Pipeline", () => {
       "0xDCD5CF12340B50ACC04DBE7E14A903BE373456C81E4DB20DD84CF0301F6AB869"
     );
     await expect(
-      internalizedTokenImbalance(internalized, db, simulator)
+      internalizedTokenImbalance(internalized, db, simulator, provider)
     ).resolves.not.toThrowError();
   }, 300000);
 
-  test("run pipeline on transaction with unavailable competition data", async () => {
+  test("throws on unavailable competition data for successful transaction", async () => {
     const txHash =
       "0xe6a0fbad3f9571e7614dbbc1d65d523cbeb6929b59bd20cde80ac791899fccfb";
     const unavailable = await getTxData(txHash);
     await expect(
-      internalizedTokenImbalance(unavailable, db, simulator)
+      internalizedTokenImbalance(unavailable, db, simulator, provider)
     ).rejects.toThrow(`No competition found for ${txHash}`);
+  }, 300000);
+
+  test("resolves on unavailable competition data for failed transaction", async () => {
+    const txHash =
+      "0x1231f2c9b519adc5ae7db17c84418e140553e234b2868d6b1d7f66a692683e73";
+    const unavailable = await getTxData(txHash);
+    await expect(
+      internalizedTokenImbalance(unavailable, db, simulator, provider)
+    ).resolves.not.toThrowError();
   }, 300000);
 });

--- a/internal_transfers/actions/tests/e2e/pipeline.spec.ts
+++ b/internal_transfers/actions/tests/e2e/pipeline.spec.ts
@@ -16,7 +16,7 @@ const provider = ethers.getDefaultProvider(NODE_URL!);
 
 const db = getDB("postgresql://postgres:postgres@localhost:5432/postgres");
 
-describe("Run Full Pipeline", () => {
+describe.skip("Run Full Pipeline", () => {
   test("run pipeline on non-internalized transaction", async () => {
     const notInternalized = await getTxData(
       "0x0f86c06d9ace6a88644db6b654a904aa62c82305023e094ce49650467c91bd6e"


### PR DESCRIPTION
Closes #280 

We had a short outage due to a forked block / failed transaction (cf [tenderly](https://dashboard.tenderly.co/gp-v2/solver-slippage/action/4f657ddd-c054-4704-9e1e-50385ad2fc2c/execution/a14e3e0f-3e26-4290-8684-1720d74f1513)). 

This [transaction](https://etherscan.io/tx/0x1231f2c9b519adc5ae7db17c84418e140553e234b2868d6b1d7f66a692683e73) was previously included in a block that wound up forked (tenderly picked this up as successful beforehand) we stored the original successful transaction in our DB, but then later it turns out to be a failed transaction. This explains why the solver competition was not found.

Instead of throwing an Error when competition is not found, we can at least go back to the EVM and check if the transaction details still match what we have. I am not exactly sure how to uniquely identify a "failed" transaction, but it suffices for our purposes that the transaction does not have any logs.


## Test Plan

Added a test demonstrating that the pipeline does not throw when this scenario occurs.