### PR TITLE
[Easy] Small rework of transfer_file initialization

### DIFF
--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -461,7 +461,7 @@ def construct_partner_fee_payments(
 
 
 def construct_payouts(
-    dune: DuneFetcher, ignore_slippage_flag: bool, orderbook: MultiInstanceDBFetcher
+    orderbook: MultiInstanceDBFetcher, dune: DuneFetcher, ignore_slippage_flag: bool
 ) -> list[Transfer]:
     """Workflow of solver reward payout logic post-CIP27"""
     # pylint: disable-msg=too-many-locals

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -106,12 +106,12 @@ def auto_propose(
 if __name__ == "__main__":
     args = generic_script_init(description="Fetch Complete Reimbursement")
 
+    orderbook = MultiInstanceDBFetcher(
+        [os.environ["PROD_DB_URL"], os.environ["BARN_DB_URL"]]
+    )
     dune = DuneFetcher(
         dune=DuneClient(os.environ["DUNE_API_KEY"]),
         period=AccountingPeriod(args.start),
-    )
-    orderbook = MultiInstanceDBFetcher(
-        [os.environ["PROD_DB_URL"], os.environ["BARN_DB_URL"]]
     )
 
     dune.log_saver.print(
@@ -120,10 +120,11 @@ if __name__ == "__main__":
     )
 
     payout_transfers_temp = construct_payouts(
-        dune,
-        args.ignore_slippage,
         orderbook=orderbook,
+        dune=dune,
+        ignore_slippage_flag=args.ignore_slippage,
     )
+
     payout_transfers = []
     for tr in payout_transfers_temp:
         if tr.token is None:

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -9,6 +9,7 @@ import ssl
 from dataclasses import asdict
 
 import certifi
+from dune_client.client import DuneClient
 from dune_client.file.interface import FileIO
 from eth_typing import URI
 from gnosis.eth.ethereum_client import EthereumClient
@@ -23,6 +24,7 @@ from src.constants import (
     FILE_OUT_DIR,
     DOCS_URL,
 )
+from src.fetch.dune import DuneFetcher
 from src.fetch.payouts import construct_payouts
 from src.models.accounting_period import AccountingPeriod
 from src.models.transfer import Transfer, CSVTransfer
@@ -103,14 +105,18 @@ def auto_propose(
 
 if __name__ == "__main__":
     args = generic_script_init(description="Fetch Complete Reimbursement")
-    dune = args.dune
+
+    dune = DuneFetcher(
+        dune=DuneClient(os.environ["DUNE_API_KEY"]),
+        period=AccountingPeriod(args.start),
+    )
     dune.log_saver.print(
         f"The data aggregated can be visualized at\n{dune.period.dashboard_url()}",
         category=Category.GENERAL,
     )
 
     payout_transfers_temp = construct_payouts(
-        args.dune,
+        dune,
         args.ignore_slippage,
         orderbook=MultiInstanceDBFetcher(
             [os.environ["PROD_DB_URL"], os.environ["BARN_DB_URL"]]

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -110,6 +110,10 @@ if __name__ == "__main__":
         dune=DuneClient(os.environ["DUNE_API_KEY"]),
         period=AccountingPeriod(args.start),
     )
+    orderbook = MultiInstanceDBFetcher(
+        [os.environ["PROD_DB_URL"], os.environ["BARN_DB_URL"]]
+    )
+
     dune.log_saver.print(
         f"The data aggregated can be visualized at\n{dune.period.dashboard_url()}",
         category=Category.GENERAL,
@@ -118,9 +122,7 @@ if __name__ == "__main__":
     payout_transfers_temp = construct_payouts(
         dune,
         args.ignore_slippage,
-        orderbook=MultiInstanceDBFetcher(
-            [os.environ["PROD_DB_URL"], os.environ["BARN_DB_URL"]]
-        ),
+        orderbook=orderbook,
     )
     payout_transfers = []
     for tr in payout_transfers_temp:

--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -1,21 +1,15 @@
 """Common method for initializing setup for scripts"""
 
 import argparse
-import os
 from datetime import date, timedelta
 from dataclasses import dataclass
-
-from dune_client.client import DuneClient
-
-from src.fetch.dune import DuneFetcher
-from src.models.accounting_period import AccountingPeriod
 
 
 @dataclass
 class ScriptArgs:
     """A collection of common script arguments relevant to this project"""
 
-    dune: DuneFetcher
+    start: str
     post_tx: bool
     dry_run: bool
     consolidate_transfers: bool
@@ -79,10 +73,7 @@ def generic_script_init(description: str) -> ScriptArgs:
     )
     args = parser.parse_args()
     return ScriptArgs(
-        dune=DuneFetcher(
-            dune=DuneClient(os.environ["DUNE_API_KEY"]),
-            period=AccountingPeriod(args.start),
-        ),
+        start=args.start,
         post_tx=args.post_tx,
         dry_run=args.dry_run,
         consolidate_transfers=args.consolidate_transfers,


### PR DESCRIPTION
This PR changes the initialization step in the transfer_file script. It does not change the behavior of the code.

The main change is to move the initialization of the dune fetcher into the main script and out of the parsing of arguments. This will make it easier to later explicitly pass config into initialization steps. It is also easier for me to understand, what individual steps in the script do. This change required adding a start argument to `ScriptArgs`.

I also reordered the script a bit and to make it easier to consistently pass config objects as last argument of function calls.

