### PR TITLE
Ignore zero wei transfers

### DIFF
--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -339,7 +339,7 @@ def prepare_transfers(
                 Transfer(
                     token=None,
                     recipient=Address(address),
-                    amount_wei=partner_fees_wei[address],
+                    amount_wei=amount_wei,
                 )
             )
 

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -332,13 +332,16 @@ def prepare_transfers(
             )
         )
     for address in partner_fees_wei:
-        transfers.append(
-            Transfer(
-                token=None,
-                recipient=Address(address),
-                amount_wei=partner_fees_wei[address],
+        amount_wei = partner_fees_wei[address]
+        assert amount_wei >= 0, f"Can't construct negative transfer of {amount_wei}"
+        if amount_wei > 0:
+            transfers.append(
+                Transfer(
+                    token=None,
+                    recipient=Address(address),
+                    amount_wei=partner_fees_wei[address],
+                )
             )
-        )
 
     return PeriodPayouts(overdrafts, transfers)
 

--- a/src/models/transfer.py
+++ b/src/models/transfer.py
@@ -52,6 +52,8 @@ class Transfer:
     amount_wei: int
 
     def __init__(self, token: Optional[Token], recipient: Address, amount_wei: int):
+        assert amount_wei > 0, f"Can't construct non-positive transfer of {amount_wei}"
+
         self.token = token
         self._recipient = recipient
         self.amount_wei = amount_wei

--- a/src/models/transfer.py
+++ b/src/models/transfer.py
@@ -52,8 +52,6 @@ class Transfer:
     amount_wei: int
 
     def __init__(self, token: Optional[Token], recipient: Address, amount_wei: int):
-        assert amount_wei > 0, f"Can't construct negative transfer of {amount_wei}"
-
         self.token = token
         self._recipient = recipient
         self.amount_wei = amount_wei


### PR DESCRIPTION
Today's dry-run failed because of an assertion that fails with the following msg:

`AssertionError: Can't construct negative transfer of 0`

It seems the script is now trying to add some zero wei transfers for partner fees. I admit i don't know why these transfers show up now and weren't showing up before, but for now this PR proposes to relax the test and only complain for negative transfers for partner fees, while ignoring the zero wei transfers.