### PR TITLE
HotFix: adjust trader in when settlement contract is the trader

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -21,7 +21,11 @@ batch_meta as (
 ,filtered_trades as (
     select t.tx_hash,
            t.block_number,
-           trader                                       as trader_in,
+           case
+                when trader = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+                then 0x0000000000000000000000000000000000000000
+                else trader
+           end as trader_in,
            receiver                                     as trader_out,
            sell_token_address                           as sell_token,
            buy_token_address                            as buy_token,
@@ -90,6 +94,7 @@ batch_meta as (
       and 0x9008d19f58aabd9ed0d60971565aa8510560ab41 in (to, "from")
       and not contains(traders_in, "from")
       and not contains(traders_out, to)
+      and to != "from"
       and "from" not in ( -- ETH FLOW ORDERS ARE NOT AMM TRANSFERS!
           select distinct contract_address
           from cow_protocol_ethereum.CoWSwapEthFlow_evt_OrderPlacement


### PR DESCRIPTION
[PoC Query](https://dune.com/queries/2518760?sidebar=none&StartTime_d83555=2023-05-23+00%3A00%3A00&EndTime_d83555=2023-05-30+00%3A00%3A00)

There was an issue with the new withdraw scripts where our query logic was flawed (due to the settlement contract being also a trader). This very simple fix adjusts it. We have tested against our hypothesis that the [3 settlements having settlement contract as trader](https://dune.com/queries/2518672) were no longer part of the unusual slippage.





