### PR TITLE
[Easy] Simplify logging

### DIFF
--- a/src/fetch/dune.py
+++ b/src/fetch/dune.py
@@ -6,10 +6,10 @@ from dune_client.client import DuneClient
 from dune_client.query import QueryBase
 from dune_client.types import QueryParameter, DuneRecord
 
-from src.logger import set_log
+from src.logger import set_log, log_saver
 from src.models.accounting_period import AccountingPeriod
 from src.queries import QUERIES, QueryData
-from src.utils.print_store import PrintStore, Category
+from src.utils.print_store import Category
 
 log = set_log(__name__)
 
@@ -22,7 +22,6 @@ class DuneFetcher:
 
     dune: DuneClient
     period: AccountingPeriod
-    log_saver: PrintStore
 
     def __init__(
         self,
@@ -31,7 +30,6 @@ class DuneFetcher:
     ):
         self.dune = dune
         self.period = period
-        self.log_saver = PrintStore()
         # Already have period set, so we might as well store this upon construction.
         # This may become an issue when we make the fetchers async;
         # since python does not allow async constructors
@@ -58,7 +56,7 @@ class DuneFetcher:
             exec_result = self.dune.get_result(job_id)
 
         log.info(f"Fetch completed for execution {exec_result.execution_id}")
-        self.log_saver.print(
+        log_saver.print(
             f"{query.name} execution ID: {exec_result.execution_id}", Category.EXECUTION
         )
         # TODO - use a real logger:

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -17,6 +17,7 @@ from pandas import DataFrame, Series
 from src.config import AccountingConfig
 from src.fetch.dune import DuneFetcher
 from src.fetch.prices import exchange_rate_atoms
+from src.logger import log_saver
 from src.models.accounting_period import AccountingPeriod
 from src.models.overdraft import Overdraft
 from src.models.token import Token
@@ -582,7 +583,7 @@ def construct_payouts(
         for _, payment in complete_payout_df.iterrows()
     )
 
-    dune.log_saver.print(
+    log_saver.print(
         "Payment breakdown (ignoring service fees):\n"
         f"Performance Reward: {performance_reward / 10 ** 18:.4f}\n"
         f"Quote Reward: {quote_reward / 10 ** 18:.4f}\n"
@@ -601,5 +602,5 @@ def construct_payouts(
         config,
     )
     for overdraft in payouts.overdrafts:
-        dune.log_saver.print(str(overdraft), Category.OVERDRAFT)
+        log_saver.print(str(overdraft), Category.OVERDRAFT)
     return payouts.transfers

--- a/src/fetch/prices.py
+++ b/src/fetch/prices.py
@@ -4,7 +4,6 @@ Currently, only price feed is CoinPaprika's Free tier API.
 """
 
 import functools
-import logging.config
 from datetime import datetime
 from enum import Enum
 from fractions import Fraction
@@ -12,12 +11,9 @@ from fractions import Fraction
 from coinpaprika import client as cp
 from dune_client.types import Address
 
-from src.config import IOConfig
+from src.logger import set_log
 
-log = logging.getLogger(__name__)
-logging.config.fileConfig(
-    fname=IOConfig.from_env().log_config_file.absolute(), disable_existing_loggers=False
-)
+log = set_log(__name__)
 
 client = cp.Client()
 

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -52,7 +52,7 @@ def manual_propose(
 
 def auto_propose(
     transfers: list[Transfer],
-    log_saver: PrintStore,
+    log_saver_obj: PrintStore,
     slack_client: WebClient,
     dry_run: bool,
     config: AccountingConfig,
@@ -69,7 +69,7 @@ def auto_propose(
 
     client = EthereumClient(URI(config.node_config.node_url))
 
-    log_saver.print(Transfer.summarize(transfers), category=Category.TOTALS)
+    log_saver_obj.print(Transfer.summarize(transfers), category=Category.TOTALS)
     transactions = prepend_unwrap_if_necessary(
         client,
         config.payment_config.payment_safe_address,
@@ -77,9 +77,9 @@ def auto_propose(
         transactions=[t.as_multisend_tx() for t in transfers],
     )
     if len(transactions) > len(transfers):
-        log_saver.print("Prepended WETH unwrap", Category.GENERAL)
+        log_saver_obj.print("Prepended WETH unwrap", Category.GENERAL)
 
-    log_saver.print(
+    log_saver_obj.print(
         "Instructions for verifying the payout transaction can be found at\n"
         f"{config.payment_config.verification_docs_url}",
         category=Category.GENERAL,
@@ -104,7 +104,7 @@ def auto_propose(
                 f"To sign and execute, visit:\n{config.payment_config.safe_queue_url}\n"
                 f"More details in thread"
             ),
-            sub_messages=log_saver.get_values(),
+            sub_messages=log_saver_obj.get_values(),
         )
 
 
@@ -154,7 +154,7 @@ def main() -> None:
         )
         auto_propose(
             transfers=payout_transfers,
-            log_saver=log_saver,
+            log_saver_obj=log_saver,
             slack_client=slack_client,
             dry_run=args.dry_run,
             config=config,

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -18,6 +18,7 @@ from slack.web.client import WebClient
 from src.config import AccountingConfig, Network
 from src.fetch.dune import DuneFetcher
 from src.fetch.payouts import construct_payouts
+from src.logger import log_saver
 from src.models.accounting_period import AccountingPeriod
 from src.models.transfer import Transfer, CSVTransfer
 from src.multisend import post_multisend, prepend_unwrap_if_necessary
@@ -122,7 +123,7 @@ def main() -> None:
         period=AccountingPeriod(args.start),
     )
 
-    dune.log_saver.print(
+    log_saver.print(
         f"The data aggregated can be visualized at\n{dune.period.dashboard_url()}",
         category=Category.GENERAL,
     )
@@ -153,7 +154,7 @@ def main() -> None:
         )
         auto_propose(
             transfers=payout_transfers,
-            log_saver=dune.log_saver,
+            log_saver=log_saver,
             slack_client=slack_client,
             dry_run=args.dry_run,
             config=config,

--- a/src/logger.py
+++ b/src/logger.py
@@ -8,7 +8,6 @@ from src.config import IOConfig
 io_config = IOConfig.from_env()
 
 
-# TODO - use this in every file that logs (and prints).
 def set_log(name: str) -> Logger:
     """Removes redundancy when setting log in each file"""
 

--- a/src/logger.py
+++ b/src/logger.py
@@ -4,6 +4,7 @@ import logging.config
 from logging import Logger
 
 from src.config import IOConfig
+from src.utils.print_store import PrintStore
 
 io_config = IOConfig.from_env()
 
@@ -18,3 +19,6 @@ def set_log(name: str) -> Logger:
         disable_existing_loggers=False,
     )
     return log
+
+
+log_saver = PrintStore()

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -3,8 +3,6 @@ All the tools necessary to compose and encode a
 Safe Multisend transaction consisting of Transfers
 """
 
-import logging.config
-
 from eth_typing.evm import ChecksumAddress
 from gnosis.eth.ethereum_client import EthereumClient
 from gnosis.eth.ethereum_network import EthereumNetwork
@@ -12,13 +10,12 @@ from gnosis.safe.api import TransactionServiceApi
 from gnosis.safe.multi_send import MultiSend, MultiSendOperation, MultiSendTx
 from gnosis.safe.safe import Safe
 
-from src.config import web3, IOConfig
-from src.abis.load import weth9
 
-log = logging.getLogger(__name__)
-logging.config.fileConfig(
-    fname=IOConfig.from_env().log_config_file.absolute(), disable_existing_loggers=False
-)
+from src.constants import web3
+from src.abis.load import weth9
+from src.logger import set_log
+
+log = set_log(__name__)
 
 # This contract address can be removed once this issue is resolved:
 # https://github.com/safe-global/safe-eth-py/issues/283

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -11,7 +11,7 @@ from gnosis.safe.multi_send import MultiSend, MultiSendOperation, MultiSendTx
 from gnosis.safe.safe import Safe
 
 
-from src.constants import web3
+from src.config import web3
 from src.abis.load import weth9
 from src.logger import set_log
 

--- a/src/utils/token_details.py
+++ b/src/utils/token_details.py
@@ -3,19 +3,14 @@ Very basic Token Info Fetcher that gets token decimals
 """
 
 import functools
-import logging.config
 
 from dune_client.types import Address
 from web3 import Web3
 
 from src.abis.load import erc20
-from src.config import IOConfig
+from src.logger import set_log
 
-log = logging.getLogger(__name__)
-
-logging.config.fileConfig(
-    fname=IOConfig.from_env().log_config_file.absolute(), disable_existing_loggers=False
-)
+log = set_log(__name__)
 
 
 @functools.cache


### PR DESCRIPTION
This PR removes a logging object from the dune fetcher and uses a global logging object instead. It also makes the setup of local loggers more consistent, implementing an old TODO.

This PR makes it easier to pass config objects everywhere they are needed.

The logging object can be made local again later, if desired.