### PR TITLE
Add missing transfers for sDAI deposits and withdraws

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -125,6 +125,33 @@ batch_meta as (
     -- ETH transfers to traders are already part of USER_OUT
     and not contains(traders_out, to)
 )
+-- sDAI emit only one transfer event for deposits and withdrawls.
+-- This reconstructs the missing transfer from event logs.
+,sdai_deposit_withdrawl_transfers as (
+    -- withdraw events result in additional AMM_IN transfer
+    select
+        tx_hash,
+        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as sender,
+        0x0000000000000000000000000000000000000000 as receiver,
+        contract_address as token,
+        cast(shares as int256) as amount_wei,
+        'AMM_IN' as transfer_type
+    from batch_meta bm
+    join maker_ethereum.SavingsDai_evt_Withdraw w
+    on w.evt_tx_hash= bm.tx_hash
+    union all
+    -- for deposit events result in additional AMM_OUT transfer
+    select
+        tx_hash,
+        0x0000000000000000000000000000000000000000 as sender,
+        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as receiver,
+        contract_address as token,
+        cast(shares as int256) as amount_wei,
+        'AMM_OUT' as transfer_type
+    from batch_meta bm
+    join maker_ethereum.SavingsDai_evt_Deposit w
+    on w.evt_tx_hash= bm.tx_hash
+)
 ,pre_batch_transfers as (
     select * from (
         select * from user_in
@@ -134,6 +161,8 @@ batch_meta as (
         select * from other_transfers
         union all
         select * from eth_transfers
+        union all
+        select * from sdai_deposit_withdrawl_transfers
         ) as _
     order by tx_hash
 )

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -125,9 +125,9 @@ batch_meta as (
     -- ETH transfers to traders are already part of USER_OUT
     and not contains(traders_out, to)
 )
--- sDAI emit only one transfer event for deposits and withdrawls.
+-- sDAI emits only one transfer event for deposits and withdrawals.
 -- This reconstructs the missing transfer from event logs.
-,sdai_deposit_withdrawl_transfers as (
+,sdai_deposit_withdrawal_transfers as (
     -- withdraw events result in additional AMM_IN transfer
     select
         tx_hash,
@@ -140,7 +140,7 @@ batch_meta as (
     join maker_ethereum.SavingsDai_evt_Withdraw w
     on w.evt_tx_hash= bm.tx_hash
     union all
-    -- for deposit events result in additional AMM_OUT transfer
+    -- deposit events result in additional AMM_OUT transfer
     select
         tx_hash,
         0x0000000000000000000000000000000000000000 as sender,
@@ -162,7 +162,7 @@ batch_meta as (
         union all
         select * from eth_transfers
         union all
-        select * from sdai_deposit_withdrawl_transfers
+        select * from sdai_deposit_withdrawal_transfers
         ) as _
     order by tx_hash
 )

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -139,6 +139,7 @@ batch_meta as (
     from batch_meta bm
     join maker_ethereum.SavingsDai_evt_Withdraw w
     on w.evt_tx_hash= bm.tx_hash
+    where sender = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
     union all
     -- deposit events result in additional AMM_OUT transfer
     select
@@ -151,6 +152,7 @@ batch_meta as (
     from batch_meta bm
     join maker_ethereum.SavingsDai_evt_Deposit w
     on w.evt_tx_hash= bm.tx_hash
+    where owner = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
 )
 ,pre_batch_transfers as (
     select * from (

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,4 +1,4 @@
--- https://github.com/cowprotocol/solver-rewards/pull/322
+-- https://github.com/cowprotocol/solver-rewards/pull/327
 -- Query Here: https://dune.com/queries/3093726
 with
 batch_meta as (


### PR DESCRIPTION
Conversions DAI<>sDAI  are not correctly accounted for in the current slippage query. This has led to two settlements with computes slippage even though the slippage was actually small.

- https://etherscan.io/tx/0xdae82500c69c66db4e4a8c64e1d6a95f3cdc5cb81a5a00228ce6f247b9b8cefd
- https://etherscan.io/tx/0x8dc62a04eb6b42e571c19cccf7d6503c83f8b1add671ba5b5a9c4c8404b1042a

The reason is that `Withdraw` and `Deposit` events are only accompanied by _one_ transfer. But in terms  buffer changes they correspond to _two_ transfers.

[Tenderly](https://www.tdly.co/tx/mainnet/0xdae82500c69c66db4e4a8c64e1d6a95f3cdc5cb81a5a00228ce6f247b9b8cefd) and [eigenphi](https://eigenphi.io/mev/eigentx/0xdae82500c69c66db4e4a8c64e1d6a95f3cdc5cb81a5a00228ce6f247b9b8cefd) get this wrong as well in their asset change calculations. To see what happens to buffers one can use [phalcon](https://explorer.phalcon.xyz/tx/eth/0xdae82500c69c66db4e4a8c64e1d6a95f3cdc5cb81a5a00228ce6f247b9b8cefd) or look at state changes.

With the proposed change, additional transfers are created by looking at event logs of the SavingsDAI contract.
- One AMM_IN transfer is created for each `Withdraw` event.
- One AMM_OUT transfer is created for each `Deposit` event.

This is not a general solution and only works for sDAI. Since we want to support that token now, I added this fix to the query.
Long term it would be nice to have a more general solution.