### PR TITLE
[Easy] Move main script into function

### DIFF
--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -103,7 +103,9 @@ def auto_propose(
         )
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Generate transfers for an accounting period"""
+
     args = generic_script_init(description="Fetch Complete Reimbursement")
 
     orderbook = MultiInstanceDBFetcher(
@@ -149,3 +151,7 @@ if __name__ == "__main__":
         )
     else:
         manual_propose(transfers=payout_transfers, period=dune.period)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR moves the main script into its own `main`function. This is following a typical python programming practice.

This avoids some linting issues since the old way of writing the code created global variables which could be shadowed by local variables of the same name in functions. With this change, workarounds like 7849a08e62d33da4b6f93e14765147dd3704456f can be avoided.