### PR TITLE
Send eth refunds to rewards address for cow bonding pool solvers

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -9,6 +9,7 @@ from web3 import Web3
 
 
 COW_TOKEN_ADDRESS = Address("0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB")
+COW_BONDING_POOL = Address("0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6")
 
 PROJECT_ROOT = Path(__file__).parent.parent
 FILE_OUT_DIR = PROJECT_ROOT / Path("out")

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -186,22 +186,13 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             # = self.total_outgoing_eth()
             # >= 0 (because not self.is_overdraft())
             try:
-                if self.bonding_pool == COW_BONDING_POOL:
-                    result.append(
-                        Transfer(
-                            token=None,
-                            recipient=self.reward_target,
-                            amount_wei=reimbursement_eth + total_eth_reward,
-                        )
+                result.append(
+                    Transfer(
+                        token=None,
+                        recipient=self.reward_target if self.bonding_pool == COW_BONDING_POOL else self.solver,
+                        amount_wei=reimbursement_eth + total_eth_reward,
                     )
-                else:
-                    result.append(
-                        Transfer(
-                            token=None,
-                            recipient=self.solver,
-                            amount_wei=reimbursement_eth + total_eth_reward,
-                        )
-                    )
+                )
             except AssertionError:
                 logging.warning(
                     f"Invalid ETH Transfer {self.solver} "
@@ -231,22 +222,13 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             return result
 
         try:
-            if self.bonding_pool == COW_BONDING_POOL:
-                result.append(
-                    Transfer(
-                        token=None,
-                        recipient=self.reward_target,
-                        amount_wei=reimbursement_eth,
-                    )
+            result.append(
+                Transfer(
+                    token=None,
+                    recipient=self.reward_target if self.bonding_pool == COW_BONDING_POOL else self.solver,
+                    amount_wei=reimbursement_eth,
                 )
-            else:
-                result.append(
-                    Transfer(
-                        token=None,
-                        recipient=self.solver,
-                        amount_wei=reimbursement_eth,
-                    )
-                )
+            )
         except AssertionError:
             logging.warning(
                 f"Invalid ETH Transfer {self.solver} with amount={reimbursement_eth}"

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -186,7 +186,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             # = self.total_outgoing_eth()
             # >= 0 (because not self.is_overdraft())
             try:
-                if (self.bonding_pool == COW_BONDING_POOL):
+                if self.bonding_pool == COW_BONDING_POOL:
                     result.append(
                         Transfer(
                             token=None,
@@ -231,7 +231,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             return result
 
         try:
-            if (self.bonding_pool == COW_BONDING_POOL):
+            if self.bonding_pool == COW_BONDING_POOL:
                 result.append(
                     Transfer(
                         token=None,

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -189,7 +189,9 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
                 result.append(
                     Transfer(
                         token=None,
-                        recipient=self.reward_target if self.bonding_pool == COW_BONDING_POOL else self.solver,
+                        recipient=self.reward_target
+                        if self.bonding_pool == COW_BONDING_POOL
+                        else self.solver,
                         amount_wei=reimbursement_eth + total_eth_reward,
                     )
                 )
@@ -225,7 +227,9 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             result.append(
                 Transfer(
                     token=None,
-                    recipient=self.reward_target if self.bonding_pool == COW_BONDING_POOL else self.solver,
+                    recipient=self.reward_target
+                    if self.bonding_pool == COW_BONDING_POOL
+                    else self.solver,
                     amount_wei=reimbursement_eth,
                 )
             )

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -13,7 +13,7 @@ import pandas
 from dune_client.types import Address
 from pandas import DataFrame, Series
 
-from src.constants import COW_TOKEN_ADDRESS
+from src.constants import COW_TOKEN_ADDRESS, COW_BONDING_POOL
 from src.fetch.dune import DuneFetcher
 from src.fetch.prices import eth_in_token, TokenId, token_in_eth
 from src.models.accounting_period import AccountingPeriod
@@ -77,6 +77,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         solver: Address,
         solver_name: str,
         reward_target: Address,
+        bonding_pool: Address,
         primary_reward_eth: int,
         secondary_reward_eth: int,
         slippage_eth: int,
@@ -91,6 +92,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         self.solver = solver
         self.solver_name = solver_name
         self.reward_target = reward_target
+        self.bonding_pool = bonding_pool
         self.slippage_eth = slippage_eth
         self.primary_reward_eth = primary_reward_eth
         self.primary_reward_cow = primary_reward_cow
@@ -108,6 +110,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         )
         solver = frame["solver"]
         reward_target = frame["reward_target"]
+        bonding_pool = frame["pool"]
         if reward_target is None:
             logging.warning(f"solver {solver} without reward_target. Using solver")
             reward_target = solver
@@ -116,6 +119,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             solver=Address(solver),
             solver_name=frame["solver_name"],
             reward_target=Address(reward_target),
+            bonding_pool=Address(bonding_pool),
             slippage_eth=slippage,
             primary_reward_eth=int(frame["primary_reward_eth"]),
             primary_reward_cow=int(frame["primary_reward_cow"]),
@@ -171,7 +175,6 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             if total_eth_reward != 0
             else 0
         )
-
         if reimbursement_eth > 0 > total_cow_reward:
             # If the total payment is positive but the total rewards are negative,
             # pay the total payment in ETH. The total payment corresponds to reimbursement,
@@ -183,13 +186,22 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             # = self.total_outgoing_eth()
             # >= 0 (because not self.is_overdraft())
             try:
-                result.append(
-                    Transfer(
-                        token=None,
-                        recipient=self.solver,
-                        amount_wei=reimbursement_eth + total_eth_reward,
+                if (self.bonding_pool == COW_BONDING_POOL):
+                    result.append(
+                        Transfer(
+                            token=None,
+                            recipient=self.reward_target,
+                            amount_wei=reimbursement_eth + total_eth_reward,
+                        )
                     )
-                )
+                else:
+                    result.append(
+                        Transfer(
+                            token=None,
+                            recipient=self.solver,
+                            amount_wei=reimbursement_eth + total_eth_reward,
+                        )
+                    )
             except AssertionError:
                 logging.warning(
                     f"Invalid ETH Transfer {self.solver} "
@@ -219,13 +231,22 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             return result
 
         try:
-            result.append(
-                Transfer(
-                    token=None,
-                    recipient=self.solver,
-                    amount_wei=reimbursement_eth,
+            if (self.bonding_pool == COW_BONDING_POOL):
+                result.append(
+                    Transfer(
+                        token=None,
+                        recipient=self.reward_target,
+                        amount_wei=reimbursement_eth,
+                    )
                 )
-            )
+            else:
+                result.append(
+                    Transfer(
+                        token=None,
+                        recipient=self.solver,
+                        amount_wei=reimbursement_eth,
+                    )
+                )
         except AssertionError:
             logging.warning(
                 f"Invalid ETH Transfer {self.solver} with amount={reimbursement_eth}"
@@ -442,6 +463,7 @@ def construct_payouts(
         slippage_df=pandas.DataFrame(dune.get_period_slippage()),
         reward_target_df=pandas.DataFrame(dune.get_vouches()),
     )
+
     # Sort by solver before breaking this data frame into Transfer objects.
     complete_payout_df = complete_payout_df.sort_values("solver")
 

--- a/tests/unit/test_payouts.py
+++ b/tests/unit/test_payouts.py
@@ -323,7 +323,7 @@ class TestPayoutTransformations(unittest.TestCase):
                     "0x0000000000000000000000000000000000000026",
                     "0x0000000000000000000000000000000000000026",
                     "0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6",
-                ]
+                ],
             }
         )
         period = AccountingPeriod("1985-03-10", 1)

--- a/tests/unit/test_payouts.py
+++ b/tests/unit/test_payouts.py
@@ -318,6 +318,12 @@ class TestPayoutTransformations(unittest.TestCase):
                     "0x0000000000000000000000000000000000000007",
                     "0x0000000000000000000000000000000000000008",
                 ],
+                "pool": [
+                    "0x0000000000000000000000000000000000000025",
+                    "0x0000000000000000000000000000000000000026",
+                    "0x0000000000000000000000000000000000000026",
+                    "0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6",
+                ]
             }
         )
         period = AccountingPeriod("1985-03-10", 1)
@@ -384,6 +390,7 @@ class TestRewardAndPenaltyDatum(unittest.TestCase):
         self.solver = Address.from_int(1)
         self.solver_name = "Solver1"
         self.reward_target = Address.from_int(2)
+        self.bonding_pool = Address.from_int(3)
         self.cow_token = Token(COW_TOKEN_ADDRESS)
         self.conversion_rate = 1000
 
@@ -399,6 +406,7 @@ class TestRewardAndPenaltyDatum(unittest.TestCase):
             solver=self.solver,
             solver_name=self.solver_name,
             reward_target=self.reward_target,
+            bonding_pool=self.bonding_pool,
             primary_reward_eth=primary_reward,
             primary_reward_cow=primary_reward * self.conversion_rate,
             secondary_reward_eth=secondary_reward,


### PR DESCRIPTION
This PR proposes that the ETH refunds that up till now were sent directly to the solver submission address are to be sent to the rewards address of each solver from now on; this will only be applied to CoW DAO bonding pool solvers.

The rationale behind this is that this would allow for more active management of these funds from the solver teams, and would likely reduce the number of requests for withdrawals from these accounts, as well as  it would reduce the total amount of ETH that is currently locked in these accounts and poses a risk for the core team.