### PR TITLE
Restructure price fetching

### DIFF
--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -13,9 +13,10 @@ import pandas
 from dune_client.types import Address
 from pandas import DataFrame, Series
 
+from src.abis.load import WETH9_ADDRESS
 from src.constants import COW_TOKEN_ADDRESS, COW_BONDING_POOL
 from src.fetch.dune import DuneFetcher
-from src.fetch.prices import eth_in_token, TokenId, token_in_eth
+from src.fetch.prices import exchange_rate_atoms
 from src.models.accounting_period import AccountingPeriod
 from src.models.overdraft import Overdraft
 from src.models.token import Token
@@ -466,9 +467,6 @@ def construct_payouts(
     """Workflow of solver reward payout logic post-CIP27"""
     # pylint: disable-msg=too-many-locals
 
-    price_day = dune.period.end - timedelta(days=1)
-    reward_token = TokenId.COW
-
     quote_rewards_df = orderbook.get_quote_rewards(dune.start_block, dune.end_block)
     batch_rewards_df = orderbook.get_solver_rewards(dune.start_block, dune.end_block)
     partner_fees_df = batch_rewards_df[["partner_list", "partner_fee_eth"]]
@@ -504,15 +502,26 @@ def construct_payouts(
         # TODO - After CIP-20 phased in, adapt query to return `solver` like all the others
         slippage_df = slippage_df.rename(columns={"solver_address": "solver"})
 
+    reward_token = COW_TOKEN_ADDRESS
+    native_token = Address(WETH9_ADDRESS)
+    price_day = dune.period.end - timedelta(days=1)
+    converter = TokenConversion(
+        eth_to_token=lambda t: exchange_rate_atoms(
+            native_token, reward_token, price_day
+        )
+        * t,
+        token_to_eth=lambda t: exchange_rate_atoms(
+            native_token, reward_token, price_day
+        )
+        * t,
+    )
+
     complete_payout_df = construct_payout_dataframe(
         # Fetch and extend auction data from orderbook.
         payment_df=extend_payment_df(
             pdf=merged_df,
             # provide token conversion functions (ETH <--> COW)
-            converter=TokenConversion(
-                eth_to_token=lambda t: eth_in_token(reward_token, t, price_day),
-                token_to_eth=lambda t: token_in_eth(reward_token, t, price_day),
-            ),
+            converter=converter,
         ),
         # Dune: Fetch Solver Slippage & Reward Targets
         slippage_df=slippage_df,

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -262,7 +262,6 @@ class TokenConversion:
     """
 
     eth_to_token: Callable
-    token_to_eth: Callable
 
 
 def extend_payment_df(pdf: DataFrame, converter: TokenConversion) -> DataFrame:
@@ -507,10 +506,6 @@ def construct_payouts(
     price_day = dune.period.end - timedelta(days=1)
     converter = TokenConversion(
         eth_to_token=lambda t: exchange_rate_atoms(
-            native_token, reward_token, price_day
-        )
-        * t,
-        token_to_eth=lambda t: exchange_rate_atoms(
             native_token, reward_token, price_day
         )
         * t,

--- a/src/fetch/prices.py
+++ b/src/fetch/prices.py
@@ -59,8 +59,8 @@ def exchange_rate_atoms(
     """
     token_1 = TOKEN_ADDRESS_TO_ID[token_1_address]
     token_2 = TOKEN_ADDRESS_TO_ID[token_2_address]
-    price_1 = Fraction(usd_price(token_1, day)) / 10 ** token_1.decimals()
-    price_2 = Fraction(usd_price(token_2, day)) / 10 ** token_2.decimals()
+    price_1 = Fraction(usd_price(token_1, day)) / Fraction(10 ** token_1.decimals())
+    price_2 = Fraction(usd_price(token_2, day)) / Fraction(10 ** token_2.decimals())
     return price_1 / price_2
 
 

--- a/tests/unit/test_payouts.py
+++ b/tests/unit/test_payouts.py
@@ -83,9 +83,7 @@ class TestPayoutTransformations(unittest.TestCase):
             0.0,
         ]
         # Mocking TokenConversion!
-        self.mock_converter = TokenConversion(
-            eth_to_token=lambda t: int(t * 1000), token_to_eth=lambda t: t // 1000
-        )
+        self.mock_converter = TokenConversion(eth_to_token=lambda t: int(t * 1000))
 
     def test_extend_payment_df(self):
         base_data_dict = {


### PR DESCRIPTION
This PR slightly restructures the price fetching for converting token amount for rewards.

- Instead of having functions for converting to and from ETH (`eth_in_token`, `token_in_eth`) we just provide an exchange rate for conversion between two tokens (`exchange_rate_atoms`). This will make it easier to add conversion between COW and the native token of the chain, as well as between XDAI and ETH.
- Instead of using token ids as argument, the main function accepts addresses. This is mostly to avoid leaking the implementation of the price fetching (token id on coin paprika) into the rest of the code. It also avoids a circular dependency in making the reward token part of the configuration in #412.

The `TokenId` abstraction still feels a bit stange as there is some overlap with `Token` due to decimals. Supporting USDC seems a bit artificial since that is only used for testing and checking that decimals are correctly accounted for.

Tests for price fetching were adapted accordingly. Transfers for the accounting week starting on 2024-10-29 only differ on the level of floating point precision. 