### PR TITLE
Remove consistency rewards and dune parameters cleanup and fixing

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -54,12 +54,3 @@ SAFE_URL = f"{SAFE_URL}/{SHORT_NAME}:{SAFE_ADDRESS}/transactions/queue"
 
 # Real Web3 Instance
 web3 = Web3(Web3.HTTPProvider(NODE_URL))
-
-RECOGNIZED_BONDING_POOLS = [
-    "('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD', 'Gnosis', "
-    "'0x6c642cafcbd9d8383250bb25f67ae409147f78b2')",
-    "('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6', 'CoW Services', "
-    "'0x423cec87f19f0778f549846e0801ee267a917935')",
-    "('0xC96569Dc132ebB6694A5f0b781B33f202Da8AcE8', 'Project Blanc', "
-    "'0xCa99e3Fc7B51167eaC363a3Af8C9A185852D1622')",
-]

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -113,9 +113,7 @@ class DuneFetcher:
             self._parameterized_query(
                 QUERIES["PERIOD_SLIPPAGE"],
                 params=self._period_params()
-                + [
-                    QueryParameter.text_type("tx_hash", "0x")
-                ],
+                + [QueryParameter.text_type("tx_hash", "0x")],
             ),
             job_id,
         )

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -106,8 +106,7 @@ class DuneFetcher:
 
         return self._get_query_results(
             self._parameterized_query(
-                QUERIES["PERIOD_SLIPPAGE"],
-                params=self._period_params()
+                QUERIES["PERIOD_SLIPPAGE"], params=self._period_params()
             ),
             job_id,
         )

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -118,6 +118,6 @@ class DuneFetcher:
         return self._get_query_results(
             query=self._parameterized_query(
                 query_data=QUERIES["SERVICE_FEE_STATUS"],
-                params=None,
+                params=[],
             )
         )

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -7,7 +7,6 @@ from dune_client.query import QueryBase
 from dune_client.types import QueryParameter, DuneRecord
 
 from src.constants import RECOGNIZED_BONDING_POOLS
-from src.fetch.token_list import get_trusted_tokens
 from src.logger import set_log
 from src.models.accounting_period import AccountingPeriod
 from src.queries import QUERIES, QueryData

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -6,7 +6,6 @@ from dune_client.client import DuneClient
 from dune_client.query import QueryBase
 from dune_client.types import QueryParameter, DuneRecord
 
-from src.constants import RECOGNIZED_BONDING_POOLS
 from src.logger import set_log
 from src.models.accounting_period import AccountingPeriod
 from src.queries import QUERIES, QueryData

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -84,14 +84,12 @@ class DuneFetcher:
         """
         Fetches & Returns Parsed Results for VouchRegistry query.
         """
-        pool_values = ",\n".join(RECOGNIZED_BONDING_POOLS)
         return self._get_query_results(
             query=self._parameterized_query(
                 query_data=QUERIES["VOUCH_REGISTRY"],
                 params=[
-                    QueryParameter.date_type("EndTime", self.period.end),
-                    QueryParameter.text_type("BondingPoolData", pool_values),
-                    QueryParameter.enum_type("VOUCH_CTE_NAME", "valid_vouches"),
+                    QueryParameter.date_type("end_time", self.period.end),
+                    QueryParameter.enum_type("vouch_cte_name", "valid_vouches"),
                 ],
             )
         )
@@ -101,9 +99,7 @@ class DuneFetcher:
         Executes & Fetches results of slippage query per solver for specified accounting period.
         Returns a class representation of the results as two lists (positive & negative).
         """
-        params = self._period_params() + [
-            QueryParameter.text_type("tx_hash", "0x"),
-        ]
+        params = self._period_params()
         # trigger dashboard update
         self.dune.execute(
             self._parameterized_query(QUERIES["DASHBOARD_SLIPPAGE"], params=params)
@@ -113,7 +109,6 @@ class DuneFetcher:
             self._parameterized_query(
                 QUERIES["PERIOD_SLIPPAGE"],
                 params=self._period_params()
-                + [QueryParameter.text_type("tx_hash", "0x")],
             ),
             job_id,
         )

--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -102,10 +102,8 @@ class DuneFetcher:
         Executes & Fetches results of slippage query per solver for specified accounting period.
         Returns a class representation of the results as two lists (positive & negative).
         """
-        token_list = get_trusted_tokens()
         params = self._period_params() + [
-            QueryParameter.text_type("TxHash", "0x"),
-            QueryParameter.text_type("TokenList", ",".join(token_list)),
+            QueryParameter.text_type("tx_hash", "0x"),
         ]
         # trigger dashboard update
         self.dune.execute(
@@ -117,8 +115,7 @@ class DuneFetcher:
                 QUERIES["PERIOD_SLIPPAGE"],
                 params=self._period_params()
                 + [
-                    QueryParameter.text_type("TxHash", "0x"),
-                    QueryParameter.text_type("TokenList", ",".join(token_list)),
+                    QueryParameter.text_type("tx_hash", "0x")
                 ],
             ),
             job_id,
@@ -128,12 +125,9 @@ class DuneFetcher:
         """
         Fetches & Returns Parsed Results for VouchRegistry query.
         """
-        pool_values = ",\n".join(RECOGNIZED_BONDING_POOLS)
         return self._get_query_results(
             query=self._parameterized_query(
                 query_data=QUERIES["SERVICE_FEE_STATUS"],
-                params=[
-                    QueryParameter.text_type("BondingPoolData", pool_values),
-                ],
+                params=None,
             )
         )

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -114,7 +114,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         )
         solver = frame["solver"]
         reward_target = frame["reward_target"]
-        bonding_pool = frame["pool"]
+        bonding_pool = frame["pool_address"]
         if reward_target is None:
             logging.warning(f"solver {solver} without reward_target. Using solver")
             reward_target = solver
@@ -547,6 +547,8 @@ def construct_payouts(
     performance_reward = complete_payout_df["primary_reward_cow"].sum()
     participation_reward = complete_payout_df["secondary_reward_cow"].sum()
     quote_reward = complete_payout_df["quote_reward_cow"].sum()
+
+
 
     dune.log_saver.print(
         "Payment breakdown (ignoring service fees):\n"

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -23,8 +23,6 @@ from src.models.transfer import Transfer
 from src.pg_client import MultiInstanceDBFetcher
 from src.utils.print_store import Category
 
-PERIOD_BUDGET_COW = 250000 * 10**18
-CONSISTENCY_REWARD_CAP_ETH = 6 * 10**18
 QUOTE_REWARD_COW = 6 * 10**18
 QUOTE_REWARD_CAP_ETH = 6 * 10**14
 SERVICE_FEE_FACTOR = Fraction(15, 100)
@@ -35,8 +33,6 @@ PAYMENT_COLUMNS = {
     "solver",
     "primary_reward_eth",
     "primary_reward_cow",
-    "secondary_reward_eth",
-    "secondary_reward_cow",
     "quote_reward_cow",
     "protocol_fee_eth",
     "network_fee_eth",
@@ -53,8 +49,6 @@ COMPLETE_COLUMNS = PAYMENT_COLUMNS.union(SLIPPAGE_COLUMNS).union(REWARD_TARGET_C
 NUMERICAL_COLUMNS = [
     "primary_reward_eth",
     "primary_reward_cow",
-    "secondary_reward_cow",
-    "secondary_reward_eth",
     "quote_reward_cow",
     "protocol_fee_eth",
 ]
@@ -81,15 +75,12 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         reward_target: Address,
         bonding_pool: Address,
         primary_reward_eth: int,
-        secondary_reward_eth: int,
         slippage_eth: int,
         primary_reward_cow: int,
-        secondary_reward_cow: int,
         quote_reward_cow: int,
         service_fee: bool,
     ):
-        assert secondary_reward_eth >= 0, "invalid secondary_reward_eth"
-        assert secondary_reward_cow >= 0, "invalid secondary_reward_cow"
+
         assert quote_reward_cow >= 0, "invalid quote_reward_cow"
 
         self.solver = solver
@@ -99,8 +90,6 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         self.slippage_eth = slippage_eth
         self.primary_reward_eth = primary_reward_eth
         self.primary_reward_cow = primary_reward_cow
-        self.secondary_reward_eth = secondary_reward_eth
-        self.secondary_reward_cow = secondary_reward_cow
         self.quote_reward_cow = quote_reward_cow
         self.service_fee = service_fee
 
@@ -127,8 +116,6 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             slippage_eth=slippage,
             primary_reward_eth=int(frame["primary_reward_eth"]),
             primary_reward_cow=int(frame["primary_reward_cow"]),
-            secondary_reward_eth=int(frame["secondary_reward_eth"]),
-            secondary_reward_cow=int(frame["secondary_reward_cow"]),
             quote_reward_cow=int(frame["quote_reward_cow"]),
             service_fee=bool(frame["service_fee"]),
         )
@@ -139,17 +126,11 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
 
     def total_cow_reward(self) -> int:
         """Total outgoing COW token reward"""
-        return int(
-            self.reward_scaling()
-            * (self.primary_reward_cow + self.secondary_reward_cow)
-        )
+        return int(self.reward_scaling() * self.primary_reward_cow)
 
     def total_eth_reward(self) -> int:
         """Total outgoing ETH reward"""
-        return int(
-            self.reward_scaling()
-            * (self.primary_reward_eth + self.secondary_reward_eth)
-        )
+        return int(self.reward_scaling() * self.primary_reward_eth)
 
     def reward_scaling(self) -> Fraction:
         """Scaling factor for service fee
@@ -198,7 +179,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             # Note that;
             # reimbursement_eth + reward_eth
             # = self.total_eth_reward() + self.exec_cost + self.slippage_eth
-            # = self.payment_eth + self.secondary_reward_eth + self.slippage_eth
+            # = self.payment_eth + self.slippage_eth
             # = self.total_outgoing_eth()
             # >= 0 (because not self.is_overdraft())
             try:
@@ -288,31 +269,9 @@ def extend_payment_df(pdf: DataFrame, converter: TokenConversion) -> DataFrame:
     Extending the basic columns returned by SQL Query with some after-math:
     - reward_eth as difference of payment and execution_cost
     - reward_cow as conversion from ETH to cow.
-    - secondary_reward (as the remaining reward after all has been distributed)
-        This is evaluated in both ETH and COW (for different use cases).
     """
     # Note that this can be negative!
     pdf["primary_reward_cow"] = pdf["primary_reward_eth"].apply(converter.eth_to_token)
-
-    secondary_allocation = max(
-        min(
-            PERIOD_BUDGET_COW - pdf["primary_reward_cow"].sum(),
-            converter.eth_to_token(CONSISTENCY_REWARD_CAP_ETH),
-        ),
-        0,
-    )
-    participation_total = pdf["num_participating_batches"].sum()
-    if participation_total == 0:
-        # Due to CIP-48 we will stop counting participation. This workaround avoids
-        # division by zero as the num_participation_batches is set to zero for all
-        # solvers after CIP-48.
-        participation_total = 1
-    pdf["secondary_reward_cow"] = (
-        secondary_allocation * pdf["num_participating_batches"] / participation_total
-    )
-    pdf["secondary_reward_eth"] = pdf["secondary_reward_cow"].apply(
-        converter.token_to_eth
-    )
 
     # Pandas has poor support for large integers, must cast the constant to float here,
     # otherwise the dtype would be inferred as int64 (which overflows).
@@ -545,13 +504,11 @@ def construct_payouts(
     partner_fee_tax_wei = total_partner_fee_wei_untaxed - total_partner_fee_wei_taxed
 
     performance_reward = complete_payout_df["primary_reward_cow"].sum()
-    participation_reward = complete_payout_df["secondary_reward_cow"].sum()
     quote_reward = complete_payout_df["quote_reward_cow"].sum()
 
     dune.log_saver.print(
         "Payment breakdown (ignoring service fees):\n"
         f"Performance Reward: {performance_reward / 10 ** 18:.4f}\n"
-        f"Participation Reward: {participation_reward / 10 ** 18:.4f}\n"
         f"Quote Reward: {quote_reward / 10 ** 18:.4f}\n"
         f"Protocol Fees: {final_protocol_fee_wei / 10 ** 18:.4f}\n"
         f"Partner Fees Tax: {partner_fee_tax_wei / 10 ** 18:.4f}\n"

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -548,8 +548,6 @@ def construct_payouts(
     participation_reward = complete_payout_df["secondary_reward_cow"].sum()
     quote_reward = complete_payout_df["quote_reward_cow"].sum()
 
-
-
     dune.log_saver.print(
         "Payment breakdown (ignoring service fees):\n"
         f"Performance Reward: {performance_reward / 10 ** 18:.4f}\n"

--- a/src/models/accounting_period.py
+++ b/src/models/accounting_period.py
@@ -33,8 +33,8 @@ class AccountingPeriod:
     def as_query_params(self) -> list[QueryParameter]:
         """Returns commonly used (StartTime, EndTime) query parameters"""
         return [
-            QueryParameter.date_type("StartTime", self.start),
-            QueryParameter.date_type("EndTime", self.end),
+            QueryParameter.date_type("start_time", self.start),
+            QueryParameter.date_type("end_time", self.end),
         ]
 
     def dashboard_url(self) -> str:

--- a/tests/unit/test_payouts.py
+++ b/tests/unit/test_payouts.py
@@ -58,12 +58,7 @@ class TestPayoutTransformations(unittest.TestCase):
             -10000000000000000.00000,
             0.00000,
         ]
-        self.batch_participation = [
-            7,
-            2,
-            7,
-            6,
-        ]
+
         self.protocol_fee_eth = [
             1000000000000000.0,
             2000000000000000.0,
@@ -86,7 +81,6 @@ class TestPayoutTransformations(unittest.TestCase):
             "solver": self.solvers,
             "num_quotes": self.num_quotes,
             "primary_reward_eth": self.primary_reward_eth,
-            "num_participating_batches": self.batch_participation,
             "protocol_fee_eth": self.protocol_fee_eth,
             "network_fee_eth": self.network_fee_eth,
         }
@@ -101,7 +95,6 @@ class TestPayoutTransformations(unittest.TestCase):
                 -10000000000000000.00000,
                 0.00000,
             ],
-            "num_participating_batches": self.batch_participation,
             "protocol_fee_eth": self.protocol_fee_eth,
             "network_fee_eth": self.network_fee_eth,
             "primary_reward_cow": [
@@ -138,7 +131,6 @@ class TestPayoutTransformations(unittest.TestCase):
             {
                 "solver": [],
                 "payment_eth": [],
-                "num_participating_batches": [],
                 "protocol_fee_eth": [],
                 "network_fee_eth": [],
                 "primary_reward_eth": [],
@@ -199,7 +191,6 @@ class TestPayoutTransformations(unittest.TestCase):
                     "solver": self.solvers,
                     "num_quotes": self.num_quotes,
                     "primary_reward_eth": self.primary_reward_eth,
-                    "num_participating_batches": self.batch_participation,
                     "protocol_fee_eth": self.protocol_fee_eth,
                     "network_fee_eth": self.network_fee_eth,
                 }
@@ -236,7 +227,6 @@ class TestPayoutTransformations(unittest.TestCase):
                 "solver": self.solvers,
                 "num_quotes": self.num_quotes,
                 "primary_reward_eth": [600000000000000.0, 1.2e16, -1e16, 0.0],
-                "num_participating_batches": [7, 2, 7, 6],
                 "protocol_fee_eth": [
                     1000000000000000.0,
                     2000000000000000.0,
@@ -309,7 +299,7 @@ class TestPayoutTransformations(unittest.TestCase):
                     "0x0000000000000000000000000000000000000007",
                     "0x0000000000000000000000000000000000000008",
                 ],
-                "pool": [
+                "pool_address": [
                     "0x0000000000000000000000000000000000000025",
                     "0x0000000000000000000000000000000000000026",
                     "0x0000000000000000000000000000000000000026",
@@ -521,8 +511,8 @@ class TestRewardAndPenaltyDatum(unittest.TestCase):
 
     def test_reward_datum_slippage_exceeds_reward(self):
         """Negative slippage leads to overtraft."""
-        primary_reward, participation, slippage = 1, 2, -4
-        test_datum = self.sample_record(primary_reward, participation, slippage, 0)
+        primary_reward, slippage = 1, -4
+        test_datum = self.sample_record(primary_reward, slippage, 0)
         self.assertTrue(test_datum.is_overdraft())
         self.assertEqual(test_datum.as_payouts(), [])
 

--- a/tests/unit/test_payouts.py
+++ b/tests/unit/test_payouts.py
@@ -328,12 +328,12 @@ class TestPayoutTransformations(unittest.TestCase):
                 Transfer(
                     token=Token(COW_TOKEN_ADDRESS),
                     recipient=Address(self.reward_targets[0]),
-                    amount_wei=663636363636363640,
+                    amount_wei=600000000000000000,
                 ),
                 Transfer(
                     token=Token(COW_TOKEN_ADDRESS),
                     recipient=Address(self.reward_targets[1]),
-                    amount_wei=12018181818181818180,
+                    amount_wei=12000000000000000000,
                 ),
                 Transfer(
                     token=Token(COW_TOKEN_ADDRESS),

--- a/tests/unit/test_payouts.py
+++ b/tests/unit/test_payouts.py
@@ -346,11 +346,6 @@ class TestPayoutTransformations(unittest.TestCase):
                     amount_wei=int(180000000000000000000 * (1 - SERVICE_FEE_FACTOR)),
                 ),
                 Transfer(
-                    token=Token(COW_TOKEN_ADDRESS),
-                    recipient=Address(self.reward_targets[3]),
-                    amount_wei=int(54545454545454544 * (1 - SERVICE_FEE_FACTOR)),
-                ),
-                Transfer(
                     token=None,
                     recipient=PROTOCOL_FEE_SAFE,
                     amount_wei=3000000000000000,
@@ -365,7 +360,7 @@ class TestPayoutTransformations(unittest.TestCase):
                 Overdraft(
                     period,
                     account=Address(self.solvers[2]),
-                    wei=9936363636363638,
+                    wei=10000000000000001,
                     name="S_3",
                 )
             ],


### PR DESCRIPTION
As part of cleaning up and restructuring some Dune queries (see relevant PRs [here](https://github.com/cowprotocol/dune-queries/pulls)), some parameters needed to be dropped or renamed. This branch is what we used to run the script for the payouts of Sep 3-10, 2024.

Moreover, we decided to remove consistency rewards altogether from the main script, as we are moving away from those and it doesn't seem likely that they will come back. Note however that the main sql query that computes rewards, one of the core components of the script, is not changed and consistency rewards are still computed there. This will be addressed in a follow-up PR as that query is an important part of the script and thus we thought it is better to address it separately.