### PR TITLE
[Draft] Use consistent block ranges in queries

### DIFF
--- a/queries/dune_v2/period_block_interval.sql
+++ b/queries/dune_v2/period_block_interval.sql
@@ -1,6 +1,16 @@
 -- V3: https://dune.com/queries/1541504
-select
-    min("number") as start_block,
-    max("number") as end_block
-from ethereum.blocks
-where date_trunc('minute', time) between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
+with block_range_start as (
+    select
+        max("number") as start_block
+    from ethereum.blocks
+    where time <= cast('{{StartTime}}' as timestamp)
+)
+,block_range_stop as (
+    select
+        max("number") as end_block
+    from ethereum.blocks
+    where time <= cast('{{EndTime}}' as timestamp)
+)
+select *
+from block_range_start
+cross join block_range_stop

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -225,11 +225,22 @@ incoming_and_outgoing as (
     SELECT from_hex(address_str) as address
     FROM ( VALUES {{TokenList}} ) as _ (address_str)
 )
+,block_range_start as (
+    select
+        max("number") as start_block
+    from ethereum.blocks
+    where time <= cast('{{StartTime}}' as timestamp)
+)
+,block_range_stop as (
+    select
+        max("number") as end_block
+    from ethereum.blocks
+    where time <= cast('{{EndTime}}' as timestamp)
+)
 ,block_range as (
-  select min(number) as start_block,
-       max(number) as end_block
-  from ethereum.blocks
-  where time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
+    select *
+    from block_range_start
+    cross join block_range_stop
 )
 ,internalized_imbalances as (
   select  b.block_time,

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -14,7 +14,8 @@ batch_meta as (
            num_trades,
            b.solver_address
     from cow_protocol_ethereum.batches b
-    where b.block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
+    where b.block_time > cast('{{StartTime}}' as timestamp)
+    and b.block_time <= cast('{{EndTime}}' as timestamp)
     and (b.solver_address = from_hex('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
     and (b.tx_hash = from_hex('{{TxHash}}') or '{{TxHash}}' = '0x')
 )
@@ -38,8 +39,10 @@ batch_meta as (
     left outer join cow_protocol_ethereum.order_rewards f
         on f.tx_hash = t.tx_hash
         and f.order_uid = t.order_uid
-    where b.block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
-    and t.block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
+    where b.block_time > cast('{{StartTime}}' as timestamp)
+    and b.block_time <= cast('{{EndTime}}' as timestamp)
+    and t.block_time > cast('{{StartTime}}' as timestamp)
+    and t.block_time <= cast('{{EndTime}}' as timestamp)
     and (b.solver_address = from_hex('{{SolverAddress}}') or '{{SolverAddress}}' = '0x')
     and (t.tx_hash = from_hex('{{TxHash}}') or '{{TxHash}}' = '0x')
 )
@@ -89,7 +92,8 @@ batch_meta as (
                 and evt_tx_hash = b.tx_hash
              inner join batchwise_traders bt
                 on evt_tx_hash = bt.tx_hash
-    where b.block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
+    where b.block_time > cast('{{StartTime}}' as timestamp)
+      and b.block_time <= cast('{{EndTime}}' as timestamp)
       and 0x9008d19f58aabd9ed0d60971565aa8510560ab41 in (to, "from")
       and not contains(traders_in, "from")
       and not contains(traders_out, to)
@@ -257,7 +261,8 @@ incoming_and_outgoing as (
     join tokens.erc20 t
         on contract_address = from_hex(token)
         and blockchain = 'ethereum'
-    where i.block_number between (select start_block from block_range) and (select end_block from block_range)
+    where i.block_number > (select start_block from block_range)
+    and i.bloc_number <= (select end_block from block_range)
     and ('{{SolverAddress}}' = '0x' or b.solver_address = from_hex('{{SolverAddress}}'))
     and ('{{TxHash}}' = '0x' or b.tx_hash = from_hex('{{TxHash}}'))
 )
@@ -305,7 +310,7 @@ incoming_and_outgoing as (
     from
         prices.usd pusd
     inner join token_times tt
-        on minute between date(hour) and date(hour) + interval '1' day -- query execution speed optimization since minute is indexed
+        on minute >= date(hour) and minute <= date(hour) + interval '1' day -- query execution speed optimization since minute is indexed
         and date_trunc('hour', minute) = hour
         and contract_address = token
         and blockchain = 'ethereum'
@@ -327,7 +332,8 @@ incoming_and_outgoing as (
             date_trunc('hour', block_time) as hour,
             usd_value / units_bought as price
         FROM cow_protocol_ethereum.trades
-        WHERE block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
+        WHERE block_time > cast('{{StartTime}}' as timestamp)
+        AND block_time <= cast('{{EndTime}}' as timestamp)
         AND units_bought > 0
     UNION
         select
@@ -336,7 +342,8 @@ incoming_and_outgoing as (
             date_trunc('hour', block_time) as hour,
             usd_value / units_sold as price
         FROM cow_protocol_ethereum.trades
-        WHERE block_time between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
+        WHERE block_time > cast('{{StartTime}}' as timestamp)
+        AND block_time <= cast('{{EndTime}}' as timestamp)
         AND units_sold > 0
     ) as combined
     GROUP BY hour, contract_address, decimals
@@ -371,7 +378,8 @@ incoming_and_outgoing as (
     from prices.usd
     where blockchain = 'ethereum'
     and contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
-    and minute between cast('{{StartTime}}' as timestamp) and cast('{{EndTime}}' as timestamp)
+    and minute >= cast('{{StartTime}}' as timestamp)
+    and minute <= cast('{{EndTime}}' as timestamp)
     group by date_trunc('hour', minute)
 )
 ,results_per_tx as (

--- a/queries/orderbook/quote_rewards.sql
+++ b/queries/orderbook/quote_rewards.sql
@@ -4,7 +4,7 @@ with winning_quotes as (SELECT concat('0x', encode(oq.solver, 'hex')) as solver,
                                INNER JOIN orders o ON order_uid = uid
                                JOIN order_quotes oq ON t.order_uid = oq.order_uid
                         WHERE o.class = 'market'
-                          AND block_number BETWEEN {{start_block}} AND {{end_block}}
+                          AND block_number > {{start_block}} AND block_number <= {{end_block}}
                           AND oq.solver != '\x0000000000000000000000000000000000000000')
 
 SELECT solver, count(*) AS num_quotes

--- a/src/scripts/gap_detector.py
+++ b/src/scripts/gap_detector.py
@@ -18,11 +18,11 @@ from src.pg_client import MultiInstanceDBFetcher
 
 DB_COUNT_QUERY = (
     "select count(*) as batches from settlements "
-    "where block_number between {{start}} and {{end}};"
+    "where block_number >= {{start}} and block_number <= {{end}};"
 )
 DB_HASH_QUERY = (
     "select concat('0x', encode(tx_hash, 'hex')) as tx_hash from settlements "
-    "where block_number between {{start}} and {{end}};"
+    "where block_number >= {{start}} and block_number <= {{end}};"
 )
 
 DUNE_COUNT_QUERY_ID = 2481826


### PR DESCRIPTION
At the moment, ranges in different queries follow different conventions for including the lower and upper bound. This can be problematic since for example reward queries are called repeatedly with different time ranges and each auction has to be accounted for exactly once. The previous code contained some hacks and probably did the right thing in most cases. To make the code a bit easier to understand, we adopt a new convention in this PR.

- All occurrences of between are changed to explicit inequalities.
- When douple counting is an issue, we _exclude_ the lower bound of a range and _include_ upper bound.

With this convention one has that `end_block` in week `n` is `start_block`
in week `n+1`. That block is only counted in week `n`. Each block is counted exactly once.

In most cases we stick to the above convention. There are exceptions for computing mean prices where both bounds are included. There, double counting does not matter.

Alternatively, we could always _include_ the lower bound and _exclude_ the upper bound. This would be in line with how python handles ranges.

TODO:
- [ ] Change queries on Dune
- [ ] Test?