### PR TITLE
Alert Missing Competition

### DIFF
--- a/internal_transfers/actions/src/alert/slack.ts
+++ b/internal_transfers/actions/src/alert/slack.ts
@@ -1,0 +1,13 @@
+import axios from "axios";
+export async function alertSlack(slackWebhook: string, message: string) {
+  const { data } = await axios.post(
+    slackWebhook,
+    { text: message },
+    {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  console.log(`Slack webhook response: ${data}`);
+}

--- a/internal_transfers/actions/src/pipeline.ts
+++ b/internal_transfers/actions/src/pipeline.ts
@@ -95,7 +95,6 @@ export async function internalizedTokenImbalance(
       if (reFetchedReceipt.logs.length === 0) {
         settlementSimulations = null;
       } else {
-        // TODO - TENDERLY ALERT?!
         throw error;
       }
     }


### PR DESCRIPTION
Generally the only known exception in this that is not handled in this function is `Competition Not Found`. So the idea is that we would send an alert to slack here. I think we may want to classify our errors better so that we can filter by type (if there are indeed others). For example, [the discussion](https://cowservices.slack.com/archives/C036PMLUPQF/p1684918444443309?thread_ts=1684916503.457969&cid=C036PMLUPQF) suggests we should determine which environment the settlement came from and alert in the appropriate channel (for this we would have to identify our Error as a Competition Not Found Error - then go and use the txHash to identify which environment the sender lives in.


Note also - this code was borrowed from [here](https://github.com/cowprotocol/tenderly-alerts/blob/fc320751478ad9dc1b650b17ec7906bc8d5f8d55/actions/alerts.ts#L193)