### PR TITLE
[DB] Add Primary Key to TxReceipts Table

### DIFF
--- a/internal_transfers/actions/src/database.ts
+++ b/internal_transfers/actions/src/database.ts
@@ -33,7 +33,7 @@ export async function insertTxReceipt(
   db: ConnectionPool,
   receipt: MinimalTxData
 ) {
-  await tx_receipts(db).insert({
+  await tx_receipts(db).insertOrIgnore({
     hash: hexToBytea(receipt.hash),
     block_number: receipt.blockNumber,
     data: receipt,

--- a/internal_transfers/actions/src/pipeline.ts
+++ b/internal_transfers/actions/src/pipeline.ts
@@ -4,6 +4,7 @@ import {
   insertPipelineResults,
   insertSettlementAndMarkProcessed,
   insertTxReceipt,
+  markReceiptProcessed,
   recordExists,
 } from "./database";
 import {
@@ -75,6 +76,7 @@ export async function internalizedTokenImbalance(
   // Duplication Guard!
   if (await recordExists(db, txHash)) {
     console.warn(`event record exists for tx: ${txHash}`);
+    await markReceiptProcessed(db, txHash);
     return;
   }
 

--- a/internal_transfers/database/sql/V004__create_tx_receipts.sql
+++ b/internal_transfers/database/sql/V004__create_tx_receipts.sql
@@ -13,7 +13,9 @@ CREATE TABLE tx_receipts
     -- processing only occurs after current_block > block_number + 65
     processed    bool   NOT NULL DEFAULT false,
     -- any relevant content from transaction receipt.
-    data         jsonb  NOT NULL
+    data         jsonb  NOT NULL,
+
+    PRIMARY KEY (hash)
 );
 
 CREATE INDEX tx_receipt_idx ON tx_receipts (processed);


### PR DESCRIPTION
We had some duplicated records in the tx receipt table every run of the tenderly action was always trying to process this same transaction every time. 

This can occur if tenderly triggers an action for a transaction hash twice or if we trigger the actions manually. Luckily we are still in staging and the tx_receipts table is not guaranteed to contain all records. We also aim to mark processed when we discover event record existence.


The actual correct way to apply these kinds of changes are to create a new version and run `ALTER TABLE... ` -- However, since we are not in production yet, I don't see the point.

Locally (in my test DB), the table was fixed with:

```sql
-- deduplicate
delete from tx_receipts 
where hash in (select hash from tx_receipts group by hash having count(*) > 1);
-- add primary key
ALTER table tx_receipts add primary key (hash);
```