### PR TITLE
Ignore ETH wrapping transfers

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,4 +1,4 @@
--- https://github.com/cowprotocol/solver-rewards/pull/259
+-- https://github.com/cowprotocol/solver-rewards/pull/322
 -- Query Here: https://dune.com/queries/2421375
 with
 batch_meta as (

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -121,7 +121,7 @@ batch_meta as (
         and success = true
     and 0x9008d19f58aabd9ed0d60971565aa8510560ab41 in (to, "from")
     -- WETH unwraps don't have cancelling WETH transfer.
-    and "from" != 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+    and not 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 in (to, "from")
     -- ETH transfers to traders are already part of USER_OUT
     and not contains(traders_out, to)
 )


### PR DESCRIPTION
Before only transfers from WETH to the contract were ignored. those
correspond to unwraps/withdrawals.
With this change, also transfers from the protocol to WETH are ignored.
those correspond to wraps/deposits.

The general idea is that all transfers between the protocol and WETH should
correspond to wrapping and unwrapping. Such operations do change the ETH balance
and WETH balance without incurring any slippage or change in value of the buffers.