### PR TITLE
[HotFix] Align Types

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -20,7 +20,7 @@ batch_meta as (
 )
 ,filtered_trades as (
     select t.tx_hash,
-           t.block_number,
+           b.block_number,
            case
                 when trader = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
                 then 0x0000000000000000000000000000000000000000
@@ -29,13 +29,12 @@ batch_meta as (
            receiver                                     as trader_out,
            sell_token_address                           as sell_token,
            buy_token_address                            as buy_token,
-           atoms_sold - coalesce(surplus_fee, 0)        as atoms_sold,
+           atoms_sold - coalesce(surplus_fee, cast(0 as uint256))        as atoms_sold,
            atoms_bought,
            0x9008d19f58aabd9ed0d60971565aa8510560ab41 as contract_address
     from cow_protocol_ethereum.trades t
          join cow_protocol_ethereum.batches b
-            on t.block_number = b.block_number
-            and t.tx_hash = b.tx_hash
+            on t.tx_hash = b.tx_hash
     left outer join cow_protocol_ethereum.order_rewards f
         on f.tx_hash = t.tx_hash
         and f.order_uid = t.order_uid


### PR DESCRIPTION
Recent migrations of Dune to DuneSQL have resulted in some queries failing.

- surplus fee is now uint256 so coalesce must be between same types
- silly me [forgot to include](https://github.com/duneanalytics/spellbook/pull/3719/files/7adb5fe2f2eb95a96fa7024383e579e29de61f8d..0081ca43fbd80d9a4a0c24ba3d3d31208754b0ae#diff-d22523138ecc729d8f9bacad2f79746074c3799bc6d67d2aaca0748d479aab89) `block_number` in the trades table (this [is being fixed](https://github.com/duneanalytics/spellbook/pull/3745) and can be reverted later)

Queries on Dune have already been updated and demonstrated to run now -- Since our queries are independent of this repo, this PR is more of a formality.