### PR TITLE
Ignore slippage for settlements with ERC404 tokens

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,5 +1,5 @@
 -- https://github.com/cowprotocol/solver-rewards/pull/340
--- Query Here: https://dune.com/queries/3333368
+-- Query Here: https://dune.com/queries/3427668
 with
 block_range as (
     select
@@ -399,7 +399,7 @@ block_range as (
         sum(usd_value) as usd_value,
         sum(eth_slippage_wei) as eth_slippage_wei,
         concat(
-            '<a href="https://dune.com/queries/2421375?SolverAddress=',
+            '<a href="https://dune.com/queries/3427668?SolverAddress=',
             cast(solver_address as varchar),
             '&CTE_NAME=results_per_tx',
             '&StartTime={{StartTime}}',

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -269,6 +269,7 @@ block_range as (
     or 0x6C061D18D2b5bbfBe8a8D1EEB9ee27eFD544cC5D in (buy_token, sell_token) -- exclude MNRCH
     or 0xbE33F57f41a20b2f00DEc91DcC1169597f36221F in (buy_token, sell_token) -- exclude Rug
     or 0x938403C5427113C67b1604d3B407D995223C2B78 in (buy_token, sell_token) -- exclude OOZ
+    or 0x54832d8724f8581e7Cc0914b3A4e70aDC0D94872 in (buy_token, sell_token) -- exclude DN404
 )
 ,final_token_balance_sheet as (
     select

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -171,7 +171,7 @@ block_range as (
         union all
         select * from eth_transfers
         union all
-        select * from sdai_deposit_with
+        select * from sdai_deposit_withdrawal_transfers
         ) as _
     order by tx_hash
 )

--- a/src/queries.py
+++ b/src/queries.py
@@ -43,7 +43,7 @@ QUERIES = {
     "PERIOD_SLIPPAGE": QueryData(
         name="Solver Slippage for Period",
         filepath="period_slippage.sql",
-        q_id=3333368,
+        q_id=3427668,
     ),
     "DASHBOARD_SLIPPAGE": QueryData(
         name="Period Solver Rewards",


### PR DESCRIPTION
This PR addresses  #340 by explicitly excluding settlements from slippage which trade the ERC404 tokens 404, Pandora, Monarch, and Rug. No other ERC404 tokens seem to have been traded on CoW Protocol until all of them were blocked in the backend.
