### PR TITLE
Add some assertions for dataframes before merging

### DIFF
--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -478,6 +478,16 @@ def construct_payouts(
     ]
     service_fee_df = service_fee_df[["solver", "service_fee"]]
 
+    # check if all solvers receiving rewards have an associated service fee status
+    service_fee_df_solvers = []
+    for _, row in service_fee_df.iterrows():
+        service_fee_df_solvers.append(row["solver"])
+    for _, row in merged_df.iterrows():
+        solver = row["solver"]
+        assert (
+            solver in service_fee_df_solvers
+        ), "Solver service fee status undefinded " + str(solver)
+
     complete_payout_df = construct_payout_dataframe(
         # Fetch and extend auction data from orderbook.
         payment_df=extend_payment_df(

--- a/src/pg_client.py
+++ b/src/pg_client.py
@@ -56,8 +56,16 @@ class MultiInstanceDBFetcher:
             results.append(
                 self.exec_query(query=batch_reward_query_barn, engine=engine)
             )
-
-        return pd.concat(results)
+        result = pd.concat(results)
+        # check for duplicate solver entries and raise an error if there are any duplicates
+        solvers = []
+        for _, row in result.iterrows():
+            solver = row["solver"]
+            assert (
+                solver not in solvers
+            ), "Solver for batch rewards appears in both prod and barn " + str(solver)
+            solvers.append(solver)
+        return result
 
     def get_quote_rewards(self, start_block: str, end_block: str) -> DataFrame:
         """Returns aggregated solver quote rewards for block range"""
@@ -70,8 +78,16 @@ class MultiInstanceDBFetcher:
             self.exec_query(query=quote_reward_query, engine=engine)
             for engine in self.connections
         ]
-
-        return pd.concat(results)
+        result = pd.concat(results)
+        # check for duplicate solver entries and raise an error if there are any duplicates
+        solvers = []
+        for _, row in result.iterrows():
+            solver = row["solver"]
+            assert (
+                solver not in solvers
+            ), "Solver for quote rewards appears in both prod and barn " + str(solver)
+            solvers.append(solver)
+        return result
 
 
 def pg_hex2bytea(hex_address: str) -> str:


### PR DESCRIPTION
This is an incomplete PR that adds some checks, in order to avoid cases where:
- a solver address appears both in prod and barn; this has caused issues in the past
- we don't compute a service fee for a solver address; this again has caused issues in the past due to a bug in the service fee query