### PR TITLE
Adapt slippage to handle protocol fees

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,5 +1,5 @@
 -- https://github.com/cowprotocol/solver-rewards/pull/340
--- Query Here: https://dune.com/queries/3427668
+-- Query Here: https://dune.com/queries/3427730
 with
 block_range as (
     select
@@ -455,7 +455,7 @@ block_range as (
         sum(usd_value) as usd_value,
         sum(eth_slippage_wei) as eth_slippage_wei,
         concat(
-            '<a href="https://dune.com/queries/3427668?SolverAddress=',
+            '<a href="https://dune.com/queries/3427730?SolverAddress=',
             cast(solver_address as varchar),
             '&CTE_NAME=results_per_tx',
             '&StartTime={{StartTime}}',

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -468,7 +468,6 @@ block_range as (
         on address = solver_address
     group by
         solver_address,
-        concat(environment
-, '-', name)
+        concat(environment, '-', name)
 )
 select * from {{CTE_NAME}}

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -161,28 +161,6 @@ block_range as (
     on w.evt_tx_hash= bm.tx_hash
     where owner = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
 )
--- correction for PANDORA token which uses ERC20Transfer events
-,pandora_transfers as (
-    select
-        bm.tx_hash,
-        "from" as sender,
-        to as receiver,
-        contract_address as token,
-        cast(amount as int256) as amount_wei,
-        case
-          when 0x9008d19f58aabd9ed0d60971565aa8510560ab41 = to
-          then 'AMM_IN'
-          else 'AMM_OUT'
-        end as transfer_type
-    from batch_meta bm
-    join batchwise_traders bt
-    on bt.tx_hash = bm.tx_hash
-    join pandoranew_ethereum.Pandora_evt_ERC20Transfer t
-    on t.evt_tx_hash= bm.tx_hash
-    where 0x9008d19f58aabd9ed0d60971565aa8510560ab41 in (to, "from")
-    and not contains(traders_in, "from")
-    and not contains(traders_out, to)
-)
 ,pre_batch_transfers as (
     select * from (
         select * from user_in
@@ -193,9 +171,7 @@ block_range as (
         union all
         select * from eth_transfers
         union all
-        select * from sdai_deposit_withdrawal_transfers
-        union all
-        select * from pandora_transfers
+        select * from sdai_deposit_with
         ) as _
     order by tx_hash
 )

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -1,4 +1,4 @@
--- https://github.com/cowprotocol/solver-rewards/pull/340
+-- https://github.com/cowprotocol/solver-rewards/pull/342
 -- Query Here: https://dune.com/queries/3427730
 with
 block_range as (

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -171,7 +171,7 @@ block_range as (
         union all
         select * from eth_transfers
         union all
-        select * from sdai_deposit_with
+        select * from sdai_deposit_withdrawal_transfers
         ) as _
     order by tx_hash
 )

--- a/src/queries.py
+++ b/src/queries.py
@@ -43,7 +43,7 @@ QUERIES = {
     "PERIOD_SLIPPAGE": QueryData(
         name="Solver Slippage for Period",
         filepath="period_slippage.sql",
-        q_id=3427668,
+        q_id=3427730,
     ),
     "DASHBOARD_SLIPPAGE": QueryData(
         name="Period Solver Rewards",


### PR DESCRIPTION
This PR changes the handling of protocol fees in slippage. Slippage is now computed accounting for protocol fees in the correct token.