### PR TITLE
Fix boolean command line options

### DIFF
--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -40,7 +40,7 @@ def generic_script_init(description: str) -> ScriptArgs:
         "--dry-run",
         action="store_true",
         help="Flag indicating whether script should not post alerts or transactions. "
-        "Only relevant in combination with --post-tx True"
+        "Only relevant in combination with --post-tx"
         "Primarily intended for deployment in staging environment.",
     )
     parser.add_argument(

--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -32,18 +32,16 @@ def generic_script_init(description: str) -> ScriptArgs:
     )
     parser.add_argument(
         "--post-tx",
-        type=bool,
+        action="store_true",
         help="Flag indicating whether multisend should be posted to safe "
         "(requires valid env var `PROPOSER_PK`)",
-        default=False,
     )
     parser.add_argument(
         "--dry-run",
-        type=bool,
+        action="store_true",
         help="Flag indicating whether script should not post alerts or transactions. "
         "Only relevant in combination with --post-tx True"
         "Primarily intended for deployment in staging environment.",
-        default=False,
     )
     parser.add_argument(
         "--min-transfer-amount-wei",
@@ -59,9 +57,8 @@ def generic_script_init(description: str) -> ScriptArgs:
     )
     parser.add_argument(
         "--ignore-slippage",
-        type=bool,
+        action="store_true",
         help="Flag for ignoring slippage computations",
-        default=False,
     )
     args = parser.parse_args()
     return ScriptArgs(


### PR DESCRIPTION
This PR changes how boolean command line options are implemented.

With this change, adding `--dry-run` or `--post-tx` or `--ignore-slippage` as command line argument will switch the corresponding argument to `True`. Otherwise, it is set to `False`. The implementation follows what is describet [here](https://docs.python.org/3/library/argparse.html#action).

Before this change, adding `--dry-run True` was supposed to switch on the dry run option. A bit surprisingly, adding `--dry-run False` or `--dry-run dummy` also switched on the option as well. None of these ways to set the option are accepted with this PR. Adding `--dry-run` switches the option on, not adding the option switches it off.

This is a breaking change to the command line API. This PR should only be merged after adapting call sites appropriately.