### PR TITLE
Add simulation ID to DB json

### DIFF
--- a/internal_transfers/actions/src/database.ts
+++ b/internal_transfers/actions/src/database.ts
@@ -111,6 +111,7 @@ export function jsonFromSettlementData(datum: SimulationData): object {
     logs: datum.logs,
     blockNumber: datum.blockNumber,
     ethDelta: bigIntMapToJSON(datum.ethDelta),
+    simId: datum.simulationID,
   };
 }
 

--- a/internal_transfers/actions/tests/database.spec.ts
+++ b/internal_transfers/actions/tests/database.spec.ts
@@ -147,11 +147,13 @@ describe("All Database Tests", () => {
       const expected = [
         {
           complete: {
+            simId: "sim-id",
             blockNumber: blockNumber,
             ethDelta: bigIntMapToJSON(exampleEthDelta),
             logs: [exampleLog, exampleLog],
           },
           reduced: {
+            simId: "sim-id",
             blockNumber: blockNumber,
             ethDelta: bigIntMapToJSON(exampleEthDelta),
             logs: [exampleLog],
@@ -423,6 +425,7 @@ describe("jsonFromSettlementData", () => {
       ethDelta: new Map([["0x1", bigNumber]]),
     };
     expect(jsonFromSettlementData(dummySimData)).toStrictEqual({
+      simId: "sim-id",
       blockNumber: 1,
       ethDelta: {
         "0x1": bigNumber.toString(),


### PR DESCRIPTION
Sometimes its nice to have a reference to an existing simulation. 

TODO - Might also be nice to write an ID for failed simulations as well.