### PR TITLE
Trigger Dashboard Query Refresh

### DIFF
--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -169,6 +169,15 @@ class DuneFetcher:
         Returns a class representation of the results as two lists (positive & negative).
         """
         token_list = get_trusted_tokens()
+        params = self._period_params() + [
+            QueryParameter.text_type("TxHash", "0x"),
+            QueryParameter.text_type("TokenList", ",".join(token_list)),
+        ]
+        # trigger dashboard update
+        self.dune.execute(
+            self._parameterized_query(QUERIES["DASHBOARD_SLIPPAGE"], params=params)
+        )
+
         return self._get_query_results(
             self._parameterized_query(
                 QUERIES["PERIOD_SLIPPAGE"],

--- a/src/queries.py
+++ b/src/queries.py
@@ -60,4 +60,9 @@ QUERIES = {
         filepath="period_slippage.sql",
         q_id=2259597,
     ),
+    "DASHBOARD_SLIPPAGE": QueryData(
+        name="Dashboard Slippage for Period",
+        filepath="not currently stored in project",
+        q_id=2283297,
+    ),
 }


### PR DESCRIPTION
People keep having issues with the dashboard query being out of sync when they land on the dashboard page. This will trigger refresh (in the background) at script runtime.