### PR TITLE
Change use of block deadlines

### DIFF
--- a/queries/orderbook/barn_batch_rewards.sql
+++ b/queries/orderbook/barn_batch_rewards.sql
@@ -347,7 +347,7 @@ reward_data AS (
         winning_score,
         case
             when block_number is not null
-            and block_number <= block_deadline + 1 then winning_score -- this includes a grace period of one block for settling the order
+            and block_number <= block_deadline + 1 then winning_score -- this includes a grace period of one block for settling a batch
             else 0
         end as observed_score,
         reference_score,

--- a/queries/orderbook/barn_batch_rewards.sql
+++ b/queries/orderbook/barn_batch_rewards.sql
@@ -340,26 +340,14 @@ reward_data AS (
         coalesce(os.solver, winner) as solver,
         block_number as settlement_block,
         block_deadline,
-        case
-            when block_number is not null
-            and block_number > block_deadline then 0
-            else coalesce(execution_cost, 0) -- if block_number is null, execution cost is 0
-        end as execution_cost,
-        case
-            when block_number is not null
-            and block_number > block_deadline then 0
-            else coalesce(surplus, 0) -- if block_number is null, surplus is 0
-        end as surplus,
-        case
-            when block_number is not null
-            and block_number > block_deadline then 0
-            else coalesce(fee, 0) -- if block_number is null, fee is 0
-        end as fee,
+        coalesce(execution_cost, 0) as execution_cost,
+        coalesce(surplus, 0) as surplus,
+        coalesce(fee, 0) as fee,
         -- scores
         winning_score,
         case
             when block_number is not null
-            and block_number <= block_deadline then winning_score
+            and block_number <= block_deadline + 1 then winning_score -- this includes a grace period of one block for settling the order
             else 0
         end as observed_score,
         reference_score,

--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -347,7 +347,7 @@ reward_data AS (
         winning_score,
         case
             when block_number is not null
-            and block_number <= block_deadline + 1 then winning_score -- this includes a grace period of one block for settling the order
+            and block_number <= block_deadline + 1 then winning_score -- this includes a grace period of one block for settling a batch
             else 0
         end as observed_score,
         reference_score,

--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -340,26 +340,14 @@ reward_data AS (
         coalesce(os.solver, winner) as solver,
         block_number as settlement_block,
         block_deadline,
-        case
-            when block_number is not null
-            and block_number > block_deadline then 0
-            else coalesce(execution_cost, 0) -- if block_number is null, execution cost is 0
-        end as execution_cost,
-        case
-            when block_number is not null
-            and block_number > block_deadline then 0
-            else coalesce(surplus, 0) -- if block_number is null, surplus is 0
-        end as surplus,
-        case
-            when block_number is not null
-            and block_number > block_deadline then 0
-            else coalesce(fee, 0) -- if block_number is null, fee is 0
-        end as fee,
+        coalesce(execution_cost, 0) as execution_cost,
+        coalesce(surplus, 0) as surplus,
+        coalesce(fee, 0) as fee,
         -- scores
         winning_score,
         case
             when block_number is not null
-            and block_number <= block_deadline then winning_score
+            and block_number <= block_deadline + 1 then winning_score -- this includes a grace period of one block for settling the order
             else 0
         end as observed_score,
         reference_score,


### PR DESCRIPTION
This PR adds a grace period of one block to the deadline for settling on chain. It also removes the use of block deadlines in computing fees and other quantities.

The PR changes two things:
- Settlements are still rewarded if solvers settle one block after the deadline. This change is implemented to not punish solvers for slightly suboptimal transaction canceling in the driver. The alternative would be to implement very cautios canceling which might negatively impact revert rates.
- The use of block deadlines for setting `surplus`, `fee`, and `execution_cost` to zero was removed. For every successful settlemen, even if after the deadline by many blocks, those values will just be copies of the respective values in the `settlement_observations` table. The change to `surplus`and `execution_cost`does not have any effect on solver payments. Those values are only used for analytics. The change to `fee` has an effect since it enters the computation of `network_fee_eth`. Before the change, the network fee was computed to be negative and essentially equal to `-protocol_fee_eth`. On the one hand, network fees were already removed from slippage using per order data. On the other hand, slippage is also modified by adding the value of network fees to reimburse solvers the cost of execution. Since network fees were computed to be negative protocol fees, instead of paying solvers those network fees they paid us protocol fees. See #380. With the proposed change, network fees are always paid as part of slippage to the solver. This is consistent with how slippage is handled in general.

The estimated impact on solver from adding a grace period is an increase in overall rewards by about 1.48 ETH in the accounting period 2024-08-06--2024-08-13.
The impact of the second change on slippage is not estimated precisely. The overcharging of protocol fees amounts to 0.6 ETH. The missing reimbursement of network fees is not estimated.
See [this Dune query](https://dune.com/queries/3987946).

The changes should be mirrored to dune-sync and data for the accounting period starting on 2024-08-13 should be re-synced.
