### PR TITLE
Add MATERIALIZED to batch reward query

### DIFF
--- a/queries/orderbook/batch_rewards.sql
+++ b/queries/orderbook/batch_rewards.sql
@@ -1,4 +1,4 @@
-WITH observed_settlements AS (SELECT
+WITH observed_settlements AS MATERIALIZED (SELECT
                                 -- settlement
                                 tx_hash,
                                 solver,
@@ -17,7 +17,7 @@ WITH observed_settlements AS (SELECT
                               WHERE ss.block_deadline >= {{start_block}}
                                 AND ss.block_deadline <= {{end_block}}),
 
-     auction_participation as (SELECT ss.auction_id, array_agg(participant) as participating_solvers
+     auction_participation as MATERIALIZED (SELECT ss.auction_id, array_agg(participant) as participating_solvers
                                FROM auction_participants
                                       JOIN settlement_scores ss
                                            ON auction_participants.auction_id = ss.auction_id
@@ -129,7 +129,7 @@ order_surplus AS (
     JOIN auction_prices ap_protocol -- contains price: protocol fee token
         ON opf.auction_id = ap_protocol.auction_id AND opf.protocol_fee_token = ap_protocol.token
 ),
-batch_protocol_fees AS (
+batch_protocol_fees AS MATERIALIZED (
     SELECT
         solver,
         tx_hash,


### PR DESCRIPTION
There has been a severe performance bug in the batch rewards query increasing the time to execute the batch rewards query from below 1 minute to over 3 hours.

This might be due to #334. The problems seems to be that the execution plan for the query became quite suboptimal even though the changes to the query were not substantial. Each of the tables `observed_settlements`, `auction_participation`, and `batch_protocol_fees` is fast to compute on its own. But (outer) joining them on `settlement_scores` to get the `reward_data` table takes extremely long now.

This PR adds `MATERIALIZED` to the tables `observed_settlements`, `auction_participation`, and `batch_protocol_fees` in the `WITH` clause. This forces those tables to not get folded into later queries. See the second to last paragraph of [this documentation](
https://www.postgresql.org/docs/16/sql-select.html#SQL-WITH) for a mention of this type of optimizaion. ~On my local machine~ This resulted in more efficient computation of `reward_data` and the final result. The execution time for the last accounting period was below 1 minute with the change and did non finish in 20 minutes without the change.

A similar change needs to be implemented in dune-sync, see https://github.com/cowprotocol/dune-sync/pull/79.