### PR TITLE
Add runtime argument for minimum cow transfer threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ looking at the script help menu can help provide a list of options!
 $  python -m src.fetch.transfer_file --help 
 
 usage: Fetch Complete Reimbursement [-h] [--start START] [--post-tx POST_TX] [--consolidate-transfers CONSOLIDATE_TRANSFERS] [--dry-run DRY_RUN]
-                                    [--min-transfer-amount-wei MIN_TRANSFER_AMOUNT_WEI]
+                                    [--min-transfer-amount-wei MIN_TRANSFER_AMOUNT_WEI] [--min-transfer-amount-cow-atoms MIN_TRANSFER_AMOUNT_COW_ATOMS] 
 
 options:
   -h, --help            show this help message and exit
@@ -86,8 +86,9 @@ options:
   --dry-run DRY_RUN     Flag indicating whether script should not post alerts or transactions. Only relevant in combination with --post-tx TruePrimarily intended for
                         deployment in staging environment.
   --min-transfer-amount-wei MIN_TRANSFER_AMOUNT_WEI
-                        Ignore transfers with amount less than this
-
+                        Ignore ETH transfers with amount less than this
+  --min-transfer-amount-cow-atoms MIN_TRANSFER_AMOUNT_COW_ATOMS
+                        Ignore COW transfers with amount less than this
 ```
 
 The solver reimbursements are executed each Tuesday with the accounting period of the last 7 days.

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -264,6 +264,8 @@ def extend_payment_df(pdf: DataFrame, converter: TokenConversion) -> DataFrame:
     """
     # Note that this can be negative!
     pdf["reward_eth"] = pdf["payment_eth"] - pdf["execution_cost_eth"]
+    # num = pdf._get_numeric_data()
+    # num[num < 0] = 0
     pdf["reward_cow"] = pdf["reward_eth"].apply(converter.eth_to_token)
 
     secondary_allocation = max(PERIOD_BUDGET_COW - pdf["reward_cow"].sum(), 0)

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -264,8 +264,6 @@ def extend_payment_df(pdf: DataFrame, converter: TokenConversion) -> DataFrame:
     """
     # Note that this can be negative!
     pdf["reward_eth"] = pdf["payment_eth"] - pdf["execution_cost_eth"]
-    # num = pdf._get_numeric_data()
-    # num[num < 0] = 0
     pdf["reward_cow"] = pdf["reward_eth"].apply(converter.eth_to_token)
 
     secondary_allocation = max(PERIOD_BUDGET_COW - pdf["reward_cow"].sum(), 0)

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -108,18 +108,21 @@ if __name__ == "__main__":
         category=Category.GENERAL,
     )
 
-    payout_transfers = construct_payouts(
+    payout_transfers_temp = construct_payouts(
         args.dune,
         orderbook=MultiInstanceDBFetcher(
             [os.environ["PROD_DB_URL"], os.environ["BARN_DB_URL"]]
         ),
     )
-    payout_transfers = list(
-        filter(
-            lambda payout: payout.amount_wei > args.min_transfer_amount_wei,
-            payout_transfers,
-        )
-    )
+    payout_transfers = []
+    for tr in payout_transfers_temp:
+        if tr.token is None:
+            if tr.amount_wei > args.min_transfer_amount_wei:
+                payout_transfers.append(tr)
+        else:
+            if tr.amount_wei > args.min_transfer_amount_cow_atoms:
+                payout_transfers.append(tr)
+
     if args.consolidate_transfers:
         payout_transfers = Transfer.consolidate(payout_transfers)
 

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -117,10 +117,10 @@ if __name__ == "__main__":
     payout_transfers = []
     for tr in payout_transfers_temp:
         if tr.token is None:
-            if tr.amount_wei > args.min_transfer_amount_wei:
+            if tr.amount_wei >= args.min_transfer_amount_wei:
                 payout_transfers.append(tr)
         else:
-            if tr.amount_wei > args.min_transfer_amount_cow_atoms:
+            if tr.amount_wei >= args.min_transfer_amount_cow_atoms:
                 payout_transfers.append(tr)
 
     if args.consolidate_transfers:

--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -19,6 +19,7 @@ class ScriptArgs:
     dry_run: bool
     consolidate_transfers: bool
     min_transfer_amount_wei: int
+    min_transfer_amount_cow_atoms: int
 
 
 def generic_script_init(description: str) -> ScriptArgs:
@@ -60,8 +61,14 @@ def generic_script_init(description: str) -> ScriptArgs:
     parser.add_argument(
         "--min-transfer-amount-wei",
         type=int,
-        help="Ignore transfers with amount less than this",
+        help="Ignore ETH transfers with amount less than this",
         default=1000000000000000,
+    )
+    parser.add_argument(
+        "--min-transfer-amount-cow-atoms",
+        type=int,
+        help="Ignore COW transfers with amount less than this",
+        default=10,
     )
     args = parser.parse_args()
     return ScriptArgs(
@@ -73,4 +80,5 @@ def generic_script_init(description: str) -> ScriptArgs:
         dry_run=args.dry_run,
         consolidate_transfers=args.consolidate_transfers,
         min_transfer_amount_wei=args.min_transfer_amount_wei,
+        min_transfer_amount_cow_atoms=args.min_transfer_amount_cow_atoms,
     )

--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -57,7 +57,6 @@ def generic_script_init(description: str) -> ScriptArgs:
         "Primarily intended for deployment in staging environment.",
         default=False,
     )
-    # TODO: this should be per token (like list[tuple[Token,minAmount]])
     parser.add_argument(
         "--min-transfer-amount-wei",
         type=int,
@@ -68,7 +67,7 @@ def generic_script_init(description: str) -> ScriptArgs:
         "--min-transfer-amount-cow-atoms",
         type=int,
         help="Ignore COW transfers with amount less than this",
-        default=10,
+        default=100000000000000000000,
     )
     args = parser.parse_args()
     return ScriptArgs(


### PR DESCRIPTION
This PR adds the option to specify a minimum COW transfer amount, effectively ignoring all transfers below that amount.

After merging this PR and before tagging a new release, I will do a PR in the infrastructure repo to set up these arguments correctly.