### PR TITLE
Sync dune query to repo: fix for protocol trades

### DIFF
--- a/queries/dune_v2/period_slippage.sql
+++ b/queries/dune_v2/period_slippage.sql
@@ -30,7 +30,7 @@ block_range as (
            b.block_number,
            case
                 when trader = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-                then 0x0000000000000000000000000000000000000000
+                then 0x0000000000000000000000000000000000000001
                 else trader
            end as trader_in,
            receiver                                     as trader_out,


### PR DESCRIPTION
This PR makes the query in the repo (functionally) identical to the query on Dune.

On Dune we had deployed a fix to a bug which cause transfers to be excluded in the accounting.
Without that fix, trades from the zero address to the protocol are excluded even though they correspond to valid trades and are not accounted for by user trades.

With the fix, all transfers should be accounted for since there will never be transfers from the address `0x00..001` to the protocol or vice versa.