### PR TITLE
Merge weth and native eth imbalances

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -320,6 +320,7 @@ block_range as (
         block_time,
         tx_hash,
         solver_address,
+        symbol,
         CASE
             WHEN token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee then 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
             ELSE token

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -326,6 +326,7 @@ block_range as (
         END as token,
         amount,
         transfer_type
+    from incoming_and_outgoing_with_internalized_imbalances_unmerged
 )
 
 -- These batches involve a token who do not emit standard transfer events.

--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -338,6 +338,7 @@ block_range as (
     select
         solver_address,
         sum(amount) token_imbalance_wei,
+        symbol,
         token,
         tx_hash,
         date_trunc('hour', block_time) as hour
@@ -345,7 +346,7 @@ block_range as (
         incoming_and_outgoing_with_internalized_imbalances
     where tx_hash not in (select tx_hash from excluded_batches)
     group by
-        token, solver_address, tx_hash, block_time
+        symbol, token, solver_address, tx_hash, block_time
     having
         sum(amount) != cast(0 as int256)
 )


### PR DESCRIPTION
Some unexpected results showed up from time to time in txs where native ETH was traded. This PR modifies the slippage Dune query and proposes that we convert every perceived ETH imbalance to a WETH imbalance (so that only the price feed of WETH is used in a consistent way).

The proposed change has been applied to the following queries (sharing ids here):

- 3427730
- 2332678
- 2510345/4131517