### PR TITLE
Fix query id for slippage accounting

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,5 +1,5 @@
 -- https://github.com/cowprotocol/solver-rewards/pull/322
--- Query Here: https://dune.com/queries/2421375
+-- Query Here: https://dune.com/queries/3093726
 with
 batch_meta as (
     select b.block_time,

--- a/src/queries.py
+++ b/src/queries.py
@@ -43,7 +43,7 @@ QUERIES = {
     "PERIOD_SLIPPAGE": QueryData(
         name="Solver Slippage for Period",
         filepath="period_slippage.sql",
-        q_id=2421375,
+        q_id=3093726,
     ),
     "DASHBOARD_SLIPPAGE": QueryData(
         name="Period Solver Rewards",


### PR DESCRIPTION
The change to the `period_slippage.sql` query  in #322 did not change the dune query called from the code. This resulted in wrong slippage computations from this repository. The Dune dashboards already showed the correct slippage.
In this PR, the code in `queries.py` is changed to point to a new Dune query created by cowprotocol. The code of that query is identical to `period_slippage.sql`.