### PR TITLE
Exclude one auction which has faulty score data

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -17,6 +17,7 @@ batch_meta as (
     where b.block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
     and (b.solver_address = from_hex('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
     and (b.tx_hash = from_hex('{{TxHash}}') or '{{TxHash}}' = '0x')
+    and (b.tx_hash !=0xd881e90f4afb020d92b8fa1b4931d2352aab4179e4f8d9a4aeafd01ebc75f808)
 )
 ,filtered_trades as (
     select t.tx_hash,


### PR DESCRIPTION
This just excludes the auction with hash `0xd881e90f4afb020d92b8fa1b4931d2352aab4179e4f8d9a4aeafd01ebc75f808` from the slippage accounting.

This was done as a quick fix to work around wrong data on fees in our database.

I am mostly posting this here so we can keep track of which versions of the slippage query have been used for payments.