### PR TITLE
[Hotfix] Payout 2024-04-30 -- 2024-05-07

### DIFF
--- a/queries/orderbook/barn_batch_rewards.sql
+++ b/queries/orderbook/barn_batch_rewards.sql
@@ -161,7 +161,8 @@ order_protocol_fee_prices AS (
         END AS network_fee_correction,
         opf.sell_token as network_fee_token,
         ap_surplus.price / pow(10, 18) as surplus_token_native_price,
-        ap_protocol.price / pow(10, 18) as protocol_fee_token_native_price,
+        case when protocol_fee_token = '\x365accfca291e7d3914637abf1f7635db165bb09' and ap_protocol.price / pow(10, 18) > 1.0 then 0.03532282233117098
+        else ap_protocol.price / pow(10, 18) end as protocol_fee_token_native_price,
         ap_sell.price / pow(10, 18) as network_fee_token_native_price
     FROM
         order_protocol_fee opf

--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -161,7 +161,8 @@ order_protocol_fee_prices AS (
         END AS network_fee_correction,
         opf.sell_token as network_fee_token,
         ap_surplus.price / pow(10, 18) as surplus_token_native_price,
-        ap_protocol.price / pow(10, 18) as protocol_fee_token_native_price,
+        case when protocol_fee_token = '\x365accfca291e7d3914637abf1f7635db165bb09' then 0.03532282233117098
+        else ap_protocol.price / pow(10, 18) end as protocol_fee_token_native_price,
         ap_sell.price / pow(10, 18) as network_fee_token_native_price
     FROM
         order_protocol_fee opf

--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -161,7 +161,7 @@ order_protocol_fee_prices AS (
         END AS network_fee_correction,
         opf.sell_token as network_fee_token,
         ap_surplus.price / pow(10, 18) as surplus_token_native_price,
-        case when protocol_fee_token = '\x365accfca291e7d3914637abf1f7635db165bb09' then 0.03532282233117098
+        case when protocol_fee_token = '\x365accfca291e7d3914637abf1f7635db165bb09' and ap_protocol.price / pow(10, 18) > 1.0 then 0.03532282233117098
         else ap_protocol.price / pow(10, 18) end as protocol_fee_token_native_price,
         ap_sell.price / pow(10, 18) as network_fee_token_native_price
     FROM


### PR DESCRIPTION
The protocol fee transefer with the relase branche is `37055.8301 ETH`. This wrong amount comes from an off native price for the FXN token (`1271627.305335353`).

The hotfix (only to be used for this accounting period) hardcodes the price of FXN token to the last native price with reasonable value (`0.03532282233117098`). The values were obtained from the dune query
```
select * from query_3373259 where protocol_fee_token = 0x365accfca291e7d3914637abf1f7635db165bb09 order by block_number desc
```