### PR TITLE
[Hotfix] Payout 2024-05-28 -- 2024-06-04

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -30,7 +30,7 @@ block_range as (
            b.block_number,
            case
                 when trader = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-                then 0x0000000000000000000000000000000000000000
+                then 0x0000000000000000000000000000000000000001
                 else trader
            end as trader_in,
            receiver                                     as trader_out,

--- a/queries/orderbook/barn_batch_rewards.sql
+++ b/queries/orderbook/barn_batch_rewards.sql
@@ -161,7 +161,11 @@ order_protocol_fee_prices AS (
         END AS network_fee_correction,
         opf.sell_token as network_fee_token,
         ap_surplus.price / pow(10, 18) as surplus_token_native_price,
-        ap_protocol.price / pow(10, 18) as protocol_fee_token_native_price,
+        case
+            when protocol_fee_token = '\x440e6ca1779977b4D225b266262A9E75Ce31a0b4' then 0
+        else
+            ap_protocol.price / pow(10, 18)
+        end as protocol_fee_token_native_price,
         ap_sell.price / pow(10, 18) as network_fee_token_native_price
     FROM
         order_protocol_fee opf

--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -161,7 +161,11 @@ order_protocol_fee_prices AS (
         END AS network_fee_correction,
         opf.sell_token as network_fee_token,
         ap_surplus.price / pow(10, 18) as surplus_token_native_price,
-        ap_protocol.price / pow(10, 18) as protocol_fee_token_native_price,
+        case
+            when protocol_fee_token = '\x440e6ca1779977b4D225b266262A9E75Ce31a0b4' then 0
+        else
+            ap_protocol.price / pow(10, 18)
+        end as protocol_fee_token_native_price,
         ap_sell.price / pow(10, 18) as network_fee_token_native_price
     FROM
         order_protocol_fee opf


### PR DESCRIPTION
This PR ignores this token `0x440e6ca1779977b4d225b266262a9e75ce31a0b4`
when it comes to collecting protocol fees due to erroneous native price.

I believe the only tx effectively excluded is this:
https://etherscan.io/tx/0xaf0da6fcf437fe17fa9703cd78a830ca610c0f8660f908e1406df9e22c232ff1

