### PR TITLE
Freeze numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ SQLAlchemy<2.0.0
 sqlalchemy-stubs==0.4
 pandas==2.0.3
 pandas-stubs==2.0.2.230605
+numpy==1.26.4


### PR DESCRIPTION
Numpy released a new major version 2.0.0. For some reason this makes our code crash. This was noticed in #364 where unrelated tests started failing.

I guess the problem is due to us using an outdated pandas version.

A quick fix is implemented in this PR. The version of numpy is fixed to the latest release before 2.0.0.

This is not the first time we freeze a dependency to an old version.  Midterm we should update our dependencies instead.