### PR TITLE
Add service fee log

### DIFF
--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -138,8 +138,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         return 1 - SERVICE_FEE_FACTOR * self.service_fee
 
     def total_service_fee(self) -> Fraction:
-        """Scaling factor for service fee
-        The reward is multiplied by this factor"""
+        """Total service fee charged from rewards"""
         return (
             SERVICE_FEE_FACTOR
             * self.service_fee


### PR DESCRIPTION
This PR adds a log for the service fee charged to solvers in the COW DAO bonding pool.

This log is useful since it determines the budget for ongoing bounties.

This PR does not change the behavior of the code and no additional test was added.