### PR TITLE
Fix service fee log

### DIFF
--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -155,11 +155,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
 
     def total_service_fee(self) -> Fraction:
         """Total service fee charged from rewards"""
-        return (
-            SERVICE_FEE_FACTOR
-            * self.service_fee
-            * (self.primary_reward_cow + self.quote_reward_cow)
-        )
+        return self.service_fee * (self.primary_reward_cow + self.quote_reward_cow)
 
     def is_overdraft(self) -> bool:
         """


### PR DESCRIPTION
This PR fixes an issue with the log for service fees.

The meaning of the attribute `service_fee` of the `RewardAndPenaltyDatum` CHANGED IN #418. This change was not correctly handled in the computation of the total service fee. The reward was thus multiplied by the square of the service fee instead of just the bare service fee. This is fixed in the PR.

No tests are changed since the log is not tested. Maybe we need to add a test for the property that `total_reward_cow() + reward_scaling() * quote_reward_cow + total_service_fee() == primary_reward_cow + quote_reward_cow`.