### PR TITLE
fix bogus native price

### DIFF
--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -135,7 +135,10 @@ trade_data_processed_with_prices AS (
         END AS network_fee,
         tdp.sell_token AS network_fee_token,
         surplus_token_native_price,
-        protocol_fee_token_native_price,
+        CASE
+            WHEN tdp.order_uid = '\xd6dda5a9dc263af80b6b4155d61f3cd172432fb0e3564fefa537f90603aea78bffff8298631efa764238485543fcff82b878ce1e66fcdfc0' THEN 2.2093961173361646e-7
+            ELSE protocol_fee_token_native_price
+        END AS protocol_fee_token_native_price,
         network_fee_token_native_price
     FROM
         trade_data_processed AS tdp

--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -136,7 +136,7 @@ trade_data_processed_with_prices AS (
         tdp.sell_token AS network_fee_token,
         surplus_token_native_price,
         CASE
-            WHEN tdp.order_uid = '\xd6dda5a9dc263af80b6b4155d61f3cd172432fb0e3564fefa537f90603aea78bffff8298631efa764238485543fcff82b878ce1e66fcdfc0' THEN 2.2093961173361646e-7
+            WHEN tdp.order_uid = '\xd6dda5a9dc263af80b6b4155d61f3cd172432fb0e3564fefa537f90603aea78bffff8298631efa764238485543fcff82b878ce1e66fcdfc0' THEN 2.13762621005e-7
             ELSE protocol_fee_token_native_price
         END AS protocol_fee_token_native_price,
         network_fee_token_native_price


### PR DESCRIPTION
This PR manually fixes the native price associated with order
https://explorer.cow.fi/orders/0xd6dda5a9dc263af80b6b4155d61f3cd172432fb0e3564fefa537f90603aea78bffff8298631efa764238485543fcff82b878ce1e66fcdfc0?tab=overview

The order was executed in this tx: https://etherscan.io/tx/0x5eef22d04a2f30e62df76614decf43e1cc92ab957285a687f182a0191d85d15a

Due to a bogus native price reported by 0x, the Dune data now show that the protocol fee collected is equal to 42 ETH; the following query certifies this:

```
select
  tx_hash,
  order_uid,
  data.protocol_fee_native_price,
  coalesce(cast(data.protocol_fee as double), 0) * data.protocol_fee_native_price / POW(10, 18) as protocol_fee_eth
from
  cowswap.raw_order_rewards
where
  order_uid='0xd6dda5a9dc263af80b6b4155d61f3cd172432fb0e3564fefa537f90603aea78bffff8298631efa764238485543fcff82b878ce1e66fcdfc0'
```

Looking at the logs, it seems that a few seconds before the wrong native price, we had a much more reasonable price feed, as shown in the screenshot below. And this last reasonable price is what this PR uses.

![image](https://github.com/user-attachments/assets/c3121ba7-af5f-476f-b889-bb3c9b7c87be)
