### PR TITLE
Manual fix for wrong protocol fee token price for August 13-20, 2024 payouts

### DIFF
--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -304,7 +304,10 @@ order_protocol_fee_prices AS (
         END AS network_fee_correction,
         opf.sell_token as network_fee_token,
         ap_surplus.price / pow(10, 18) as surplus_token_native_price,
-        ap_protocol.price / pow(10, 18) as protocol_fee_token_native_price,
+        CASE
+            WHEN opf.order_uid = '\x942e55be89314c5e799a12b487387a1221e5671bd17222a1bc69cb2b7728a4eea53a13a80d72a855481de5211e7654fabdfe352666e32aec' then 1.9088477506249592e-5
+            ELSE ap_protocol.price / pow(10, 18)
+        END AS protocol_fee_token_native_price,
         ap_sell.price / pow(10, 18) as network_fee_token_native_price
     FROM
         order_protocol_fee as opf

--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -305,7 +305,7 @@ order_protocol_fee_prices AS (
         opf.sell_token as network_fee_token,
         ap_surplus.price / pow(10, 18) as surplus_token_native_price,
         CASE
-            WHEN opf.order_uid = '\x942e55be89314c5e799a12b487387a1221e5671bd17222a1bc69cb2b7728a4eea53a13a80d72a855481de5211e7654fabdfe352666e32aec' then 1.9088477506249592e-5
+            WHEN opf.order_uid = '\x942e55be89314c5e799a12b487387a1221e5671bd17222a1bc69cb2b7728a4eea53a13a80d72a855481de5211e7654fabdfe352666e32aec' and opf.auction_id = 9269949 then 1.9088477506249592e-5
             ELSE ap_protocol.price / pow(10, 18)
         END AS protocol_fee_token_native_price,
         ap_sell.price / pow(10, 18) as network_fee_token_native_price


### PR DESCRIPTION
This order
https://explorer.cow.fi/orders/0x942e55be89314c5e799a12b487387a1221e5671bd17222a1bc69cb2b7728a4eea53a13a80d72a855481de5211e7654fabdfe352666e32aec?tab=overview

causes the protocol fees to be wrongly calculated as the auction it got executed in had a very wrong DBR  (surplus token of order) price
https://api.cow.fi/mainnet/api/v1/solver_competition/by_tx_hash/0x75e9283a7083e159aab70ca4462d16bb66d7309f504106924bd5fe1ff885fe2f

`      "0xad038eb671c44b853887a7e32528fab35dc5d710": "4712869163461536907264",`

I checked the logs and i saw this

![image](https://github.com/user-attachments/assets/3fcd6d7f-70cf-437a-a4ce-78d51d97a93d)

so i decided to use the previous native price we had computed for DBR

**NOTE:** This is not meant to be merged but the payouts today will be executed using this branch.