### PR TITLE
[Multi-Chain] Pass config explicitly everywhere

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,3 +26,5 @@ jobs:
       - name: Unit Tests
         run:
           python -m pytest tests/unit
+        env:
+          NODE_URL: ${{ secrets.NODE_URL }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -27,4 +27,4 @@ jobs:
         run:
           python -m pytest tests/unit
         env:
-          NODE_URL: ${{ secrets.NODE_URL }}
+          NODE_URL: https://rpc.ankr.com/eth

--- a/src/abis/load.py
+++ b/src/abis/load.py
@@ -13,10 +13,10 @@ from web3 import Web3
 # TODO - following this issue: https://github.com/ethereum/web3.py/issues/3017
 from web3.contract import Contract  # type: ignore
 
-from src.config import config
+from src.config import IOConfig
 from src.logger import set_log
 
-ABI_PATH = config.io_config.project_root_dir / Path("src/abis")
+ABI_PATH = IOConfig.from_env().project_root_dir / Path("src/abis")
 
 log = set_log(__name__)
 
@@ -60,9 +60,11 @@ class IndexedContract(Enum):
 # don't have to import a bunch of stuff to get the contract then want
 
 
-def weth9(web3: Optional[Web3] = None) -> Contract | Type[Contract]:
+def weth9(
+    web3: Optional[Web3] = None, address: ChecksumAddress | None = None
+) -> Contract | Type[Contract]:
     """Returns an instance of WETH9 Contract"""
-    return IndexedContract.WETH9.get_contract(web3, config.payment_config.weth_address)
+    return IndexedContract.WETH9.get_contract(web3, address)
 
 
 def erc20(

--- a/src/config.py
+++ b/src/config.py
@@ -291,6 +291,8 @@ class AccountingConfig:
         )
 
 
-config = AccountingConfig.from_network(Network(os.environ.get("NETWORK", "mainnet")))
-
-web3 = Web3(Web3.HTTPProvider(config.node_config.node_url))
+web3 = Web3(
+    Web3.HTTPProvider(
+        NodeConfig.from_network(Network(os.environ.get("NETWORK", "mainnet"))).node_url
+    )
+)

--- a/src/fetch/prices.py
+++ b/src/fetch/prices.py
@@ -12,11 +12,11 @@ from fractions import Fraction
 from coinpaprika import client as cp
 from dune_client.types import Address
 
-from src.config import config
+from src.config import IOConfig
 
 log = logging.getLogger(__name__)
 logging.config.fileConfig(
-    fname=config.io_config.log_config_file.absolute(), disable_existing_loggers=False
+    fname=IOConfig.from_env().log_config_file.absolute(), disable_existing_loggers=False
 )
 
 client = cp.Client()

--- a/src/logger.py
+++ b/src/logger.py
@@ -3,7 +3,9 @@
 import logging.config
 from logging import Logger
 
-from src.config import config
+from src.config import IOConfig
+
+io_config = IOConfig.from_env()
 
 
 # TODO - use this in every file that logs (and prints).
@@ -13,7 +15,7 @@ def set_log(name: str) -> Logger:
     log = logging.getLogger(name)
 
     logging.config.fileConfig(
-        fname=config.io_config.log_config_file.absolute(),
+        fname=io_config.log_config_file.absolute(),
         disable_existing_loggers=False,
     )
     return log

--- a/src/models/token.py
+++ b/src/models/token.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from dune_client.types import Address
 
-from src.config import config, web3
+from src.config import web3
 from src.utils.token_details import get_token_decimals
 
 
@@ -47,10 +47,6 @@ class Token:
         if isinstance(address, str):
             address = Address(address)
         self.address = address
-
-        if address == config.payment_config.cow_token_address:
-            # Avoid Web3 Calls for main branch of program.
-            decimals = 18
 
         self.decimals = (
             decimals if decimals is not None else get_token_decimals(web3, address)

--- a/src/pg_client.py
+++ b/src/pg_client.py
@@ -8,7 +8,6 @@ from pandas import DataFrame, Series
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 
-from src.config import config
 from src.logger import set_log
 from src.utils.query_file import open_query
 
@@ -31,7 +30,13 @@ class MultiInstanceDBFetcher:
         """Executes query on DB engine"""
         return pd.read_sql(sql=query, con=engine)
 
-    def get_solver_rewards(self, start_block: str, end_block: str) -> DataFrame:
+    def get_solver_rewards(
+        self,
+        start_block: str,
+        end_block: str,
+        reward_cap_upper: int,
+        reward_cap_lower: int,
+    ) -> DataFrame:
         """
         Returns aggregated solver rewards for accounting period defined by block range
         """
@@ -39,23 +44,15 @@ class MultiInstanceDBFetcher:
             open_query("orderbook/prod_batch_rewards.sql")
             .replace("{{start_block}}", start_block)
             .replace("{{end_block}}", end_block)
-            .replace(
-                "{{EPSILON_LOWER}}", str(config.reward_config.batch_reward_cap_lower)
-            )
-            .replace(
-                "{{EPSILON_UPPER}}", str(config.reward_config.batch_reward_cap_upper)
-            )
+            .replace("{{EPSILON_LOWER}}", str(reward_cap_lower))
+            .replace("{{EPSILON_UPPER}}", str(reward_cap_upper))
         )
         batch_reward_query_barn = (
             open_query("orderbook/barn_batch_rewards.sql")
             .replace("{{start_block}}", start_block)
             .replace("{{end_block}}", end_block)
-            .replace(
-                "{{EPSILON_LOWER}}", str(config.reward_config.batch_reward_cap_lower)
-            )
-            .replace(
-                "{{EPSILON_UPPER}}", str(config.reward_config.batch_reward_cap_upper)
-            )
+            .replace("{{EPSILON_LOWER}}", str(reward_cap_lower))
+            .replace("{{EPSILON_UPPER}}", str(reward_cap_upper))
         )
         results = []
 

--- a/src/utils/query_file.py
+++ b/src/utils/query_file.py
@@ -6,7 +6,9 @@ These utilities eliminate the need to use relative paths.
 
 import os
 
-from src.config import config
+from src.config import IOConfig
+
+io_config = IOConfig.from_env()
 
 
 def open_query(filename: str) -> str:
@@ -23,9 +25,9 @@ def open_dashboard_query(filename: str) -> str:
 
 def query_file(filename: str) -> str:
     """Returns proper path for filename in QUERY_PATH"""
-    return os.path.join(config.io_config.query_dir, filename)
+    return os.path.join(io_config.query_dir, filename)
 
 
 def dashboard_file(filename: str) -> str:
     """Returns proper path for filename in DASHBOARD_PATH"""
-    return os.path.join(config.io_config.dashboard_dir, filename)
+    return os.path.join(io_config.dashboard_dir, filename)

--- a/src/utils/token_details.py
+++ b/src/utils/token_details.py
@@ -9,12 +9,12 @@ from dune_client.types import Address
 from web3 import Web3
 
 from src.abis.load import erc20
-from src.config import config
+from src.config import IOConfig
 
 log = logging.getLogger(__name__)
 
 logging.config.fileConfig(
-    fname=config.io_config.log_config_file.absolute(), disable_existing_loggers=False
+    fname=IOConfig.from_env().log_config_file.absolute(), disable_existing_loggers=False
 )
 
 

--- a/tests/e2e/test_prices.py
+++ b/tests/e2e/test_prices.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from dune_client.types import Address
 
-from src.config import config
+from src.config import AccountingConfig, Network
 from src.fetch.prices import (
     TokenId,
     exchange_rate_atoms,
@@ -16,12 +16,13 @@ DELTA = 0.00001
 
 class TestPrices(unittest.TestCase):
     def setUp(self) -> None:
+        self.config = AccountingConfig.from_network(Network.MAINNET)
         self.some_date = datetime.strptime("2024-09-01", "%Y-%m-%d")
         self.cow_price = usd_price(TokenId.COW, self.some_date)
         self.eth_price = usd_price(TokenId.ETH, self.some_date)
         self.usdc_price = usd_price(TokenId.USDC, self.some_date)
-        self.cow_address = config.reward_config.reward_token_address
-        self.weth_address = Address(config.payment_config.weth_address)
+        self.cow_address = self.config.reward_config.reward_token_address
+        self.weth_address = Address(self.config.payment_config.weth_address)
         self.usdc_address = Address("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
 
     def test_usd_price(self):

--- a/tests/queries/test_batch_rewards.py
+++ b/tests/queries/test_batch_rewards.py
@@ -3,12 +3,16 @@ import unittest
 import pandas.testing
 from pandas import DataFrame
 
+from src.config import RewardConfig, Network
 from src.pg_client import MultiInstanceDBFetcher
 
 
 class TestBatchRewards(unittest.TestCase):
     def setUp(self) -> None:
         db_url = "postgres:postgres@localhost:5432/postgres"
+        reward_config = RewardConfig.from_network(Network.MAINNET)
+        self.batch_reward_cap_upper = reward_config.batch_reward_cap_upper
+        self.batch_reward_cap_lower = reward_config.batch_reward_cap_lower
         self.fetcher = MultiInstanceDBFetcher([db_url])
         with open(
             "./tests/queries/batch_rewards_test_db.sql", "r", encoding="utf-8"
@@ -17,7 +21,12 @@ class TestBatchRewards(unittest.TestCase):
 
     def test_get_batch_rewards(self):
         start_block, end_block = "0", "100"
-        batch_rewards = self.fetcher.get_solver_rewards(start_block, end_block)
+        batch_rewards = self.fetcher.get_solver_rewards(
+            start_block,
+            end_block,
+            self.batch_reward_cap_upper,
+            self.batch_reward_cap_lower,
+        )
         expected = DataFrame(
             {
                 "solver": [

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -7,7 +7,7 @@ from gnosis.safe.multi_send import MultiSendTx, MultiSendOperation
 from web3 import Web3
 
 from src.abis.load import erc20
-from src.config import config
+from src.config import PaymentConfig, Network
 from src.fetch.transfer_file import Transfer
 from src.models.accounting_period import AccountingPeriod
 from src.models.token import Token
@@ -19,6 +19,7 @@ ONE_ETH = 10**18
 
 class TestTransfer(unittest.TestCase):
     def setUp(self) -> None:
+        self.payment_config = PaymentConfig.from_network(Network.MAINNET)
         self.token_1 = Token(Address.from_int(1), 18)
         self.token_2 = Token(Address.from_int(2), 18)
 
@@ -39,7 +40,7 @@ class TestTransfer(unittest.TestCase):
             ),
         )
         erc20_transfer = Transfer(
-            token=Token(config.payment_config.cow_token_address),
+            token=Token(self.payment_config.cow_token_address),
             recipient=Address(receiver),
             amount_wei=15,
         )
@@ -47,7 +48,7 @@ class TestTransfer(unittest.TestCase):
             erc20_transfer.as_multisend_tx(),
             MultiSendTx(
                 operation=MultiSendOperation.CALL,
-                to=config.payment_config.cow_token_address.address,
+                to=self.payment_config.cow_token_address.address,
                 value=0,
                 data=erc20().encodeABI(fn_name="transfer", args=[receiver, 15]),
             ),
@@ -94,7 +95,7 @@ class TestTransfer(unittest.TestCase):
             [
                 Transfer(token=None, recipient=receiver, amount_wei=eth_amount),
                 Transfer(
-                    token=Token(config.payment_config.cow_token_address),
+                    token=Token(self.payment_config.cow_token_address),
                     recipient=receiver,
                     amount_wei=cow_amount,
                 ),


### PR DESCRIPTION
This PR is based on #412. It creates config objects explicitly in the payout script and passes it through the code as argument. Before, the config was a global object.

This makes it easier, for example,  to set up configuration at run time, combine config with command line arguments, and separate tests from the rest of the code.