### PR TITLE
Restructure payouts file

### DIFF
--- a/src/fetch/buffer_accounting.py
+++ b/src/fetch/buffer_accounting.py
@@ -1,0 +1,52 @@
+"""Functionality for buffer accounting."""
+
+import pandas as pd
+from pandas import DataFrame
+
+BATCH_DATA_COLUMNS = ["solver", "network_fee_eth"]
+SLIPPAGE_COLUMNS = [
+    "solver",
+    "eth_slippage_wei",
+]
+
+BUFFER_ACCOUNTING_COLUMNS = [
+    "solver",
+    "network_fee_eth",
+    "slippage_eth",
+]
+
+
+def compute_buffer_accounting(
+    batch_data: DataFrame, slippage_data: DataFrame
+) -> DataFrame:
+    """Compute buffer accounting per solver"""
+
+    # validate batch rewards and quote rewards columns
+    assert set(BATCH_DATA_COLUMNS).issubset(set(batch_data.columns))
+    assert set(SLIPPAGE_COLUMNS).issubset(set(slippage_data.columns))
+
+    with pd.option_context(
+        "future.no_silent_downcasting", True
+    ):  # remove this after Future warning disappears. We do not depend on down-casting,
+        # as we will work with object and int explicitly.
+        buffer_accounting = (
+            (
+                batch_data[BATCH_DATA_COLUMNS]
+                .astype(object)
+                .merge(
+                    slippage_data[SLIPPAGE_COLUMNS].astype(object),
+                    how="outer",
+                    on="solver",
+                    validate="one_to_one",
+                )
+            )
+            .fillna(0)
+            .astype(object)
+        )
+    buffer_accounting = buffer_accounting.rename(
+        columns={"eth_slippage_wei": "slippage_eth"}
+    )
+
+    assert set(buffer_accounting.columns) == set(BUFFER_ACCOUNTING_COLUMNS)
+
+    return buffer_accounting

--- a/src/fetch/buffer_accounting.py
+++ b/src/fetch/buffer_accounting.py
@@ -21,7 +21,7 @@ def compute_buffer_accounting(
 ) -> DataFrame:
     """Compute buffer accounting per solver"""
 
-    # validate batch rewards and quote rewards columns
+    # validate batch data and slippage data columns
     assert set(BATCH_DATA_COLUMNS).issubset(set(batch_data.columns))
     assert set(SLIPPAGE_COLUMNS).issubset(set(slippage_data.columns))
 

--- a/src/fetch/buffer_accounting.py
+++ b/src/fetch/buffer_accounting.py
@@ -26,16 +26,17 @@ def compute_buffer_accounting(
     batch_data : DataFrame
         Batch rewards data.
         The columns have to contain BATCH_REWARDS_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        network_fee_eth : int
+        - network_fee_eth : int
             Network fees in wei of a solver for settling batches.
+
     slippage_data : DataFrame
         Slippage data.
         The columns have to contain SLIPPAGE_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        eth_slippage_wei : int
+        - eth_slippage_wei : int
             Slippage in wei accrued by a solver in settling batches.
 
     Returns
@@ -43,11 +44,11 @@ def compute_buffer_accounting(
     buffer_accounting : DataFrame
         Data frame containing rewards per solver.
         The columns are REWARDS_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        network_fee_eth : int
+        - network_fee_eth : int
             Network fees in wei of a solver for settling batches.
-        slippage_eth : int
+        - slippage_eth : int
             Slippage in wei accrued by a solver in settling batches.
 
     Raises

--- a/src/fetch/buffer_accounting.py
+++ b/src/fetch/buffer_accounting.py
@@ -19,7 +19,48 @@ BUFFER_ACCOUNTING_COLUMNS = [
 def compute_buffer_accounting(
     batch_data: DataFrame, slippage_data: DataFrame
 ) -> DataFrame:
-    """Compute buffer accounting per solver"""
+    """Compute buffer accounting per solver.
+
+    Parameters
+    ----------
+    batch_data : DataFrame
+        Batch rewards data.
+        The columns have to contain BATCH_REWARDS_COLUMNS:
+        solver : str
+            "0x"-prefixed hex representation of the submission address of a solver.
+        network_fee_eth : int
+            Network fees in wei of a solver for settling batches.
+    slippage_data : DataFrame
+        Slippage data.
+        The columns have to contain SLIPPAGE_COLUMNS:
+        solver : str
+            "0x"-prefixed hex representation of the submission address of a solver.
+        eth_slippage_wei : int
+            Slippage in wei accrued by a solver in settling batches.
+
+    Returns
+    -------
+    buffer_accounting : DataFrame
+        Data frame containing rewards per solver.
+        The columns are REWARDS_COLUMNS:
+        solver : str
+            "0x"-prefixed hex representation of the submission address of a solver.
+        network_fee_eth : int
+            Network fees in wei of a solver for settling batches.
+        slippage_eth : int
+            Slippage in wei accrued by a solver in settling batches.
+
+    Raises
+    ------
+    AssertionError
+        If input dataframes do not contain required columns or if the result does not have correct
+        columns.
+
+    Notes
+    -----
+    All data frames are set to have data type `object`. Otherwise, implicit conversion to int64 can
+    lead to overflows.
+    """
 
     # validate batch data and slippage data columns
     assert set(BATCH_DATA_COLUMNS).issubset(set(batch_data.columns))

--- a/src/fetch/partner_fees.py
+++ b/src/fetch/partner_fees.py
@@ -16,7 +16,7 @@ PARTNER_FEES_COLUMNS = ["partner", "partner_fee_eth", "partner_fee_tax"]
 def compute_partner_fees(batch_data: DataFrame, config: ProtocolFeeConfig) -> DataFrame:
     """Compute partner fees per integrator"""
 
-    # validate batch rewards and quote rewards columns
+    # validate batch data columns
     assert set(BATCH_DATA_COLUMNS).issubset(set(batch_data.columns))
 
     partner_fee_lists = batch_data[BATCH_DATA_COLUMNS]

--- a/src/fetch/partner_fees.py
+++ b/src/fetch/partner_fees.py
@@ -1,0 +1,62 @@
+"""Functionality for partner fees."""
+
+from collections import defaultdict
+
+import numpy as np
+import pandas as pd
+from pandas import DataFrame
+
+from src.config import ProtocolFeeConfig
+
+BATCH_DATA_COLUMNS = ["partner_list", "partner_fee_eth"]
+
+PARTNER_FEES_COLUMNS = ["partner", "partner_fee_eth", "partner_fee_tax"]
+
+
+def compute_partner_fees(batch_data: DataFrame, config: ProtocolFeeConfig) -> DataFrame:
+    """Compute partner fees per integrator"""
+
+    # validate batch rewards and quote rewards columns
+    assert set(BATCH_DATA_COLUMNS).issubset(set(batch_data.columns))
+
+    partner_fee_lists = batch_data[BATCH_DATA_COLUMNS]
+
+    partner_fees = compute_partner_fees_per_partner(partner_fee_lists, config)
+
+    assert set(partner_fees.columns) == set(PARTNER_FEES_COLUMNS)
+
+    return partner_fees
+
+
+def compute_partner_fees_per_partner(
+    partner_fee_lists: DataFrame, config: ProtocolFeeConfig
+) -> DataFrame:
+    """Aggregate fees from different solvers"""
+
+    partner_fees_dict: defaultdict[str, int] = defaultdict(int)
+    for _, row in partner_fee_lists.iterrows():
+        if row["partner_list"] is None:
+            continue
+
+        # We assume the two lists used below, i.e.,
+        # partner_list and partner_fee_eth,
+        # are "aligned".
+
+        for partner, partner_fee in zip(row["partner_list"], row["partner_fee_eth"]):
+            partner_fees_dict[partner] += int(partner_fee)
+
+    partner_fees_df = pd.DataFrame(
+        list(partner_fees_dict.items()),
+        columns=["partner", "partner_fee_eth"],
+    )
+
+    partner_fees_df["partner_fee_tax"] = np.where(
+        partner_fees_df["partner"] == config.reduced_cut_address,
+        config.partner_fee_reduced_cut,
+        config.partner_fee_cut,
+    )
+
+    # change all types to object to use native python types
+    partner_fees_df = partner_fees_df.astype(object)
+
+    return partner_fees_df

--- a/src/fetch/partner_fees.py
+++ b/src/fetch/partner_fees.py
@@ -14,7 +14,42 @@ PARTNER_FEES_COLUMNS = ["partner", "partner_fee_eth", "partner_fee_tax"]
 
 
 def compute_partner_fees(batch_data: DataFrame, config: ProtocolFeeConfig) -> DataFrame:
-    """Compute partner fees per integrator"""
+    """Compute partner fees per partner.
+
+    Parameters
+    ----------
+    batch_data : DataFrame
+        Batch rewards data.
+        The columns have to contain BATCH_DATA_COLUMNS:
+        partner_list : list[str]
+            List of "0x"-prefixed hex representations of the partner addresses. Partner fees are
+            paid to these addresses.
+        partner_fee_eth : list[int]
+            List of partner fees in wei a solver owes to a partner for settling batches. The list is
+            aligned with the respective partners in partner_list.
+    config : ProtocolFeeConfig
+        Protocol fee configuration.
+
+    Returns
+    -------
+    partner_fees : DataFrame
+        Data frame containing partner fees per partner.
+        The columns are PARTNER_FEES_COLUMNS:
+        partner : str
+            "0x"-prefixed hex representation of the address of a partner. Partner fees are paid to
+            these addresses.
+        partner_fee_eth : int
+            Total partner fee in wei of a partner. This amount is reduced by partner_fee_tax before
+            payment.
+        partner_fee_tax : Fraction
+            The fraction of partner fees which need to be paid to the COW DAO.
+
+    Raises
+    ------
+    AssertionError
+        If input dataframe does not contain required columns or if the result does not have correct
+        columns.
+    """
 
     # validate batch data columns
     assert set(BATCH_DATA_COLUMNS).issubset(set(batch_data.columns))
@@ -31,7 +66,44 @@ def compute_partner_fees(batch_data: DataFrame, config: ProtocolFeeConfig) -> Da
 def compute_partner_fees_per_partner(
     partner_fee_lists: DataFrame, config: ProtocolFeeConfig
 ) -> DataFrame:
-    """Aggregate fees from different solvers"""
+    """Compute partner fees per partner.
+
+    This is the main computation step for partner fees. It has the same input and output format as
+    `compute_partner_fees`.
+
+    Parameters
+    ----------
+    partner_fee_lists : DataFrame
+        Batch rewards data.
+        The columns are BATCH_DATA_COLUMNS:
+        partner_list : list[str]
+            List of "0x"-prefixed hex representations of the partner addresses. Partner fees are
+            paid to these addresses.
+        partner_fee_eth : list[int]
+            List of partner fees in wei a solver owes to a partner for settling batches. The list is
+            aligned with the respective partners in partner_list.
+    config : ProtocolFeeConfig
+        Protocol fee configuration.
+
+    Returns
+    -------
+    partner_fees_df : DataFrame
+        Data frame containing partner fees per partner.
+        The columns are PARTNER_FEES_COLUMNS:
+        partner : str
+            "0x"-prefixed hex representation of the address of a partner. Partner fees are paid to
+            these addresses.
+        partner_fee_eth : int
+            Total partner fee in wei of a partner. This amount is reduced by partner_fee_tax before
+            payment.
+        partner_fee_tax : Fraction
+            The fraction of partner fees which need to be paid to the COW DAO.
+
+    Notes
+    -----
+    All data frames are set to have data type `object`. Otherwise, implicit conversion to int64 can
+    lead to overflows.
+    """
 
     partner_fees_dict: defaultdict[str, int] = defaultdict(int)
     for _, row in partner_fee_lists.iterrows():

--- a/src/fetch/partner_fees.py
+++ b/src/fetch/partner_fees.py
@@ -43,7 +43,7 @@ def compute_partner_fees(batch_data: DataFrame, config: ProtocolFeeConfig) -> Da
             Total partner fee in wei of a partner. This amount is reduced by partner_fee_tax before
             payment.
         - partner_fee_tax : Fraction
-            The fraction of partner fees which need to be paid to the COW DAO.
+            The fraction of partner fees which need to be paid to the CoW DAO.
 
     Raises
     ------
@@ -99,7 +99,7 @@ def compute_partner_fees_per_partner(
             Total partner fee in wei of a partner. This amount is reduced by partner_fee_tax before
             payment.
         - partner_fee_tax : Fraction
-            The fraction of partner fees which need to be paid to the COW DAO.
+            The fraction of partner fees which need to be paid to the CoW DAO.
 
     Notes
     -----

--- a/src/fetch/partner_fees.py
+++ b/src/fetch/partner_fees.py
@@ -21,12 +21,13 @@ def compute_partner_fees(batch_data: DataFrame, config: ProtocolFeeConfig) -> Da
     batch_data : DataFrame
         Batch rewards data.
         The columns have to contain BATCH_DATA_COLUMNS:
-        partner_list : list[str]
+        - partner_list : list[str]
             List of "0x"-prefixed hex representations of the partner addresses. Partner fees are
             paid to these addresses.
-        partner_fee_eth : list[int]
+        - partner_fee_eth : list[int]
             List of partner fees in wei a solver owes to a partner for settling batches. The list is
             aligned with the respective partners in partner_list.
+
     config : ProtocolFeeConfig
         Protocol fee configuration.
 
@@ -35,13 +36,13 @@ def compute_partner_fees(batch_data: DataFrame, config: ProtocolFeeConfig) -> Da
     partner_fees : DataFrame
         Data frame containing partner fees per partner.
         The columns are PARTNER_FEES_COLUMNS:
-        partner : str
+        - partner : str
             "0x"-prefixed hex representation of the address of a partner. Partner fees are paid to
             these addresses.
-        partner_fee_eth : int
+        - partner_fee_eth : int
             Total partner fee in wei of a partner. This amount is reduced by partner_fee_tax before
             payment.
-        partner_fee_tax : Fraction
+        - partner_fee_tax : Fraction
             The fraction of partner fees which need to be paid to the COW DAO.
 
     Raises
@@ -76,12 +77,13 @@ def compute_partner_fees_per_partner(
     partner_fee_lists : DataFrame
         Batch rewards data.
         The columns are BATCH_DATA_COLUMNS:
-        partner_list : list[str]
+        - partner_list : list[str]
             List of "0x"-prefixed hex representations of the partner addresses. Partner fees are
             paid to these addresses.
-        partner_fee_eth : list[int]
+        - partner_fee_eth : list[int]
             List of partner fees in wei a solver owes to a partner for settling batches. The list is
             aligned with the respective partners in partner_list.
+
     config : ProtocolFeeConfig
         Protocol fee configuration.
 
@@ -90,13 +92,13 @@ def compute_partner_fees_per_partner(
     partner_fees_df : DataFrame
         Data frame containing partner fees per partner.
         The columns are PARTNER_FEES_COLUMNS:
-        partner : str
+        - partner : str
             "0x"-prefixed hex representation of the address of a partner. Partner fees are paid to
             these addresses.
-        partner_fee_eth : int
+        - partner_fee_eth : int
             Total partner fee in wei of a partner. This amount is reduced by partner_fee_tax before
             payment.
-        partner_fee_tax : Fraction
+        - partner_fee_tax : Fraction
             The fraction of partner fees which need to be paid to the COW DAO.
 
     Notes

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -685,8 +685,8 @@ def summarize_payments(  # pylint: disable=too-many-locals
         f"Performance Reward (before fee): {performance_reward / 10 ** 18:.4f}\n"
         f"Quote Reward (before fee): {quote_reward / 10 ** 18:.4f}\n"
         f"CoW DAO Service Fees: {service_fee / 10 ** 18:.4f}\n"
-        f"Protocol Fees (before partner fees): {protocol_fee / 10 ** 18:.4f}\n"  # changed meaning
-        f"Partner Fees (before tax): {partner_fee / 10 ** 18:.4f}\n"  # changed meaning
+        f"Protocol Fees (excluding partner fees): {(protocol_fee - partner_fee) / 10 ** 18:.4f}\n"
+        f"Partner Fees (after tax): {(partner_fee - partner_fee_tax) / 10 ** 18:.4f}\n"
         f"Partner Fees Tax: {partner_fee_tax / 10 ** 18:.4f}\n"
         f"Network Fees: {network_fee / 10**18:.4f}\n"
         f"Slippage: {slippage / 10**18:.4f}\n\n"

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -463,51 +463,51 @@ def compute_solver_payouts(
     solver_info : DataFrame
         Data containing information about solvers.
         The columns are SOLVER_INFO_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        solver_name : str
+        - solver_name : str
             Name of a solver.
-        reward_target : str
+        - reward_target : str
             "0x"-prefixed hex representation of the reward target of a solver. All
             rewards are sent to this address.
-        buffer_accounting_target : str
+        - buffer_accounting_target : str
             "0x"-prefixed hex representation of the buffer accounting target address of a solver.
             Results of the buffer accounting are sent to this address. It is equal to `solver` or
             `reward_target`.
-        service_fee : Fraction
+        - service_fee : Fraction
             The fraction of rewards which need to be paid to the COW DAO.
 
 
     rewards : DataFrame
         Data containing reward-related information for solvers, such as batch and quote rewards.
         The columns are REWARDS_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        primary_reward_eth : int
+        - primary_reward_eth : int
             Reward for settling batches in wei.
-        primary_reward_cow : int
+        - primary_reward_cow : int
             Reward for settling batches in atoms of COW.
-        quote_reward_cow : int
+        - quote_reward_cow : int
             Reward for providing quotes in atoms of COW.
-        reward_token_address : str
+        - reward_token_address : str
             "0x"-prefixed hex representation of the reward token contract address.
 
     protocol_fees : DataFrame
         Data containing protocol fee information associated with solvers.
         The columns are PROTOCOL_FEES_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        protocol_fee_eth : int
+        - protocol_fee_eth : int
             Protocol fee of a solver for settling batches in wei.
 
     buffer_accounting : DataFrame
         Data containing buffer accounting information related to solvers.
         The columns are REWARDS_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        network_fee_eth : int
+        - network_fee_eth : int
             Network fees in wei of a solver for settling batches.
-        slippage_eth : int
+        - slippage_eth : int
             Slippage in wei accrued by a solver in settling batches.
 
     Returns
@@ -518,32 +518,32 @@ def compute_solver_payouts(
         normalized fields.
         Missing values are set to zero or some other reasonable default value.
         The columns are SOLVER_PAYOUTS_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        solver_name : str
+        - solver_name : str
             Name of a solver.
-        primary_reward_eth : int
+        - primary_reward_eth : int
             Reward for settling batches in wei.
-        primary_reward_cow : int
+        - primary_reward_cow : int
             Reward for settling batches in wei.
-        quote_reward_cow : int
+        - quote_reward_cow : int
             Reward for providing quotes in atoms of COW.
-        protocol_fee_eth : int
+        - protocol_fee_eth : int
             Protocol fee of a solver for settling batches in wei.
-        network_fee_eth : int
+        - network_fee_eth : int
             Network fees in wei of a solver for settling batches.
-        slippage_eth : int
+        - slippage_eth : int
             Slippage in wei accrued by a solver in settling batches.
-        reward_target : str
+        - reward_target : str
             "0x"-prefixed hex representation of the reward target of a solver. All
             rewards are sent to this address.
-        buffer_accounting_target : str
+        - buffer_accounting_target : str
             "0x"-prefixed hex representation of the buffer accounting target address of a solver.
             Results of the buffer accounting are sent to this address. It is equal to `solver` or
             `reward_target`.
-        reward_token_address : str
+        - reward_token_address : str
             "0x"-prefixed hex representation of the reward token contract address.
-        service_fee : Fraction
+        - service_fee : Fraction
             The fraction of rewards which need to be paid to the COW DAO.
 
     Raises
@@ -615,7 +615,9 @@ def compute_solver_payouts(
 
 def compute_partner_payouts(partner_fees: DataFrame) -> DataFrame:
     """Combine partner fee information into partner fee payouts.
-    At the moment, this function only copies the partner fee data frame."""
+
+    At the moment, this function only copies the partner fee data frame.
+    """
     assert set(PARTNER_FEES_COLUMNS).issubset(set(partner_fees.columns))
 
     partner_payouts = partner_fees[PARTNER_FEES_COLUMNS]
@@ -643,14 +645,18 @@ def summarize_payments(  # pylint: disable=too-many-locals
     solver_payouts : DataFrame
         Contains payout details from solvers, including primary rewards, quote rewards, protocol
         fees, slippage, and network fees.
+
     partner_payouts : DataFrame
         Contains partner-related payout details such as partner fees and associated tax information.
+
     exchange_rate_native_to_cow : Fraction
         Exchange rate that defines the number of COW tokens equivalent to one unit of the native
         token.
+
     exchange_rate_native_to_eth : Fraction
         Exchange rate that defines the number of ETH tokens equivalent to one unit of the native
         token.
+
     config : AccountingConfig
         Configuration object containing payment parameters such as minimum acceptable native token
         transfer and COW transfer thresholds.

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -558,9 +558,7 @@ def construct_payouts(
         exchange_rate_native_to_cow,
         config.reward_config,
     )
-    protocol_fees = compute_protocol_fees(
-        batch_data,
-    )
+    protocol_fees = compute_protocol_fees(batch_data)
     partner_fees = compute_partner_fees(batch_data, config.protocol_fee_config)
     buffer_accounting = compute_buffer_accounting(batch_data, slippage_df)
 

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -475,7 +475,7 @@ def compute_solver_payouts(
             Results of the buffer accounting are sent to this address. It is equal to `solver` or
             `reward_target`.
         - service_fee : Fraction
-            The fraction of rewards which need to be paid to the COW DAO.
+            The fraction of rewards which need to be paid to the CoW DAO.
 
 
     rewards : DataFrame
@@ -544,7 +544,7 @@ def compute_solver_payouts(
         - reward_token_address : str
             "0x"-prefixed hex representation of the reward token contract address.
         - service_fee : Fraction
-            The fraction of rewards which need to be paid to the COW DAO.
+            The fraction of rewards which need to be paid to the CoW DAO.
 
     Raises
     ------
@@ -684,7 +684,7 @@ def summarize_payments(  # pylint: disable=too-many-locals
         "Payment breakdown:\n"
         f"Performance Reward (before fee): {performance_reward / 10 ** 18:.4f}\n"
         f"Quote Reward (before fee): {quote_reward / 10 ** 18:.4f}\n"
-        f"COW DAO Service Fees: {service_fee / 10 ** 18:.4f}\n"
+        f"CoW DAO Service Fees: {service_fee / 10 ** 18:.4f}\n"
         f"Protocol Fees (before partner fees): {protocol_fee / 10 ** 18:.4f}\n"  # changed meaning
         f"Partner Fees (before tax): {partner_fee / 10 ** 18:.4f}\n"  # changed meaning
         f"Partner Fees Tax: {partner_fee_tax / 10 ** 18:.4f}\n"

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -587,13 +587,6 @@ def compute_solver_payouts(
         solver_payouts["quote_reward_cow"] = (
             solver_payouts["quote_reward_cow"].fillna(0).astype(object)
         )
-        solver_payouts["reward_token_address"] = (
-            solver_payouts["reward_token_address"]
-            .fillna(
-                "0x0000000000000000000000000000000000000001"
-            )  # dummy address, not used
-            .astype(object)
-        )
         solver_payouts["slippage_eth"] = (
             solver_payouts["slippage_eth"].fillna(0).astype(object)
         )

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -530,7 +530,7 @@ def construct_payouts(
 
     vouches = dune.get_vouches()
     if vouches:
-        reward_target_df = DataFrame(dune.get_vouches())
+        reward_target_df = DataFrame(vouches)
     else:
         log.warning("No results for vouch query.")
         reward_target_df = DataFrame(

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -97,13 +97,17 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         solver = frame["solver"]
         reward_target = frame["reward_target"]
         if pd.isna(reward_target):
-            log.warning(f"Solver {solver} without reward_target. Using solver")
+            log.warning(
+                f"Solver {solver} without reward_target. "
+                f"Using solver submission address instead."
+            )
             reward_target = solver
 
         buffer_accounting_target = frame["buffer_accounting_target"]
         if pd.isna(buffer_accounting_target):
             log.warning(
-                f"Solver {solver} without buffer_accounting_target. Using solver"
+                f"Solver {solver} without buffer_accounting_target. "
+                f"Using solver submission address instead."
             )
             buffer_accounting_target = solver
 
@@ -513,7 +517,7 @@ def construct_payouts(
     # fetch data
     # TODO: move data fetching into respective files for rewards, protocol fees, buffer accounting,
     #       solver info
-    quote_rewards_df = orderbook.get_quote_rewards(dune.start_block, dune.end_block)
+    quote_data = orderbook.get_quote_rewards(dune.start_block, dune.end_block)
     batch_data = (  # TODO: use bare batch data before aggregation
         orderbook.get_solver_rewards(
             dune.start_block,
@@ -554,7 +558,7 @@ def construct_payouts(
     )
     rewards = compute_rewards(
         batch_data,
-        quote_rewards_df,
+        quote_data,
         exchange_rate_native_to_cow,
         config.reward_config,
     )

--- a/src/fetch/protocol_fees.py
+++ b/src/fetch/protocol_fees.py
@@ -17,9 +17,9 @@ def compute_protocol_fees(
     batch_data : DataFrame
         Batch rewards data.
         The columns have to contain BATCH_DATA_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        protocol_fee_eth : int
+        - protocol_fee_eth : int
             Protocol fee of a solver for settling batches in wei.
 
     Returns
@@ -27,9 +27,9 @@ def compute_protocol_fees(
     protocol_fees : DataFrame
         Data frame containing protocol fees per solver.
         The columns are PROTOCOL_FEES_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        protocol_fee_eth : int
+        - protocol_fee_eth : int
             Protocol fee of a solver for settling batches in wei.
 
     Raises

--- a/src/fetch/protocol_fees.py
+++ b/src/fetch/protocol_fees.py
@@ -10,7 +10,39 @@ PROTOCOL_FEES_COLUMNS = BATCH_DATA_COLUMNS
 def compute_protocol_fees(
     batch_data: DataFrame,
 ) -> DataFrame:
-    """Compute protocol fees per solver."""
+    """Compute protocol fees.
+
+    Parameters
+    ----------
+    batch_data : DataFrame
+        Batch rewards data.
+        The columns have to contain BATCH_DATA_COLUMNS:
+        solver : str
+            "0x"-prefixed hex representation of the submission address of a solver.
+        protocol_fee_eth : int
+            Protocol fee of a solver for settling batches in wei.
+
+    Returns
+    -------
+    protocol_fees : DataFrame
+        Data frame containing protocol fees per solver.
+        The columns are PROTOCOL_FEES_COLUMNS:
+        solver : str
+            "0x"-prefixed hex representation of the submission address of a solver.
+        protocol_fee_eth : int
+            Protocol fee of a solver for settling batches in wei.
+
+    Raises
+    ------
+    AssertionError
+        If input dataframe does not contain required columns or if the result does not have correct
+        columns.
+
+    Notes
+    -----
+    All data frames are set to have data type `object`. Otherwise, implicit conversion to int64 can
+    lead to overflows.
+    """
 
     # validate batch data columns
     assert set(BATCH_DATA_COLUMNS).issubset(set(batch_data.columns))

--- a/src/fetch/protocol_fees.py
+++ b/src/fetch/protocol_fees.py
@@ -1,0 +1,25 @@
+"""Functionality for protocol fees."""
+
+from pandas import DataFrame
+
+BATCH_DATA_COLUMNS = ["solver", "protocol_fee_eth"]
+
+PROTOCOL_FEES_COLUMNS = BATCH_DATA_COLUMNS
+
+
+def compute_protocol_fees(
+    batch_data: DataFrame,
+) -> DataFrame:
+    """Compute protocol fees per solver."""
+
+    # validate batch rewards and quote rewards columns
+    assert set(BATCH_DATA_COLUMNS).issubset(set(batch_data.columns))
+
+    protocol_fees = batch_data[BATCH_DATA_COLUMNS].copy()
+
+    # change all types to object to use native python types
+    protocol_fees = protocol_fees.astype(object)
+
+    assert set(protocol_fees.columns) == set(PROTOCOL_FEES_COLUMNS)
+
+    return protocol_fees

--- a/src/fetch/protocol_fees.py
+++ b/src/fetch/protocol_fees.py
@@ -12,7 +12,7 @@ def compute_protocol_fees(
 ) -> DataFrame:
     """Compute protocol fees per solver."""
 
-    # validate batch rewards and quote rewards columns
+    # validate batch data columns
     assert set(BATCH_DATA_COLUMNS).issubset(set(batch_data.columns))
 
     protocol_fees = batch_data[BATCH_DATA_COLUMNS].copy()

--- a/src/fetch/rewards.py
+++ b/src/fetch/rewards.py
@@ -10,8 +10,8 @@ from src.logger import set_log
 
 log = set_log(__name__)
 
-BATCH_REWARDS_COLUMNS = ["solver", "primary_reward_eth"]
-QUOTE_REWARDS_COLUMNS = ["solver", "num_quotes"]
+BATCH_DATA_COLUMNS = ["solver", "primary_reward_eth"]
+QUOTE_DATA_COLUMNS = ["solver", "num_quotes"]
 
 REWARDS_COLUMNS = [
     "solver",
@@ -31,18 +31,18 @@ def compute_rewards(
     """Compute solver rewards"""
 
     # validate batch data and quote data columns
-    assert set(BATCH_REWARDS_COLUMNS).issubset(set(batch_data.columns))
-    assert set(QUOTE_REWARDS_COLUMNS).issubset(set(quote_data.columns))
+    assert set(BATCH_DATA_COLUMNS).issubset(set(batch_data.columns))
+    assert set(QUOTE_DATA_COLUMNS).issubset(set(quote_data.columns))
 
     with pd.option_context(
         "future.no_silent_downcasting", True
     ):  # remove this after Future warning disappears. We do not depend on down-casting,
         # as we will work with object and int explicitly.
         rewards = (
-            batch_data[BATCH_REWARDS_COLUMNS]
+            batch_data[BATCH_DATA_COLUMNS]
             .astype(object)
             .merge(
-                quote_data[QUOTE_REWARDS_COLUMNS].astype(object),
+                quote_data[QUOTE_DATA_COLUMNS].astype(object),
                 how="outer",
                 on="solver",
                 validate="one_to_one",

--- a/src/fetch/rewards.py
+++ b/src/fetch/rewards.py
@@ -24,15 +24,15 @@ REWARDS_COLUMNS = [
 
 def compute_rewards(
     batch_data: DataFrame,
-    quote_rewards: DataFrame,
+    quote_data: DataFrame,
     exchange_rate: Fraction,
     reward_config: RewardConfig,
 ) -> DataFrame:
     """Compute solver rewards"""
 
-    # validate batch rewards and quote rewards columns
+    # validate batch data and quote data columns
     assert set(BATCH_REWARDS_COLUMNS).issubset(set(batch_data.columns))
-    assert set(QUOTE_REWARDS_COLUMNS).issubset(set(quote_rewards.columns))
+    assert set(QUOTE_REWARDS_COLUMNS).issubset(set(quote_data.columns))
 
     with pd.option_context(
         "future.no_silent_downcasting", True
@@ -42,7 +42,7 @@ def compute_rewards(
             batch_data[BATCH_REWARDS_COLUMNS]
             .astype(object)
             .merge(
-                quote_rewards[QUOTE_REWARDS_COLUMNS].astype(object),
+                quote_data[QUOTE_REWARDS_COLUMNS].astype(object),
                 how="outer",
                 on="solver",
                 validate="one_to_one",
@@ -54,8 +54,6 @@ def compute_rewards(
         (rewards["primary_reward_eth"] * exchange_rate).apply(int).astype(object)
     )
 
-    # Pandas has poor support for large integers, must cast the constant to float here,
-    # otherwise the dtype would be inferred as int64 (which overflows).
     reward_per_quote = min(
         reward_config.quote_reward_cow,
         int(reward_config.quote_reward_cap_native * exchange_rate),

--- a/src/fetch/rewards.py
+++ b/src/fetch/rewards.py
@@ -35,19 +35,22 @@ def compute_rewards(
     batch_data : DataFrame
         Batch rewards data.
         The columns have to contain BATCH_REWARDS_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        primary_reward_eth : int
+        - primary_reward_eth : int
             Reward for settling batches in wei.
+
     quote_data : DataFrame
         Quote rewards data.
         The columns have to contain BATCH_REWARDS_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        num_quotes : int
+        - num_quotes : int
             Number of wins in the quote competition of executed orders.
+
     exchange_rate : Fraction
         Exchange rate of ETH to COW.
+
     reward_config : RewardConfig
         Reward configuration.
 
@@ -56,15 +59,15 @@ def compute_rewards(
     rewards : DataFrame
         Data frame containing rewards per solver.
         The columns are REWARDS_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        primary_reward_eth : int
+        - primary_reward_eth : int
             Reward for settling batches in wei.
-        primary_reward_cow : int
+        - primary_reward_cow : int
             Reward for settling batches in atoms of COW.
-        quote_reward_cow : int
+        - quote_reward_cow : int
             Reward for providing quotes in atoms of COW.
-        reward_token_address : str
+        - reward_token_address : str
             "0x"-prefixed hex representation of the reward token contract address.
 
     Raises

--- a/src/fetch/rewards.py
+++ b/src/fetch/rewards.py
@@ -1,0 +1,77 @@
+"""Functionality for rewards."""
+
+from fractions import Fraction
+
+import pandas as pd
+from pandas import DataFrame
+
+from src.config import RewardConfig
+from src.logger import set_log
+
+log = set_log(__name__)
+
+BATCH_REWARDS_COLUMNS = ["solver", "primary_reward_eth"]
+QUOTE_REWARDS_COLUMNS = ["solver", "num_quotes"]
+
+REWARDS_COLUMNS = [
+    "solver",
+    "primary_reward_eth",
+    "primary_reward_cow",
+    "quote_reward_cow",
+    "reward_token_address",
+]
+
+
+def compute_rewards(
+    batch_data: DataFrame,
+    quote_rewards: DataFrame,
+    exchange_rate: Fraction,
+    reward_config: RewardConfig,
+) -> DataFrame:
+    """Compute solver rewards"""
+
+    # validate batch rewards and quote rewards columns
+    assert set(BATCH_REWARDS_COLUMNS).issubset(set(batch_data.columns))
+    assert set(QUOTE_REWARDS_COLUMNS).issubset(set(quote_rewards.columns))
+
+    with pd.option_context(
+        "future.no_silent_downcasting", True
+    ):  # remove this after Future warning disappears. We do not depend on down-casting,
+        # as we will work with object and int explicitly.
+        rewards = (
+            batch_data[BATCH_REWARDS_COLUMNS]
+            .astype(object)
+            .merge(
+                quote_rewards[QUOTE_REWARDS_COLUMNS].astype(object),
+                how="outer",
+                on="solver",
+                validate="one_to_one",
+            )
+            .fillna(0)
+        ).astype(object)
+
+    rewards["primary_reward_cow"] = (
+        (rewards["primary_reward_eth"] * exchange_rate).apply(int).astype(object)
+    )
+
+    # Pandas has poor support for large integers, must cast the constant to float here,
+    # otherwise the dtype would be inferred as int64 (which overflows).
+    reward_per_quote = min(
+        reward_config.quote_reward_cow,
+        int(reward_config.quote_reward_cap_native * exchange_rate),
+    )
+    log.info(f"A reward of {reward_per_quote / 10**18:.4f} COW per quote is used.")
+
+    rewards["quote_reward_cow"] = reward_per_quote * rewards["num_quotes"].apply(
+        int
+    ).astype(object)
+    rewards = rewards.drop("num_quotes", axis=1)
+
+    rewards["reward_token_address"] = str(reward_config.reward_token_address)
+
+    # change all types to object to use native python types
+    rewards = rewards.astype(object)
+
+    assert set(rewards.columns) == set(REWARDS_COLUMNS)
+
+    return rewards

--- a/src/fetch/rewards.py
+++ b/src/fetch/rewards.py
@@ -28,7 +28,56 @@ def compute_rewards(
     exchange_rate: Fraction,
     reward_config: RewardConfig,
 ) -> DataFrame:
-    """Compute solver rewards"""
+    """Compute solver rewards.
+
+    Parameters
+    ----------
+    batch_data : DataFrame
+        Batch rewards data.
+        The columns have to contain BATCH_REWARDS_COLUMNS:
+        solver : str
+            "0x"-prefixed hex representation of the submission address of a solver.
+        primary_reward_eth : int
+            Reward for settling batches in wei.
+    quote_data : DataFrame
+        Quote rewards data.
+        The columns have to contain BATCH_REWARDS_COLUMNS:
+        solver : str
+            "0x"-prefixed hex representation of the submission address of a solver.
+        num_quotes : int
+            Number of wins in the quote competition of executed orders.
+    exchange_rate : Fraction
+        Exchange rate of ETH to COW.
+    reward_config : RewardConfig
+        Reward configuration.
+
+    Returns
+    -------
+    rewards : DataFrame
+        Data frame containing rewards per solver.
+        The columns are REWARDS_COLUMNS:
+        solver : str
+            "0x"-prefixed hex representation of the submission address of a solver.
+        primary_reward_eth : int
+            Reward for settling batches in wei.
+        primary_reward_cow : int
+            Reward for settling batches in atoms of COW.
+        quote_reward_cow : int
+            Reward for providing quotes in atoms of COW.
+        reward_token_address : str
+            "0x"-prefixed hex representation of the reward token contract address.
+
+    Raises
+    ------
+    AssertionError
+        If input dataframes do not contain required columns or if the result does not have correct
+        columns.
+
+    Notes
+    -----
+    All data frames are set to have data type `object`. Otherwise, implicit conversion to int64 can
+    lead to overflows.
+    """
 
     # validate batch data and quote data columns
     assert set(BATCH_DATA_COLUMNS).issubset(set(batch_data.columns))

--- a/src/fetch/solver_info.py
+++ b/src/fetch/solver_info.py
@@ -49,7 +49,7 @@ def compute_solver_info(
         - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
         - service_fee : bool
-            True if a solver needs to pay a service fee to the COW DAO. Otherwise, it is False.
+            True if a solver needs to pay a service fee to the CoW DAO. Otherwise, it is False.
 
     config : AccountingConfig
         Accounting configuration.
@@ -71,7 +71,7 @@ def compute_solver_info(
             Results of the buffer accounting are sent to this address. It is equal to `solver` or
             `reward_target`.
         - service_fee : Fraction
-            The fraction of rewards which need to be paid to the COW DAO.
+            The fraction of rewards which need to be paid to the CoW DAO.
 
     Raises
     ------

--- a/src/fetch/solver_info.py
+++ b/src/fetch/solver_info.py
@@ -54,7 +54,7 @@ def compute_solver_info(
 
     Returns
     -------
-    rewards : DataFrame
+    solver_info : DataFrame
         Data frame containing required information per solver.
         The columns are SOLVER_INFO_COLUMNS:
         solver : str

--- a/src/fetch/solver_info.py
+++ b/src/fetch/solver_info.py
@@ -26,7 +26,62 @@ def compute_solver_info(
     service_fees: DataFrame,
     config: AccountingConfig,
 ) -> DataFrame:
-    """Compute solver information"""
+    """Compute solver info.
+
+    Parameters
+    ----------
+    reward_targets : DataFrame
+        Data on reward targets and bonding pools.
+        The columns have to contain REWARD_TARGETS_COLUMNS:
+        solver : str
+            "0x"-prefixed hex representation of the submission address of a solver.
+        reward_target : str
+            "0x"-prefixed hex representation of the reward target of a solver. All rewards are sent
+            to this address.
+        pool_address: str
+            "0x"-prefixed hex representation of address of a solvers bonding pool.
+        solver_name: str
+            Name of a solver.
+    service_fees : DataFrame
+        Service fee data.
+        The columns have to contain SERVICE_FEES_COLUMNS:
+        solver : str
+            "0x"-prefixed hex representation of the submission address of a solver.
+        service_fee : bool
+            True is a solver needs to pay a service fee to the COW DAO. Otherwise, it is False.
+    config : AccountingConfig
+        Accounting configuration.
+
+    Returns
+    -------
+    rewards : DataFrame
+        Data frame containing required information per solver.
+        The columns are SOLVER_INFO_COLUMNS:
+        solver : str
+            "0x"-prefixed hex representation of the submission address of a solver.
+        solver_name : str
+            Name of a solver.
+        reward_target : str
+            "0x"-prefixed hex representation of the reward target of a solver. All
+            rewards are sent to this address.
+        buffer_accounting_target : str
+            "0x"-prefixed hex representation of the buffer accounting target address of a solver.
+            Results of the buffer accounting are sent to this address. It is equal to `solver` or
+            `reward_target`.
+        service_fee : Fraction
+            The fraction of rewards which need to be paid to the COW DAO.
+
+    Raises
+    ------
+    AssertionError
+        If input dataframes do not contain required columns or if the result does not have correct
+        columns.
+
+    Notes
+    -----
+    All data frames are set to have data type `object`. Otherwise, implicit conversion to int64 can
+    lead to overflows.
+    """
 
     # validate reward targets and service fees columns
     assert set(REWARD_TARGETS_COLUMNS).issubset(set(reward_targets.columns))

--- a/src/fetch/solver_info.py
+++ b/src/fetch/solver_info.py
@@ -33,22 +33,24 @@ def compute_solver_info(
     reward_targets : DataFrame
         Data on reward targets and bonding pools.
         The columns have to contain REWARD_TARGETS_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        reward_target : str
+        - reward_target : str
             "0x"-prefixed hex representation of the reward target of a solver. All rewards are sent
             to this address.
-        pool_address: str
+        - pool_address: str
             "0x"-prefixed hex representation of address of a solvers bonding pool.
-        solver_name: str
+        - solver_name: str
             Name of a solver.
+
     service_fees : DataFrame
         Service fee data.
         The columns have to contain SERVICE_FEES_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        service_fee : bool
-            True is a solver needs to pay a service fee to the COW DAO. Otherwise, it is False.
+        - service_fee : bool
+            True if a solver needs to pay a service fee to the COW DAO. Otherwise, it is False.
+
     config : AccountingConfig
         Accounting configuration.
 
@@ -57,18 +59,18 @@ def compute_solver_info(
     solver_info : DataFrame
         Data frame containing required information per solver.
         The columns are SOLVER_INFO_COLUMNS:
-        solver : str
+        - solver : str
             "0x"-prefixed hex representation of the submission address of a solver.
-        solver_name : str
+        - solver_name : str
             Name of a solver.
-        reward_target : str
+        - reward_target : str
             "0x"-prefixed hex representation of the reward target of a solver. All
             rewards are sent to this address.
-        buffer_accounting_target : str
+        - buffer_accounting_target : str
             "0x"-prefixed hex representation of the buffer accounting target address of a solver.
             Results of the buffer accounting are sent to this address. It is equal to `solver` or
             `reward_target`.
-        service_fee : Fraction
+        - service_fee : Fraction
             The fraction of rewards which need to be paid to the COW DAO.
 
     Raises

--- a/src/fetch/solver_info.py
+++ b/src/fetch/solver_info.py
@@ -1,0 +1,64 @@
+"""Functionality for solver information."""
+
+import numpy as np
+import pandas as pd
+from pandas import DataFrame
+
+from src.config import AccountingConfig
+from src.logger import set_log
+
+log = set_log(__name__)
+
+REWARD_TARGETS_COLUMNS = ["solver", "reward_target", "pool_address", "solver_name"]
+SERVICE_FEES_COLUMNS = ["solver", "service_fee"]
+
+SOLVER_INFO_COLUMNS = [
+    "solver",
+    "solver_name",
+    "reward_target",
+    "buffer_accounting_target",
+    "service_fee",
+]
+
+
+def compute_solver_info(
+    reward_targets: DataFrame,
+    service_fees: DataFrame,
+    config: AccountingConfig,
+) -> DataFrame:
+    """Compute solver information"""
+
+    # validate reward targets and service fees columns
+    assert set(REWARD_TARGETS_COLUMNS).issubset(set(reward_targets.columns))
+    assert set(SERVICE_FEES_COLUMNS).issubset(set(service_fees.columns))
+
+    solver_info = reward_targets[REWARD_TARGETS_COLUMNS].merge(
+        service_fees[SERVICE_FEES_COLUMNS], how="outer", on="solver"
+    )
+
+    solver_info["buffer_accounting_target"] = np.where(
+        solver_info["pool_address"] != config.reward_config.cow_bonding_pool.address,
+        solver_info["solver"],
+        solver_info["reward_target"],
+    )
+    solver_info = solver_info.drop("pool_address", axis=1)
+
+    solver_info["service_fee"] = [
+        (
+            service_fees_flag * config.reward_config.service_fee_factor
+            if not pd.isna(service_fees_flag)
+            else 0 * config.reward_config.service_fee_factor
+        )
+        for service_fees_flag in solver_info["service_fee"]
+    ]
+
+    if not solver_info["solver"].is_unique:
+        duplicate_solvers = solver_info[solver_info["solver"].duplicated(keep=False)]
+        log.warning(f"Duplicate solvers: {duplicate_solvers}. Choosing first entry.")
+        solver_info = solver_info.drop_duplicates(subset=["solver"])
+
+    solver_info = solver_info.astype(object)
+
+    assert set(solver_info.columns) == set(SOLVER_INFO_COLUMNS)
+
+    return solver_info

--- a/tests/unit/test_buffer_accounting.py
+++ b/tests/unit/test_buffer_accounting.py
@@ -1,0 +1,83 @@
+import pytest
+import pandas
+from pandas import DataFrame
+
+from src.fetch.buffer_accounting import compute_buffer_accounting
+
+
+def test_compute_buffer_accounting():
+    """Test buffer accounting computation"""
+    batch_data = DataFrame(
+        {
+            "solver": ["solver_1", "solver_2"],
+            "network_fee_eth": [10**15, 10**16],
+        }
+    )
+    slippage_data = DataFrame(
+        {
+            "solver": ["solver_2", "solver_3"],
+            "eth_slippage_wei": [10**17, 10**18],
+        }
+    )
+
+    buffer_accounting = compute_buffer_accounting(batch_data, slippage_data)
+    expected_buffer_accounting = DataFrame(
+        {
+            "solver": ["solver_1", "solver_2", "solver_3"],
+            "network_fee_eth": [10**15, 10**16, 0],
+            "slippage_eth": [0, 10**17, 10**18],
+        }
+    ).astype(object)
+
+    pandas.testing.assert_frame_equal(buffer_accounting, expected_buffer_accounting)
+
+
+def test_compute_buffer_accounting_empty():
+    """Test that code also works for empty data."""
+    batch_data = DataFrame(
+        {
+            "solver": [],
+            "network_fee_eth": [],
+        }
+    )
+    slippage_data = DataFrame(
+        {
+            "solver": [],
+            "eth_slippage_wei": [],
+        }
+    )
+
+    buffer_accounting = compute_buffer_accounting(batch_data, slippage_data)
+    expected_buffer_accounting = DataFrame(
+        {
+            "solver": [],
+            "network_fee_eth": [],
+            "slippage_eth": [],
+        }
+    ).astype(object)
+
+    pandas.testing.assert_frame_equal(buffer_accounting, expected_buffer_accounting)
+
+
+def test_compute_protocol_fees_wrong_columns():
+    """Test column validation"""
+    legit_batch_data = DataFrame(
+        {
+            "solver": [],
+            "network_fee_eth": [],
+        }
+    )
+    legit_slippage_data = DataFrame(
+        {
+            "solver": [],
+            "eth_slippage_wei": [],
+        }
+    )
+
+    wrong_columns = DataFrame({"wrong_column": []})
+
+    with pytest.raises(AssertionError):
+        compute_buffer_accounting(wrong_columns, legit_slippage_data)
+
+    with pytest.raises(AssertionError):
+        compute_buffer_accounting(legit_batch_data, wrong_columns)

--- a/tests/unit/test_partner_fees.py
+++ b/tests/unit/test_partner_fees.py
@@ -1,0 +1,108 @@
+import pytest
+import pandas
+from pandas import DataFrame
+
+from src.config import ProtocolFeeConfig, Network
+from src.fetch.partner_fees import (
+    compute_partner_fees,
+    compute_partner_fees_per_partner,
+)
+
+
+def test_compute_partner_fees_per_partner():
+    """Test partner fees computation"""
+    config = ProtocolFeeConfig.from_network(Network.MAINNET)
+    partner_fee_lists = DataFrame(
+        {
+            "partner_list": [["partner_1", "partner_2"], ["partner_2", "partner_3"]],
+            "partner_fee_eth": [[10**16, 10**17], [10**18, 10**19]],
+        }
+    )
+
+    partner_fees_df = compute_partner_fees_per_partner(partner_fee_lists, config)
+    expected_protocol_fees_df = DataFrame(
+        {
+            "partner": ["partner_1", "partner_2", "partner_3"],
+            "partner_fee_eth": [10**16, 10**17 + 10**18, 10**19],
+            "partner_fee_tax": [0.15, 0.15, 0.15],
+        }
+    ).astype(object)
+
+    pandas.testing.assert_frame_equal(partner_fees_df, expected_protocol_fees_df)
+
+
+def test_compute_partner_fees_per_partner_empty():
+    """Test that code also works for empty data."""
+    config = ProtocolFeeConfig.from_network(Network.MAINNET)
+    partner_fee_lists = DataFrame(
+        {
+            "partner_list": [],
+            "partner_fee_eth": [],
+        }
+    )
+
+    partner_fees_df = compute_partner_fees_per_partner(partner_fee_lists, config)
+    expected_protocol_fees_df = DataFrame(
+        {
+            "partner": [],
+            "partner_fee_eth": [],
+            "partner_fee_tax": [],
+        }
+    ).astype(object)
+
+    pandas.testing.assert_frame_equal(partner_fees_df, expected_protocol_fees_df)
+
+
+def test_compute_partner_fees_per_partner_reduced_cut():
+    """Test reduced cut."""
+    config = ProtocolFeeConfig.from_network(Network.MAINNET)
+    partner_fee_lists = DataFrame(
+        {
+            "partner_list": [[config.reduced_cut_address]],
+            "partner_fee_eth": [[10**18]],
+        }
+    )
+
+    partner_fees_df = compute_partner_fees_per_partner(partner_fee_lists, config)
+    expected_protocol_fees_df = DataFrame(
+        {
+            "partner": [config.reduced_cut_address],
+            "partner_fee_eth": [10**18],
+            "partner_fee_tax": [config.partner_fee_reduced_cut],
+        }
+    ).astype(object)
+
+    pandas.testing.assert_frame_equal(partner_fees_df, expected_protocol_fees_df)
+
+
+def test_compute_partner_fees_per_partner_duplicates():
+    """Test that code also works for duplicate partner on one solver.
+    This is required due to how data is merged if a solver is participating in prod and barn.
+    """
+    partner_fee_lists = DataFrame(
+        {
+            "partner_list": [["partner_1", "partner_1"]],
+            "partner_fee_eth": [[10**17, 10**18]],
+        }
+    )
+    config = ProtocolFeeConfig.from_network(Network.MAINNET)
+
+    partner_fees_df = compute_partner_fees_per_partner(partner_fee_lists, config)
+    expected_protocol_fees_df = DataFrame(
+        {
+            "partner": ["partner_1"],
+            "partner_fee_eth": [10**17 + 10**18],
+            "partner_fee_tax": [0.15],
+        }
+    ).astype(object)
+
+    pandas.testing.assert_frame_equal(partner_fees_df, expected_protocol_fees_df)
+
+
+def test_compute_partner_fees_wrong_columns():
+    """Test column validation"""
+    config = ProtocolFeeConfig.from_network(Network.MAINNET)
+    wrong_columns = DataFrame({"wrong_column": []})
+
+    with pytest.raises(AssertionError):
+        compute_partner_fees(wrong_columns, config)

--- a/tests/unit/test_payouts.py
+++ b/tests/unit/test_payouts.py
@@ -180,7 +180,7 @@ def test_compute_solver_payouts_defaults():
             ],
             "reward_target": [
                 None,
-                "reward_target_2",  # solver 2 gets rewards and also needs to have a reward target
+                "reward_target_2",
                 None,
                 None,
             ],
@@ -200,11 +200,15 @@ def test_compute_solver_payouts_defaults():
     )
     rewards = DataFrame(
         {
-            "solver": ["solver_2"],
-            "primary_reward_eth": [10**16],
-            "primary_reward_cow": [10**19],
-            "quote_reward_cow": [10**20],
-            "reward_token_address": ["cow_token_address"],
+            "solver": ["solver_2", "solver_3", "solver_4"],
+            "primary_reward_eth": [10**16, -(10**15), None],
+            "primary_reward_cow": [10**19, -(10**18), None],
+            "quote_reward_cow": [10**20, None, 10**16],
+            "reward_token_address": [
+                "cow_token_address",
+                "cow_token_address",
+                "cow_token_address",
+            ],
         }
     ).astype(object)
     protocol_fees = DataFrame(
@@ -229,9 +233,9 @@ def test_compute_solver_payouts_defaults():
                 "solver_name_3",
                 "solver_name_4",
             ],
-            "primary_reward_eth": [10**16, 0, 0],
-            "primary_reward_cow": [10**19, 0, 0],
-            "quote_reward_cow": [10**20, 0, 0],
+            "primary_reward_eth": [10**16, -(10**15), 0],
+            "primary_reward_cow": [10**19, -(10**18), 0],
+            "quote_reward_cow": [10**20, 0, 10**16],
             "protocol_fee_eth": [0, 10**14, 0],
             "network_fee_eth": [0, 0, 10**13],
             "slippage_eth": [0, 0, 10**12],
@@ -247,8 +251,8 @@ def test_compute_solver_payouts_defaults():
             ],
             "reward_token_address": [
                 "cow_token_address",
-                "0x0000000000000000000000000000000000000001",  # dummy default
-                "0x0000000000000000000000000000000000000001",
+                "cow_token_address",
+                "cow_token_address",
             ],
             "service_fee": [
                 Fraction(11, 100),

--- a/tests/unit/test_payouts.py
+++ b/tests/unit/test_payouts.py
@@ -1,19 +1,23 @@
-import unittest
 from fractions import Fraction
 
+import pytest
 import pandas
 from dune_client.types import Address
 from pandas import DataFrame
 
 from src.config import AccountingConfig, Network
 from src.fetch.payouts import (
-    extend_payment_df,
+    compute_solver_payouts,
+    compute_partner_payouts,
     normalize_address_field,
     validate_df_columns,
-    construct_payout_dataframe,
-    TokenConversion,
-    prepare_transfers,
+    prepare_payouts,
     RewardAndPenaltyDatum,
+    SOLVER_PAYOUTS_COLUMNS,
+    SOLVER_INFO_COLUMNS,
+    REWARDS_COLUMNS,
+    PROTOCOL_FEES_COLUMNS,
+    BUFFER_ACCOUNTING_COLUMNS,
 )
 from src.models.accounting_period import AccountingPeriod
 from src.models.overdraft import Overdraft
@@ -21,727 +25,871 @@ from src.models.token import Token
 from src.models.transfer import Transfer
 
 
-class TestPayoutTransformations(unittest.TestCase):
-    """Contains tests all stray methods in src/fetch/payouts.py"""
+def test_normalize_address_field():
+    # lower case value
+    column = "aDdReSs"
+    value = "AbCd"
 
-    def setUp(self) -> None:
-        self.config = AccountingConfig.from_network(Network.MAINNET)
-        self.solvers = list(
-            map(
-                str,
-                [
-                    Address.from_int(1),
-                    Address.from_int(2),
-                    Address.from_int(3),
-                    Address.from_int(4),
-                ],
-            )
-        )
-        self.num_quotes = [0, 0, 10, 20]
-        self.reward_targets = list(
-            map(
-                str,
-                [
-                    Address.from_int(5),
-                    Address.from_int(6),
-                    Address.from_int(7),
-                    Address.from_int(8),
-                ],
-            )
-        )
-        self.pool_addresses = list(
-            map(
-                str,
-                [
-                    self.config.reward_config.cow_bonding_pool,
-                    Address.from_int(10),
-                    Address.from_int(11),
-                    Address.from_int(12),
-                ],
-            )
-        )
-        self.service_fee = [
-            Fraction(0, 100),
-            Fraction(0, 100),
-            Fraction(0, 100),
-            Fraction(15, 100),
-        ]
+    test_df = DataFrame({column: [value]})
+    normalize_address_field(test_df, column)
+    pandas.testing.assert_frame_equal(test_df, DataFrame({column: [value.lower()]}))
 
-        self.primary_reward_eth = [
-            600000000000000.00000,
-            12000000000000000.00000,
-            -10000000000000000.00000,
-            0.00000,
-        ]
+    # no rows in dataframe
+    test_df = DataFrame({column: []})
+    normalize_address_field(test_df, column)
+    pandas.testing.assert_frame_equal(test_df, DataFrame({column: []}))
 
-        self.protocol_fee_eth = [
-            1000000000000000.0,
-            2000000000000000.0,
-            0.0,
-            0.0,
-        ]
-        self.network_fee_eth = [
-            2000000000000000.0,
-            4000000000000000.0,
-            0.0,
-            0.0,
-        ]
-        # Mocking TokenConversion!
-        self.mock_converter = TokenConversion(eth_to_token=lambda t: int(t * 1000))
 
-    def test_extend_payment_df(self):
-        base_data_dict = {
-            "solver": self.solvers,
-            "num_quotes": self.num_quotes,
-            "primary_reward_eth": self.primary_reward_eth,
-            "protocol_fee_eth": self.protocol_fee_eth,
-            "network_fee_eth": self.network_fee_eth,
+def test_validate_df_columns():
+    legit_solver_info = DataFrame(
+        {
+            "solver": [],
+            "reward_target": [],
+            "buffer_accounting_target": [],
+            "solver_name": [],
+            "service_fee": [],
         }
-        base_payout_df = DataFrame(base_data_dict)
-        result = extend_payment_df(
-            base_payout_df, converter=self.mock_converter, config=self.config
+    )
+    legit_rewards = DataFrame(
+        {
+            "solver": [],
+            "primary_reward_eth": [],
+            "primary_reward_cow": [],
+            "quote_reward_cow": [],
+            "reward_token_address": [],
+        }
+    )
+    legit_protocol_fees = DataFrame({"solver": [], "protocol_fee_eth": []})
+    legit_buffer_accounting = DataFrame(
+        {"solver": [], "network_fee_eth": [], "slippage_eth": []}
+    )
+
+    failing_df = DataFrame({})
+
+    with pytest.raises(AssertionError):
+        validate_df_columns(
+            solver_info=legit_solver_info,
+            rewards=legit_rewards,
+            protocol_fees=legit_protocol_fees,
+            buffer_accounting=failing_df,
         )
-        expected_data_dict = {
-            "solver": self.solvers,
-            "num_quotes": self.num_quotes,
-            "primary_reward_eth": [
-                600000000000000.00000,
-                12000000000000000.00000,
-                -10000000000000000.00000,
-                0.00000,
+    with pytest.raises(AssertionError):
+        validate_df_columns(
+            solver_info=legit_solver_info,
+            rewards=legit_rewards,
+            protocol_fees=failing_df,
+            buffer_accounting=legit_buffer_accounting,
+        )
+    with pytest.raises(AssertionError):
+        validate_df_columns(
+            solver_info=legit_solver_info,
+            rewards=failing_df,
+            protocol_fees=legit_protocol_fees,
+            buffer_accounting=legit_buffer_accounting,
+        )
+    with pytest.raises(AssertionError):
+        validate_df_columns(
+            solver_info=failing_df,
+            rewards=legit_rewards,
+            protocol_fees=legit_protocol_fees,
+            buffer_accounting=legit_buffer_accounting,
+        )
+
+    validate_df_columns(
+        solver_info=legit_solver_info,
+        rewards=legit_rewards,
+        protocol_fees=legit_protocol_fees,
+        buffer_accounting=legit_buffer_accounting,
+    )
+
+
+def test_compute_solver_payouts_empty():
+    solver_info = DataFrame(
+        {
+            "solver": [],
+            "reward_target": [],
+            "buffer_accounting_target": [],
+            "solver_name": [],
+            "service_fee": [],
+        }
+    )
+    rewards = DataFrame(
+        {
+            "solver": [],
+            "primary_reward_eth": [],
+            "primary_reward_cow": [],
+            "quote_reward_cow": [],
+            "reward_token_address": [],
+        }
+    )
+    protocol_fees = DataFrame({"solver": [], "protocol_fee_eth": []})
+    buffer_accounting = DataFrame(
+        {"solver": [], "network_fee_eth": [], "slippage_eth": []}
+    )
+
+    solver_payouts = compute_solver_payouts(
+        solver_info, rewards, protocol_fees, buffer_accounting
+    )
+    expected_solver_payouts = DataFrame(
+        {column: [] for column in SOLVER_PAYOUTS_COLUMNS}
+    )
+
+    pandas.testing.assert_frame_equal(solver_payouts, expected_solver_payouts)
+
+
+def test_compute_solver_payouts():
+    payouts_data = DataFrame(
+        {
+            "solver": ["solver_1"],
+            "reward_target": ["reward_target_1"],
+            "buffer_accounting_target": ["buffer_target_1"],
+            "solver_name": ["solver_name_1"],
+            "service_fee": [Fraction(11, 100)],
+            "primary_reward_eth": [10**16],
+            "primary_reward_cow": [10**19],
+            "quote_reward_cow": [10**20],
+            "reward_token_address": ["cow_token_address"],
+            "protocol_fee_eth": [10**14],
+            "network_fee_eth": [10**13],
+            "slippage_eth": [10**12],
+        }
+    )
+    solver_info = payouts_data[SOLVER_INFO_COLUMNS]
+    rewards = payouts_data[REWARDS_COLUMNS]
+    protocol_fees = payouts_data[PROTOCOL_FEES_COLUMNS]
+    buffer_accounting = payouts_data[BUFFER_ACCOUNTING_COLUMNS]
+
+    solver_payouts = compute_solver_payouts(
+        solver_info, rewards, protocol_fees, buffer_accounting
+    )
+    expected_solver_payouts = payouts_data[SOLVER_PAYOUTS_COLUMNS]
+
+    pandas.testing.assert_frame_equal(solver_payouts, expected_solver_payouts)
+
+
+def test_compute_solver_payouts_defaults():
+    """Test default values when some information is missing after joins."""
+    solver_info = DataFrame(
+        {
+            "solver": ["solver_1", "solver_2", "solver_3", "solver_4"],
+            "solver_name": [  # all solvers need a name at the moment
+                "solver_name_1",
+                "solver_name_2",
+                "solver_name_3",
+                "solver_name_4",
             ],
-            "protocol_fee_eth": self.protocol_fee_eth,
-            "network_fee_eth": self.network_fee_eth,
-            "primary_reward_cow": [
-                600000000000000000.0,
-                12000000000000000000.0,
-                -10000000000000000000.0,
-                0.0,
+            "reward_target": [
+                None,
+                "reward_target_2",  # solver 2 gets rewards and also needs to have a reward target
+                None,
+                None,
             ],
-            "quote_reward_cow": [
-                0.00000,
-                0.00000,
-                6000000000000000000.00000,
-                12000000000000000000.00000,
+            "buffer_accounting_target": [
+                None,
+                None,
+                None,
+                "buffer_target_4",  # solver 4 gets slippage so they need to have a buffer target
+            ],
+            "service_fee": [
+                None,
+                Fraction(11, 100),
+                None,
+                None,
             ],
         }
-        expected = DataFrame(expected_data_dict)
-        self.assertEqual(set(result.columns), set(expected.columns))
-        self.assertIsNone(pandas.testing.assert_frame_equal(expected, result))
+    )
+    rewards = DataFrame(
+        {
+            "solver": ["solver_2"],
+            "primary_reward_eth": [10**16],
+            "primary_reward_cow": [10**19],
+            "quote_reward_cow": [10**20],
+            "reward_token_address": ["cow_token_address"],
+        }
+    )
+    protocol_fees = DataFrame({"solver": ["solver_3"], "protocol_fee_eth": [10**14]})
+    buffer_accounting = DataFrame(
+        {
+            "solver": ["solver_4"],
+            "network_fee_eth": [10**13],
+            "slippage_eth": [10**12],
+        }
+    )
 
-    def test_normalize_address_field(self):
-        column = "address"
-        value = "AbCd"
+    solver_payouts = compute_solver_payouts(
+        solver_info, rewards, protocol_fees, buffer_accounting
+    )
+    expected_solver_payouts = DataFrame(
+        {
+            "solver": ["solver_2", "solver_3", "solver_4"],
+            "solver_name": [
+                "solver_name_2",
+                "solver_name_3",
+                "solver_name_4",
+            ],
+            "primary_reward_eth": [10**16, 0, 0],
+            "primary_reward_cow": [10**19, 0, 0],
+            "quote_reward_cow": [10**20, 0, 0],
+            "protocol_fee_eth": [0, 10**14, 0],
+            "network_fee_eth": [0, 0, 10**13],
+            "slippage_eth": [0, 0, 10**12],
+            "reward_target": [
+                "reward_target_2",  # solver 2 gets rewards and also needs to have a reward target
+                None,
+                None,
+            ],
+            "buffer_accounting_target": [
+                None,
+                None,
+                "buffer_target_4",  # solver 4 gets slippage so they need to have a buffer target
+            ],
+            "reward_token_address": ["cow_token_address", None, None],
+            "service_fee": [
+                Fraction(11, 100),
+                Fraction(0, 1),
+                Fraction(0, 1),
+            ],
+        }
+    )
 
-        test_df = DataFrame({column: [value]})
-        normalize_address_field(test_df, column)
-        self.assertIsNone(
-            pandas.testing.assert_frame_equal(
-                test_df, DataFrame({column: [value.lower()]})
-            )
+    pandas.testing.assert_frame_equal(solver_payouts, expected_solver_payouts)
+
+
+# class TestPayoutTransformations(unittest.TestCase):
+#     """Contains tests all stray methods in src/fetch/payouts.py"""
+#
+#     def setUp(self) -> None:
+#         self.config = AccountingConfig.from_network(Network.MAINNET)
+#         self.solvers = list(
+#             map(
+#                 str,
+#                 [
+#                     Address.from_int(1),
+#                     Address.from_int(2),
+#                     Address.from_int(3),
+#                     Address.from_int(4),
+#                 ],
+#             )
+#         )
+#         self.num_quotes = [0, 0, 10, 20]
+#         self.reward_targets = list(
+#             map(
+#                 str,
+#                 [
+#                     Address.from_int(5),
+#                     Address.from_int(6),
+#                     Address.from_int(7),
+#                     Address.from_int(8),
+#                 ],
+#             )
+#         )
+#         self.pool_addresses = list(
+#             map(
+#                 str,
+#                 [
+#                     self.config.reward_config.cow_bonding_pool,
+#                     Address.from_int(10),
+#                     Address.from_int(11),
+#                     Address.from_int(12),
+#                 ],
+#             )
+#         )
+#         self.service_fee = [
+#             Fraction(0, 100),
+#             Fraction(0, 100),
+#             Fraction(0, 100),
+#             Fraction(15, 100),
+#         ]
+#
+#         self.primary_reward_eth = [
+#             600000000000000.00000,
+#             12000000000000000.00000,
+#             -10000000000000000.00000,
+#             0.00000,
+#         ]
+#
+#         self.protocol_fee_eth = [
+#             1000000000000000.0,
+#             2000000000000000.0,
+#             0.0,
+#             0.0,
+#         ]
+#         self.network_fee_eth = [
+#             2000000000000000.0,
+#             4000000000000000.0,
+#             0.0,
+#             0.0,
+#         ]
+#         # Mocking TokenConversion!
+#         self.mock_converter = TokenConversion(eth_to_token=lambda t: int(t * 1000))
+#
+#     def test_extend_payment_df(self):
+#         base_data_dict = {
+#             "solver": self.solvers,
+#             "num_quotes": self.num_quotes,
+#             "primary_reward_eth": self.primary_reward_eth,
+#             "protocol_fee_eth": self.protocol_fee_eth,
+#             "network_fee_eth": self.network_fee_eth,
+#         }
+#         base_payout_df = DataFrame(base_data_dict)
+#         result = extend_payment_df(
+#             base_payout_df, converter=self.mock_converter, config=self.config
+#         )
+#         expected_data_dict = {
+#             "solver": self.solvers,
+#             "num_quotes": self.num_quotes,
+#             "primary_reward_eth": [
+#                 600000000000000.00000,
+#                 12000000000000000.00000,
+#                 -10000000000000000.00000,
+#                 0.00000,
+#             ],
+#             "protocol_fee_eth": self.protocol_fee_eth,
+#             "network_fee_eth": self.network_fee_eth,
+#             "primary_reward_cow": [
+#                 600000000000000000.0,
+#                 12000000000000000000.0,
+#                 -10000000000000000000.0,
+#                 0.0,
+#             ],
+#             "quote_reward_cow": [
+#                 0.00000,
+#                 0.00000,
+#                 6000000000000000000.00000,
+#                 12000000000000000000.00000,
+#             ],
+#         }
+#         expected = DataFrame(expected_data_dict)
+#         self.assertEqual(set(result.columns), set(expected.columns))
+#         self.assertIsNone(pandas.testing.assert_frame_equal(expected, result))
+#
+#
+#
+#     def test_construct_payouts(self):
+#         payments = extend_payment_df(
+#             pdf=DataFrame(
+#                 {
+#                     "solver": self.solvers,
+#                     "num_quotes": self.num_quotes,
+#                     "primary_reward_eth": self.primary_reward_eth,
+#                     "protocol_fee_eth": self.protocol_fee_eth,
+#                     "network_fee_eth": self.network_fee_eth,
+#                 }
+#             ),
+#             converter=self.mock_converter,
+#             config=self.config,
+#         )
+#
+#         slippages = DataFrame(
+#             {
+#                 "solver": self.solvers[:3],
+#                 # Note that one of the solvers did not appear,
+#                 # in this list (we are testing the left join)
+#                 "eth_slippage_wei": [1, 0, -1],
+#             }
+#         )
+#
+#         reward_targets = DataFrame(
+#             {
+#                 "solver": self.solvers,
+#                 "solver_name": ["S_1", "S_2", "S_3", "S_4"],
+#                 "reward_target": self.reward_targets,
+#                 "pool_address": self.pool_addresses,
+#             }
+#         )
+#
+#         service_fee_df = DataFrame(
+#             {"solver": self.solvers, "service_fee": self.service_fee}
+#         )
+#
+#         result = construct_payout_dataframe(
+#             payment_df=payments,
+#             slippage_df=slippages,
+#             reward_target_df=reward_targets,
+#             service_fee_df=service_fee_df,
+#             config=self.config,
+#         )
+#         expected = DataFrame(
+#             {
+#                 "buffer_accounting_target": [
+#                     "0x0000000000000000000000000000000000000005",
+#                     str(self.solvers[1]),
+#                     str(self.solvers[2]),
+#                     str(self.solvers[3]),
+#                 ],
+#                 "eth_slippage_wei": [2000000000000001.0, 4000000000000000.0, -1.0, 0.0],
+#                 "network_fee_eth": [
+#                     2000000000000000.0,
+#                     4000000000000000.0,
+#                     0.0,
+#                     0.0,
+#                 ],
+#                 "pool_address": [
+#                     str(self.config.reward_config.cow_bonding_pool),
+#                     "0x0000000000000000000000000000000000000010",
+#                     "0x0000000000000000000000000000000000000011",
+#                     "0x0000000000000000000000000000000000000012",
+#                 ],
+#                 "primary_reward_cow": [
+#                     600000000000000000.0,
+#                     12000000000000000000.0,
+#                     -10000000000000000000.0,
+#                     0.0,
+#                 ],
+#                 "primary_reward_eth": [600000000000000.0, 1.2e16, -1e16, 0.0],
+#                 "protocol_fee_eth": [
+#                     1000000000000000.0,
+#                     2000000000000000.0,
+#                     0.0,
+#                     0.0,
+#                 ],
+#                 "quote_reward_cow": [
+#                     0.00000,
+#                     0.00000,
+#                     6000000000000000000.00000,
+#                     12000000000000000000.00000,
+#                 ],
+#                 "reward_target": [
+#                     "0x0000000000000000000000000000000000000005",
+#                     "0x0000000000000000000000000000000000000006",
+#                     "0x0000000000000000000000000000000000000007",
+#                     "0x0000000000000000000000000000000000000008",
+#                 ],
+#                 "reward_token_address": [
+#                     str(self.config.reward_config.reward_token_address),
+#                     str(self.config.reward_config.reward_token_address),
+#                     str(self.config.reward_config.reward_token_address),
+#                     str(self.config.reward_config.reward_token_address),
+#                 ],
+#                 "service_fee": [
+#                     Fraction(0, 100),
+#                     Fraction(0, 100),
+#                     Fraction(0, 100),
+#                     Fraction(15, 100),
+#                 ],
+#                 "solver": self.solvers,
+#                 "solver_name": ["S_1", "S_2", "S_3", "S_4"],
+#             }
+#         )
+#
+#         self.assertIsNone(
+#             pandas.testing.assert_frame_equal(
+#                 expected, result.reindex(sorted(result.columns), axis=1)
+#             )
+#         )
+#
+#     def test_prepare_transfers(self):
+#         # Need Example of every possible scenario
+#         full_payout_data = DataFrame(
+#             {
+#                 "solver": self.solvers,
+#                 "num_quotes": self.num_quotes,
+#                 "primary_reward_eth": [600000000000000.0, 1.2e16, -1e16, 0.0],
+#                 "protocol_fee_eth": self.protocol_fee_eth,
+#                 "network_fee_eth": [100.0, 200.0, 300.0, 0.0],
+#                 "primary_reward_cow": [
+#                     600000000000000000.0,
+#                     12000000000000000000.0,
+#                     -10000000000000000000.0,
+#                     0.0,
+#                 ],
+#                 "quote_reward_cow": [
+#                     0.00000,
+#                     0.00000,
+#                     90000000000000000000.00000,
+#                     180000000000000000000.00000,
+#                 ],
+#                 "solver_name": ["S_1", "S_2", "S_3", None],
+#                 "eth_slippage_wei": [1.0, 0.0, -1.0, None],
+#                 "reward_target": [
+#                     "0x0000000000000000000000000000000000000005",
+#                     "0x0000000000000000000000000000000000000006",
+#                     "0x0000000000000000000000000000000000000007",
+#                     "0x0000000000000000000000000000000000000008",
+#                 ],
+#                 "pool_address": [
+#                     "0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6",
+#                     "0x0000000000000000000000000000000000000026",
+#                     "0x0000000000000000000000000000000000000027",
+#                     "0x0000000000000000000000000000000000000028",
+#                 ],
+#                 "service_fee": [
+#                     Fraction(0, 100),
+#                     Fraction(0, 100),
+#                     Fraction(0, 100),
+#                     Fraction(15, 100),
+#                 ],
+#                 "buffer_accounting_target": [
+#                     self.solvers[0],
+#                     "0x0000000000000000000000000000000000000006",
+#                     "0x0000000000000000000000000000000000000007",
+#                     "0x0000000000000000000000000000000000000008",
+#                 ],
+#                 "reward_token_address": [
+#                     str(self.config.reward_config.reward_token_address),
+#                     str(self.config.reward_config.reward_token_address),
+#                     str(self.config.reward_config.reward_token_address),
+#                     str(self.config.reward_config.reward_token_address),
+#                 ],
+#             }
+#         )
+#         period = AccountingPeriod("1985-03-10", 1)
+#         protocol_fee_amount = sum(self.protocol_fee_eth)
+#         payout_transfers = prepare_transfers(
+#             full_payout_data, period, protocol_fee_amount, 0, {}, self.config
+#         )
+#         self.assertEqual(
+#             [
+#                 Transfer(
+#                     token=None,
+#                     recipient=Address(self.solvers[0]),
+#                     amount_wei=1,
+#                 ),
+#                 Transfer(
+#                     token=Token(self.config.payment_config.cow_token_address),
+#                     recipient=Address(self.reward_targets[0]),
+#                     amount_wei=600000000000000000,
+#                 ),
+#                 Transfer(
+#                     token=Token(self.config.payment_config.cow_token_address),
+#                     recipient=Address(self.reward_targets[1]),
+#                     amount_wei=12000000000000000000,
+#                 ),
+#                 Transfer(
+#                     token=Token(self.config.payment_config.cow_token_address),
+#                     recipient=Address(self.reward_targets[2]),
+#                     amount_wei=90000000000000000000,
+#                 ),
+#                 Transfer(
+#                     token=Token(self.config.payment_config.cow_token_address),
+#                     recipient=Address(self.reward_targets[3]),
+#                     amount_wei=int(
+#                         180000000000000000000
+#                         * (1 - self.config.reward_config.service_fee_factor)
+#                     ),
+#                 ),
+#                 Transfer(
+#                     token=None,
+#                     recipient=self.config.protocol_fee_config.protocol_fee_safe,
+#                     amount_wei=3000000000000000,
+#                 ),
+#             ],
+#             payout_transfers.transfers,
+#         )
+#
+#         self.assertEqual(
+#             payout_transfers.overdrafts,
+#             [
+#                 Overdraft(
+#                     period,
+#                     account=Address(self.solvers[2]),
+#                     wei=10000000000000001,
+#                     name="S_3",
+#                 )
+#             ],
+#         )
+
+
+@pytest.fixture
+def common_reward_data() -> dict:
+    data: dict = {}
+    data["config"] = AccountingConfig.from_network(Network.MAINNET)
+    data["solver"] = Address.from_int(1)
+    data["solver_name"] = "Solver1"
+    data["reward_target"] = Address.from_int(2)
+    data["buffer_accounting_target"] = Address.from_int(3)
+    data["cow_token_address"] = data["config"].payment_config.cow_token_address
+    data["cow_token"] = Token(data["cow_token_address"])
+    data["conversion_rate"] = 1000
+
+    return data
+
+
+def sample_record(
+    reward_data,
+    primary_reward: int,
+    slippage: int,
+    num_quotes: int,
+    service_fee: Fraction = Fraction(0, 1),
+) -> RewardAndPenaltyDatum:
+    """Assumes a conversion rate of ETH:COW <> 1:self.conversion_rate"""
+    return RewardAndPenaltyDatum(
+        solver=reward_data["solver"],
+        solver_name=reward_data["solver_name"],
+        reward_target=reward_data["reward_target"],
+        buffer_accounting_target=reward_data["buffer_accounting_target"],
+        primary_reward_eth=primary_reward,
+        primary_reward_cow=primary_reward * reward_data["conversion_rate"],
+        slippage_eth=slippage,
+        quote_reward_cow=reward_data["config"].reward_config.quote_reward_cow
+        * num_quotes,
+        service_fee=service_fee,
+        reward_token_address=reward_data["cow_token_address"],
+    )
+
+
+def test_invalid_input(common_reward_data):
+    """Test that negative and quote rewards throw an error."""
+
+    # invalid quote reward
+    with pytest.raises(AssertionError):
+        sample_record(common_reward_data, 0, 0, -1)
+
+
+def test_reward_datum_0_0_0(common_reward_data):
+    """Without data there is no payout and no overdraft."""
+    test_datum = sample_record(common_reward_data, 0, 0, 0)
+    assert not test_datum.is_overdraft()
+    assert test_datum.as_payouts() == []
+
+
+def test_reward_datum_pm1_0_0(common_reward_data):
+    """Primary reward only."""
+
+    # positive reward is paid in COW
+    primary_reward = 1
+    test_datum = sample_record(common_reward_data, primary_reward, 0, 0)
+    assert not test_datum.is_overdraft()
+    assert test_datum.as_payouts() == [
+        Transfer(
+            token=common_reward_data["cow_token"],
+            recipient=common_reward_data["reward_target"],
+            amount_wei=primary_reward * common_reward_data["conversion_rate"],
         )
+    ]
 
-    def test_validate_df_columns(self):
-        legit_payments = DataFrame(
-            {
-                "solver": [],
-                "payment_eth": [],
-                "protocol_fee_eth": [],
-                "network_fee_eth": [],
-                "primary_reward_eth": [],
-                "primary_reward_cow": [],
-                "quote_reward_cow": [],
-            }
+    # negative reward gives overdraft
+    primary_reward = -1
+    test_datum = sample_record(common_reward_data, primary_reward, 0, 0)
+    assert test_datum.is_overdraft()
+    assert test_datum.as_payouts() == []
+
+
+def test_reward_datum_0_pm1_0(common_reward_data):
+    """Slippag only."""
+
+    # positive slippage is paid in ETH
+    slippage = 1
+    test_datum = sample_record(common_reward_data, 0, slippage, 0)
+    assert not test_datum.is_overdraft()
+    assert test_datum.as_payouts() == [
+        Transfer(
+            token=None,
+            recipient=common_reward_data["buffer_accounting_target"],
+            amount_wei=slippage,
         )
-        legit_slippages = DataFrame({"solver": [], "eth_slippage_wei": []})
-        legit_reward_targets = DataFrame(
-            {"solver": [], "solver_name": [], "reward_target": [], "pool_address": []}
+    ]
+
+    # negative slippage gives overdraft
+    slippage = -1
+    test_datum = sample_record(common_reward_data, 0, slippage, 0)
+    assert test_datum.is_overdraft()
+    assert test_datum.as_payouts() == []
+
+
+def test_reward_datum_0_0_1(common_reward_data):
+    """Quote rewards only."""
+    num_quotes = 1
+    reward_per_quote = 6 * 10**18
+    test_datum = sample_record(common_reward_data, 0, 0, num_quotes)
+    assert not test_datum.is_overdraft()
+    assert test_datum.as_payouts() == [
+        Transfer(
+            token=common_reward_data["cow_token"],
+            recipient=common_reward_data["reward_target"],
+            amount_wei=reward_per_quote * num_quotes,
         )
-        legit_service_fees = DataFrame({"solver": [], "service_fee": []})
+    ]
 
-        failing_df = DataFrame({})
 
-        with self.assertRaises(AssertionError):
-            validate_df_columns(
-                payment_df=legit_payments,
-                slippage_df=legit_reward_targets,
-                reward_target_df=legit_reward_targets,
-                service_fee_df=failing_df,
-            )
-        with self.assertRaises(AssertionError):
-            validate_df_columns(
-                payment_df=legit_payments,
-                slippage_df=legit_reward_targets,
-                reward_target_df=failing_df,
-                service_fee_df=legit_service_fees,
-            )
-        with self.assertRaises(AssertionError):
-            validate_df_columns(
-                payment_df=legit_payments,
-                slippage_df=failing_df,
-                reward_target_df=legit_reward_targets,
-                service_fee_df=legit_service_fees,
-            )
-        with self.assertRaises(AssertionError):
-            validate_df_columns(
-                payment_df=failing_df,
-                slippage_df=legit_slippages,
-                reward_target_df=legit_reward_targets,
-                service_fee_df=legit_service_fees,
-            )
+def test_reward_datum_4_1_0(common_reward_data):
+    """COW payment for rewards, ETH payment for slippage."""
+    primary_reward, slippage = 4, 1
+    test_datum = sample_record(common_reward_data, primary_reward, slippage, 0)
+    assert not test_datum.is_overdraft()
+    assert test_datum.as_payouts() == [
+        Transfer(
+            token=None,
+            recipient=common_reward_data["buffer_accounting_target"],
+            amount_wei=slippage,
+        ),
+        Transfer(
+            token=common_reward_data["cow_token"],
+            recipient=common_reward_data["reward_target"],
+            amount_wei=primary_reward * common_reward_data["conversion_rate"],
+        ),
+    ]
 
-        self.assertIsNone(
-            validate_df_columns(
-                payment_df=legit_payments,
-                slippage_df=legit_slippages,
-                reward_target_df=legit_reward_targets,
-                service_fee_df=legit_service_fees,
-            )
+
+def test_reward_datum_slippage_reduces_reward(common_reward_data):
+    """Negative slippage reduces COW reward."""
+    primary_reward, slippage = 4, -1
+    test_datum = sample_record(common_reward_data, primary_reward, slippage, 0)
+    assert not test_datum.is_overdraft()
+    assert test_datum.as_payouts() == [
+        Transfer(
+            token=common_reward_data["cow_token"],
+            recipient=common_reward_data["reward_target"],
+            amount_wei=(primary_reward + slippage)
+            * common_reward_data["conversion_rate"],
+        ),
+    ]
+
+
+def test_reward_datum_slippage_exceeds_reward(common_reward_data):
+    """Negative slippage leads to overtraft."""
+    primary_reward, slippage = 1, -4
+    test_datum = sample_record(common_reward_data, primary_reward, slippage, 0)
+    assert test_datum.is_overdraft()
+    assert test_datum.as_payouts() == []
+
+
+def test_reward_datum_reward_reduces_slippage(common_reward_data):
+    """Negative reward  reduces ETH slippage payment."""
+    primary_reward, slippage = -2, 3
+    test_datum = sample_record(common_reward_data, primary_reward, slippage, 0)
+    assert test_datum.total_outgoing_eth() == primary_reward + slippage
+    assert test_datum.as_payouts() == [
+        Transfer(
+            token=None,
+            recipient=common_reward_data["buffer_accounting_target"],
+            amount_wei=test_datum.total_outgoing_eth(),
+        ),
+    ]
+
+
+def test_performance_reward_service_fee(common_reward_data):
+    """Sevice fee reduces COW reward."""
+    primary_reward, num_quotes, service_fee = 100, 0, Fraction(15, 100)
+    test_datum = sample_record(
+        common_reward_data,
+        primary_reward=primary_reward,
+        slippage=0,
+        num_quotes=num_quotes,
+        service_fee=service_fee,
+    )
+
+    assert (
+        test_datum.total_cow_reward()
+        == test_datum.total_eth_reward() * common_reward_data["conversion_rate"]
+    )  # ensure consistency of cow and eth batch rewards
+    assert test_datum.total_service_fee() == int(
+        primary_reward * common_reward_data["conversion_rate"] * service_fee
+    )
+    assert not test_datum.is_overdraft()
+    assert test_datum.as_payouts() == [
+        Transfer(
+            token=common_reward_data["cow_token"],
+            recipient=common_reward_data["reward_target"],
+            amount_wei=int(primary_reward * (1 - service_fee))
+            * common_reward_data["conversion_rate"],
+        ),
+    ]
+
+
+def test_quote_reward_service_fee(common_reward_data):
+    """Sevice fee reduces COW reward."""
+    primary_reward, num_quotes, service_fee = 0, 100, Fraction(15, 100)
+    reward_per_quote = 6 * 10**18
+
+    test_datum = sample_record(
+        common_reward_data,
+        primary_reward=primary_reward,
+        slippage=0,
+        num_quotes=num_quotes,
+        service_fee=service_fee,
+    )
+
+    assert test_datum.total_service_fee() == int(
+        reward_per_quote * num_quotes * service_fee
+    )  # only quote rewards enter
+
+    assert not test_datum.is_overdraft()
+    assert test_datum.as_payouts() == [
+        Transfer(
+            token=common_reward_data["cow_token"],
+            recipient=common_reward_data["reward_target"],
+            amount_wei=int(reward_per_quote * num_quotes * (1 - service_fee)),
+        ),
+    ]
+
+
+def test_positive_reward_service_fee(common_reward_data):
+    """Service fee reduces COW reward."""
+    primary_reward = 10**18  # positive reward
+    num_quotes = 100
+    service_fee = Fraction(15, 100)
+    reward_per_quote = 6 * 10**18
+
+    test_datum = sample_record(
+        common_reward_data,
+        primary_reward=primary_reward,
+        slippage=0,
+        num_quotes=num_quotes,
+        service_fee=service_fee,
+    )
+
+    assert test_datum.total_service_fee() == int(
+        (
+            primary_reward * common_reward_data["conversion_rate"]
+            + reward_per_quote * num_quotes
         )
+        * service_fee
+    )
 
-    def test_construct_payouts(self):
-        payments = extend_payment_df(
-            pdf=DataFrame(
-                {
-                    "solver": self.solvers,
-                    "num_quotes": self.num_quotes,
-                    "primary_reward_eth": self.primary_reward_eth,
-                    "protocol_fee_eth": self.protocol_fee_eth,
-                    "network_fee_eth": self.network_fee_eth,
-                }
+    assert not test_datum.is_overdraft()
+    assert test_datum.as_payouts() == [
+        Transfer(
+            token=common_reward_data["cow_token"],
+            recipient=common_reward_data["reward_target"],
+            amount_wei=int(reward_per_quote * num_quotes * (1 - service_fee)),
+        ),
+        Transfer(
+            token=common_reward_data["cow_token"],
+            recipient=common_reward_data["reward_target"],
+            amount_wei=int(
+                primary_reward
+                * common_reward_data["conversion_rate"]
+                * (1 - service_fee)
             ),
-            converter=self.mock_converter,
-            config=self.config,
-        )
-
-        slippages = DataFrame(
-            {
-                "solver": self.solvers[:3],
-                # Note that one of the solvers did not appear,
-                # in this list (we are testing the left join)
-                "eth_slippage_wei": [1, 0, -1],
-            }
-        )
-
-        reward_targets = DataFrame(
-            {
-                "solver": self.solvers,
-                "solver_name": ["S_1", "S_2", "S_3", "S_4"],
-                "reward_target": self.reward_targets,
-                "pool_address": self.pool_addresses,
-            }
-        )
-
-        service_fee_df = DataFrame(
-            {"solver": self.solvers, "service_fee": self.service_fee}
-        )
-
-        result = construct_payout_dataframe(
-            payment_df=payments,
-            slippage_df=slippages,
-            reward_target_df=reward_targets,
-            service_fee_df=service_fee_df,
-            config=self.config,
-        )
-        expected = DataFrame(
-            {
-                "buffer_accounting_target": [
-                    "0x0000000000000000000000000000000000000005",
-                    str(self.solvers[1]),
-                    str(self.solvers[2]),
-                    str(self.solvers[3]),
-                ],
-                "eth_slippage_wei": [2000000000000001.0, 4000000000000000.0, -1.0, 0.0],
-                "network_fee_eth": [
-                    2000000000000000.0,
-                    4000000000000000.0,
-                    0.0,
-                    0.0,
-                ],
-                "pool_address": [
-                    str(self.config.reward_config.cow_bonding_pool),
-                    "0x0000000000000000000000000000000000000010",
-                    "0x0000000000000000000000000000000000000011",
-                    "0x0000000000000000000000000000000000000012",
-                ],
-                "primary_reward_cow": [
-                    600000000000000000.0,
-                    12000000000000000000.0,
-                    -10000000000000000000.0,
-                    0.0,
-                ],
-                "primary_reward_eth": [600000000000000.0, 1.2e16, -1e16, 0.0],
-                "protocol_fee_eth": [
-                    1000000000000000.0,
-                    2000000000000000.0,
-                    0.0,
-                    0.0,
-                ],
-                "quote_reward_cow": [
-                    0.00000,
-                    0.00000,
-                    6000000000000000000.00000,
-                    12000000000000000000.00000,
-                ],
-                "reward_target": [
-                    "0x0000000000000000000000000000000000000005",
-                    "0x0000000000000000000000000000000000000006",
-                    "0x0000000000000000000000000000000000000007",
-                    "0x0000000000000000000000000000000000000008",
-                ],
-                "reward_token_address": [
-                    str(self.config.reward_config.reward_token_address),
-                    str(self.config.reward_config.reward_token_address),
-                    str(self.config.reward_config.reward_token_address),
-                    str(self.config.reward_config.reward_token_address),
-                ],
-                "service_fee": [
-                    Fraction(0, 100),
-                    Fraction(0, 100),
-                    Fraction(0, 100),
-                    Fraction(15, 100),
-                ],
-                "solver": self.solvers,
-                "solver_name": ["S_1", "S_2", "S_3", "S_4"],
-            }
-        )
-
-        self.assertIsNone(
-            pandas.testing.assert_frame_equal(
-                expected, result.reindex(sorted(result.columns), axis=1)
-            )
-        )
-
-    def test_prepare_transfers(self):
-        # Need Example of every possible scenario
-        full_payout_data = DataFrame(
-            {
-                "solver": self.solvers,
-                "num_quotes": self.num_quotes,
-                "primary_reward_eth": [600000000000000.0, 1.2e16, -1e16, 0.0],
-                "protocol_fee_eth": self.protocol_fee_eth,
-                "network_fee_eth": [100.0, 200.0, 300.0, 0.0],
-                "primary_reward_cow": [
-                    600000000000000000.0,
-                    12000000000000000000.0,
-                    -10000000000000000000.0,
-                    0.0,
-                ],
-                "quote_reward_cow": [
-                    0.00000,
-                    0.00000,
-                    90000000000000000000.00000,
-                    180000000000000000000.00000,
-                ],
-                "solver_name": ["S_1", "S_2", "S_3", None],
-                "eth_slippage_wei": [1.0, 0.0, -1.0, None],
-                "reward_target": [
-                    "0x0000000000000000000000000000000000000005",
-                    "0x0000000000000000000000000000000000000006",
-                    "0x0000000000000000000000000000000000000007",
-                    "0x0000000000000000000000000000000000000008",
-                ],
-                "pool_address": [
-                    "0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6",
-                    "0x0000000000000000000000000000000000000026",
-                    "0x0000000000000000000000000000000000000027",
-                    "0x0000000000000000000000000000000000000028",
-                ],
-                "service_fee": [
-                    Fraction(0, 100),
-                    Fraction(0, 100),
-                    Fraction(0, 100),
-                    Fraction(15, 100),
-                ],
-                "buffer_accounting_target": [
-                    self.solvers[0],
-                    "0x0000000000000000000000000000000000000006",
-                    "0x0000000000000000000000000000000000000007",
-                    "0x0000000000000000000000000000000000000008",
-                ],
-                "reward_token_address": [
-                    str(self.config.reward_config.reward_token_address),
-                    str(self.config.reward_config.reward_token_address),
-                    str(self.config.reward_config.reward_token_address),
-                    str(self.config.reward_config.reward_token_address),
-                ],
-            }
-        )
-        period = AccountingPeriod("1985-03-10", 1)
-        protocol_fee_amount = sum(self.protocol_fee_eth)
-        payout_transfers = prepare_transfers(
-            full_payout_data, period, protocol_fee_amount, 0, {}, self.config
-        )
-        self.assertEqual(
-            [
-                Transfer(
-                    token=None,
-                    recipient=Address(self.solvers[0]),
-                    amount_wei=1,
-                ),
-                Transfer(
-                    token=Token(self.config.payment_config.cow_token_address),
-                    recipient=Address(self.reward_targets[0]),
-                    amount_wei=600000000000000000,
-                ),
-                Transfer(
-                    token=Token(self.config.payment_config.cow_token_address),
-                    recipient=Address(self.reward_targets[1]),
-                    amount_wei=12000000000000000000,
-                ),
-                Transfer(
-                    token=Token(self.config.payment_config.cow_token_address),
-                    recipient=Address(self.reward_targets[2]),
-                    amount_wei=90000000000000000000,
-                ),
-                Transfer(
-                    token=Token(self.config.payment_config.cow_token_address),
-                    recipient=Address(self.reward_targets[3]),
-                    amount_wei=int(
-                        180000000000000000000
-                        * (1 - self.config.reward_config.service_fee_factor)
-                    ),
-                ),
-                Transfer(
-                    token=None,
-                    recipient=self.config.protocol_fee_config.protocol_fee_safe,
-                    amount_wei=3000000000000000,
-                ),
-            ],
-            payout_transfers.transfers,
-        )
-
-        self.assertEqual(
-            payout_transfers.overdrafts,
-            [
-                Overdraft(
-                    period,
-                    account=Address(self.solvers[2]),
-                    wei=10000000000000001,
-                    name="S_3",
-                )
-            ],
-        )
+        ),
+    ]
 
 
-class TestRewardAndPenaltyDatum(unittest.TestCase):
-    def setUp(self) -> None:
-        self.config = AccountingConfig.from_network(Network.MAINNET)
-        self.solver = Address.from_int(1)
-        self.solver_name = "Solver1"
-        self.reward_target = Address.from_int(2)
-        self.buffer_accounting_target = Address.from_int(3)
-        self.cow_token_address = self.config.payment_config.cow_token_address
-        self.cow_token = Token(self.cow_token_address)
-        self.conversion_rate = 1000
+def test_negative_reward_service_fee(common_reward_data):
+    """Sevice fee reduces COW quote reward but not reduce a negative batch reward."""
+    primary_reward = -(10**18)  # negative reward
+    slippage = 2 * 10**18  # to avoid overdraft
+    num_quotes = 100
+    service_fee = Fraction(15, 100)
+    reward_per_quote = 6 * 10**18
+    test_datum = sample_record(
+        common_reward_data,
+        primary_reward=primary_reward,
+        slippage=slippage,
+        num_quotes=num_quotes,
+        service_fee=service_fee,
+    )
 
-    def sample_record(
-        self,
-        primary_reward: int,
-        slippage: int,
-        num_quotes: int,
-        service_fee: Fraction = Fraction(0, 1),
-    ):
-        """Assumes a conversion rate of ETH:COW <> 1:self.conversion_rate"""
-        return RewardAndPenaltyDatum(
-            solver=self.solver,
-            solver_name=self.solver_name,
-            reward_target=self.reward_target,
-            buffer_accounting_target=self.buffer_accounting_target,
-            primary_reward_eth=primary_reward,
-            primary_reward_cow=primary_reward * self.conversion_rate,
-            slippage_eth=slippage,
-            quote_reward_cow=self.config.reward_config.quote_reward_cow * num_quotes,
-            service_fee=service_fee,
-            reward_token_address=self.cow_token_address,
-        )
+    assert (
+        test_datum.total_cow_reward()
+        == test_datum.total_eth_reward() * common_reward_data["conversion_rate"]
+    )  # ensure consistency of cow and eth batch rewards
+    assert test_datum.total_service_fee() == int(
+        reward_per_quote * num_quotes * service_fee
+    )  # only quote rewards enter
 
-    def test_invalid_input(self):
-        """Test that negative and quote rewards throw an error."""
-
-        # invalid quote reward
-        with self.assertRaises(AssertionError):
-            self.sample_record(0, 0, -1)
-
-    def test_reward_datum_0_0_0(self):
-        """Without data there is no payout and no overdraft."""
-        test_datum = self.sample_record(0, 0, 0)
-        self.assertFalse(test_datum.is_overdraft())
-        self.assertEqual(test_datum.as_payouts(), [])
-
-    def test_reward_datum_pm1_0_0(self):
-        """Primary reward only."""
-
-        # positive reward is paid in COW
-        primary_reward = 1
-        test_datum = self.sample_record(primary_reward, 0, 0)
-        self.assertFalse(test_datum.is_overdraft())
-        self.assertEqual(
-            test_datum.as_payouts(),
-            [
-                Transfer(
-                    token=self.cow_token,
-                    recipient=self.reward_target,
-                    amount_wei=primary_reward * self.conversion_rate,
-                )
-            ],
-        )
-
-        # negative reward gives overdraft
-        primary_reward = -1
-        test_datum = self.sample_record(primary_reward, 0, 0)
-        self.assertTrue(test_datum.is_overdraft())
-        self.assertEqual(test_datum.as_payouts(), [])
-
-    def test_reward_datum_0_pm1_0(self):
-        """Slippag only."""
-
-        # positive slippage is paid in ETH
-        slippage = 1
-        test_datum = self.sample_record(0, slippage, 0)
-        self.assertFalse(test_datum.is_overdraft())
-        self.assertEqual(
-            test_datum.as_payouts(),
-            [
-                Transfer(
-                    token=None,
-                    recipient=self.buffer_accounting_target,
-                    amount_wei=slippage,
-                )
-            ],
-        )
-
-        # negative slippage gives overdraft
-        slippage = -1
-        test_datum = self.sample_record(0, slippage, 0)
-        self.assertTrue(test_datum.is_overdraft())
-        self.assertEqual(test_datum.as_payouts(), [])
-
-    def test_reward_datum_0_0_1(self):
-        """Quote rewards only."""
-        num_quotes = 1
-        test_datum = self.sample_record(0, 0, num_quotes)
-        self.assertFalse(test_datum.is_overdraft())
-        self.assertEqual(
-            test_datum.as_payouts(),
-            [
-                Transfer(
-                    token=self.cow_token,
-                    recipient=self.reward_target,
-                    amount_wei=6000000000000000000 * num_quotes,
-                )
-            ],
-        )
-
-    def test_reward_datum_4_1_0(self):
-        """COW payment for rewards, ETH payment for slippage."""
-        primary_reward, slippage, num_quotes = 4, 1, 0
-        test_datum = self.sample_record(primary_reward, slippage, 0)
-        self.assertFalse(test_datum.is_overdraft())
-        self.assertEqual(
-            test_datum.as_payouts(),
-            [
-                Transfer(
-                    token=None,
-                    recipient=self.buffer_accounting_target,
-                    amount_wei=slippage,
-                ),
-                Transfer(
-                    token=self.cow_token,
-                    recipient=self.reward_target,
-                    amount_wei=(primary_reward) * self.conversion_rate,
-                ),
-            ],
-        )
-
-    def test_reward_datum_slippage_reduces_reward(self):
-        """Negative slippage reduces COW reward."""
-        primary_reward, slippage, num_quotes = 4, -1, 0
-        test_datum = self.sample_record(primary_reward, slippage, 0)
-        self.assertFalse(test_datum.is_overdraft())
-        self.assertEqual(
-            test_datum.as_payouts(),
-            [
-                Transfer(
-                    token=self.cow_token,
-                    recipient=self.reward_target,
-                    amount_wei=(primary_reward + slippage) * self.conversion_rate,
-                ),
-            ],
-        )
-
-    def test_reward_datum_slippage_exceeds_reward(self):
-        """Negative slippage leads to overtraft."""
-        primary_reward, slippage = 1, -4
-        test_datum = self.sample_record(primary_reward, slippage, 0)
-        self.assertTrue(test_datum.is_overdraft())
-        self.assertEqual(test_datum.as_payouts(), [])
-
-    def test_reward_datum_reward_reduces_slippage(self):
-        """Negative reward  reduces ETH slippage payment."""
-        primary_reward, slippage = -2, 3
-        test_datum = self.sample_record(primary_reward, slippage, 0)
-        self.assertEqual(
-            test_datum.total_outgoing_eth(),
-            primary_reward + slippage,
-        )
-        self.assertEqual(
-            test_datum.as_payouts(),
-            [
-                Transfer(
-                    token=None,
-                    recipient=self.buffer_accounting_target,
-                    amount_wei=test_datum.total_outgoing_eth(),
-                ),
-            ],
-        )
-
-    def test_performance_reward_service_fee(self):
-        """Sevice fee reduces COW reward."""
-        primary_reward, num_quotes, service_fee = 100, 0, Fraction(15, 100)
-        test_datum = self.sample_record(
-            primary_reward=primary_reward,
-            slippage=0,
-            num_quotes=num_quotes,
-            service_fee=service_fee,
-        )
-
-        self.assertTrue(
-            test_datum.total_cow_reward(),
-            test_datum.total_eth_reward() * self.conversion_rate,
-        )  # ensure consistency of cow and eth batch rewards
-        self.assertEqual(
-            test_datum.total_service_fee(),
-            int(
-                primary_reward * self.conversion_rate * service_fee
-            ),  # only quote rewards enter
-        )
-        self.assertFalse(test_datum.is_overdraft())
-        self.assertEqual(
-            test_datum.as_payouts(),
-            [
-                Transfer(
-                    token=self.cow_token,
-                    recipient=self.reward_target,
-                    amount_wei=int(primary_reward * (1 - service_fee))
-                    * self.conversion_rate,
-                ),
-            ],
-        )
-
-    def test_quote_reward_service_fee(self):
-        """Sevice fee reduces COW reward."""
-        primary_reward, num_quotes, service_fee = 0, 100, Fraction(15, 100)
-        reward_per_quote = 6 * 10**18
-
-        test_datum = self.sample_record(
-            primary_reward=primary_reward,
-            slippage=0,
-            num_quotes=num_quotes,
-            service_fee=service_fee,
-        )
-
-        self.assertEqual(
-            test_datum.total_service_fee(),
-            int(
-                reward_per_quote * num_quotes * service_fee
-            ),  # only quote rewards enter
-        )
-        self.assertFalse(test_datum.is_overdraft())
-        self.assertEqual(
-            test_datum.as_payouts(),
-            [
-                Transfer(
-                    token=self.cow_token,
-                    recipient=self.reward_target,
-                    amount_wei=int(reward_per_quote * num_quotes * (1 - service_fee)),
-                ),
-            ],
-        )
-
-    def test_positive_reward_service_fee(self):
-        """Sevice fee reduces COW reward."""
-        primary_reward = 10**18  # positive reward
-        num_quotes = 100
-        service_fee = Fraction(15, 100)
-        reward_per_quote = 6 * 10**18
-
-        test_datum = self.sample_record(
-            primary_reward=primary_reward,
-            slippage=0,
-            num_quotes=num_quotes,
-            service_fee=service_fee,
-        )
-
-        self.assertEqual(
-            test_datum.total_service_fee(),
-            int(
-                (primary_reward * self.conversion_rate + reward_per_quote * num_quotes)
-                * service_fee
-            ),
-        )
-        self.assertFalse(test_datum.is_overdraft())
-        self.assertEqual(
-            test_datum.as_payouts(),
-            [
-                Transfer(
-                    token=self.cow_token,
-                    recipient=self.reward_target,
-                    amount_wei=int(reward_per_quote * num_quotes * (1 - service_fee)),
-                ),
-                Transfer(
-                    token=self.cow_token,
-                    recipient=self.reward_target,
-                    amount_wei=int(
-                        primary_reward * self.conversion_rate * (1 - service_fee)
-                    ),
-                ),
-            ],
-        )
-
-    def test_negative_reward_service_fee(self):
-        """Sevice fee reduces COW quote reward but not reduce a negative batch reward."""
-        primary_reward = -(10**18)  # negative reward
-        slippage = 2 * 10**18  # to avoid overdraft
-        num_quotes = 100
-        service_fee = Fraction(15, 100)
-        reward_per_quote = 6 * 10**18
-
-        test_datum = self.sample_record(
-            primary_reward=primary_reward,
-            slippage=slippage,
-            num_quotes=num_quotes,
-            service_fee=service_fee,
-        )
-
-        self.assertTrue(
-            test_datum.total_cow_reward(),
-            test_datum.total_eth_reward() * self.conversion_rate,
-        )  # ensure consistency of cow and eth batch rewards
-        self.assertEqual(
-            test_datum.total_service_fee(),
-            int(
-                reward_per_quote * num_quotes * service_fee
-            ),  # only quote rewards enter
-        )
-        self.assertFalse(test_datum.is_overdraft())
-        self.assertEqual(
-            test_datum.as_payouts(),
-            [
-                Transfer(
-                    token=self.cow_token,
-                    recipient=self.reward_target,
-                    amount_wei=int(reward_per_quote * num_quotes * (1 - service_fee)),
-                ),
-                Transfer(
-                    token=None,
-                    recipient=self.buffer_accounting_target,
-                    amount_wei=slippage
-                    + primary_reward,  # no multiplication by 1 - service_fee
-                ),
-            ],
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+    assert not test_datum.is_overdraft()
+    assert test_datum.as_payouts() == [
+        Transfer(
+            token=common_reward_data["cow_token"],
+            recipient=common_reward_data["reward_target"],
+            amount_wei=int(reward_per_quote * num_quotes * (1 - service_fee)),
+        ),
+        Transfer(
+            token=None,
+            recipient=common_reward_data["buffer_accounting_target"],
+            amount_wei=slippage
+            + primary_reward,  # no multiplication by 1 - service_fee
+        ),
+    ]

--- a/tests/unit/test_protocol_fees.py
+++ b/tests/unit/test_protocol_fees.py
@@ -1,0 +1,48 @@
+import pytest
+import pandas
+from pandas import DataFrame
+
+from src.fetch.protocol_fees import compute_protocol_fees
+
+
+def test_compute_protocol_fees():
+    """Test protocol fees computation"""
+    batch_data = DataFrame(
+        {
+            "solver": ["solver_1", "solver_2"],
+            "protocol_fee_eth": [10**15, 10**16],
+        }
+    )
+
+    protocol_fees = compute_protocol_fees(batch_data)
+    expected_protocol_fee = batch_data.astype(object)
+
+    pandas.testing.assert_frame_equal(protocol_fees, expected_protocol_fee)
+
+
+def test_compute_protocol_fees_empty():
+    """Test that code also works for empty data."""
+    batch_data = DataFrame(
+        {
+            "solver": [],
+            "protocol_fee_eth": [],
+        }
+    )
+
+    protocol_fees = compute_protocol_fees(batch_data)
+    expected_protocol_fee = DataFrame(
+        {
+            "solver": [],
+            "protocol_fee_eth": [],
+        }
+    ).astype(object)
+
+    pandas.testing.assert_frame_equal(protocol_fees, expected_protocol_fee)
+
+
+def test_compute_protocol_fees_wrong_columns():
+    """Test column validation"""
+    wrong_columns = DataFrame({"wrong_column": []})
+
+    with pytest.raises(AssertionError):
+        compute_protocol_fees(wrong_columns)

--- a/tests/unit/test_rewards.py
+++ b/tests/unit/test_rewards.py
@@ -1,0 +1,110 @@
+from fractions import Fraction
+
+import pytest
+import pandas
+from pandas import DataFrame
+
+from src.config import Network, RewardConfig
+from src.fetch.rewards import (
+    compute_rewards,
+    REWARDS_COLUMNS,
+)
+
+
+def test_compute_rewards():
+    """Test rewards computation"""
+    batch_data = DataFrame(
+        {
+            "solver": ["solver_1", "solver_2"],
+            "primary_reward_eth": [10**15, 10**16],
+        }
+    )
+    quote_rewards = DataFrame(
+        {"solver": ["solver_2", "solver_3"], "num_quotes": [10, 100]}
+    )
+    exchange_rate = Fraction(1000, 1)
+    reward_config = RewardConfig.from_network(Network.MAINNET)
+
+    rewards = compute_rewards(
+        batch_data,
+        quote_rewards,
+        exchange_rate,
+        reward_config,
+    )
+
+    reward_per_quote = 6 * 10**17  # capped via ETH
+    expected_rewards = DataFrame(
+        {
+            "solver": ["solver_1", "solver_2", "solver_3"],
+            "primary_reward_eth": [10**15, 10**16, 0],
+            "primary_reward_cow": [
+                int(exchange_rate * 10**15),
+                int(exchange_rate * 10**16),
+                0,
+            ],
+            "quote_reward_cow": [0, reward_per_quote * 10, reward_per_quote * 100],
+            "reward_token_address": [
+                str(reward_config.reward_token_address),
+                str(reward_config.reward_token_address),
+                str(reward_config.reward_token_address),
+            ],
+        }
+    ).astype(object)
+
+    pandas.testing.assert_frame_equal(rewards, expected_rewards)
+
+
+def test_compute_rewards_empty():
+    """Test that code also works for empty data."""
+    batch_data = DataFrame(
+        {
+            "solver": [],
+            "primary_reward_eth": [],
+        }
+    )
+    quote_rewards = DataFrame({"solver": [], "num_quotes": []})
+    exchange_rate = Fraction(1000, 1)
+    reward_config = RewardConfig.from_network(Network.MAINNET)
+
+    rewards = compute_rewards(
+        batch_data,
+        quote_rewards,
+        exchange_rate,
+        reward_config,
+    )
+    expected_rewards = DataFrame({column: [] for column in REWARDS_COLUMNS}).astype(
+        object
+    )
+
+    pandas.testing.assert_frame_equal(rewards, expected_rewards)
+
+
+def test_compute_rewards_wrong_columns():
+    """Test column validation"""
+    legit_batch_data = DataFrame(
+        {
+            "solver": [],
+            "primary_reward_eth": [],
+        }
+    )
+    legit_quote_rewards = DataFrame({"solver": [], "num_quotes": []})
+    exchange_rate = Fraction(1000, 1)
+    reward_config = RewardConfig.from_network(Network.MAINNET)
+
+    wrong_columns = DataFrame({"wrong_column": []})
+
+    with pytest.raises(AssertionError):
+        compute_rewards(
+            wrong_columns,
+            legit_quote_rewards,
+            exchange_rate,
+            reward_config,
+        )
+
+    with pytest.raises(AssertionError):
+        compute_rewards(
+            legit_batch_data,
+            wrong_columns,
+            exchange_rate,
+            reward_config,
+        )

--- a/tests/unit/test_solver_info.py
+++ b/tests/unit/test_solver_info.py
@@ -1,0 +1,169 @@
+from fractions import Fraction
+
+import pytest
+import pandas
+from pandas import DataFrame
+
+from src.config import AccountingConfig, Network
+from src.fetch.solver_info import compute_solver_info
+
+
+def test_compute_solver_info():
+    """Test protocol fees computation"""
+    config = AccountingConfig.from_network(Network.MAINNET)
+    reward_targets = DataFrame(
+        {
+            "solver": ["solver_1", "solver_2", "solver_3"],
+            "reward_target": ["target_1", "target_2", "target_3"],
+            "pool_address": ["pool_1", "pool_2", "pool_3"],
+            "solver_name": ["solver_name_1", "solver_name_2", "solver_name_3"],
+        }
+    )
+    service_fees = DataFrame(
+        {
+            "solver": [
+                "solver_2",
+                "solver_3",
+            ],  # solver 1 has not service fee status
+            "service_fee": [True, False],
+        }
+    )
+
+    solver_info = compute_solver_info(reward_targets, service_fees, config)
+    expected_solver_info = DataFrame(
+        {
+            "solver": ["solver_1", "solver_2", "solver_3"],
+            "reward_target": ["target_1", "target_2", "target_3"],
+            "solver_name": ["solver_name_1", "solver_name_2", "solver_name_3"],
+            "service_fee": [
+                Fraction(0, 1),
+                config.reward_config.service_fee_factor,
+                Fraction(0, 1),
+            ],
+            "buffer_accounting_target": ["solver_1", "solver_2", "solver_3"],
+        }
+    ).astype(object)
+
+    pandas.testing.assert_frame_equal(solver_info, expected_solver_info)
+
+
+def test_compute_solver_info_cow_dao_buffer_target():
+    """Test that buffer accounting target is set to reward target for cow dao solvers."""
+    config = AccountingConfig.from_network(Network.MAINNET)
+    reward_targets = DataFrame(
+        {
+            "solver": ["solver_1"],
+            "reward_target": ["target_1"],
+            "pool_address": [str(config.reward_config.cow_bonding_pool)],
+            "solver_name": ["solver_name_1"],
+        }
+    )
+    service_fees = DataFrame(
+        {
+            "solver": [],
+            "service_fee": [],
+        }
+    )
+
+    solver_info = compute_solver_info(reward_targets, service_fees, config)
+    expected_solver_info = DataFrame(
+        {
+            "solver": ["solver_1"],
+            "reward_target": ["target_1"],
+            "solver_name": ["solver_name_1"],
+            "service_fee": [Fraction(0, 1)],
+            "buffer_accounting_target": ["target_1"],
+        }
+    ).astype(object)
+
+    pandas.testing.assert_frame_equal(solver_info, expected_solver_info)
+
+
+def test_compute_solver_info_drop_duplicate():
+    """Test that for duplicate entries the first solver is chosen."""
+    config = AccountingConfig.from_network(Network.MAINNET)
+    reward_targets = DataFrame(
+        {
+            "solver": ["solver_1", "solver_1"],
+            "reward_target": ["target_1", "target_2"],
+            "pool_address": ["pool_1", "pool_2"],
+            "solver_name": ["solver_name_1", "solver_name_2"],
+        }
+    )
+    service_fees = DataFrame(
+        {
+            "solver": [],
+            "service_fee": [],
+        }
+    )
+
+    solver_info = compute_solver_info(reward_targets, service_fees, config)
+    expected_solver_info = DataFrame(
+        {
+            "solver": ["solver_1"],
+            "reward_target": ["target_1"],
+            "solver_name": ["solver_name_1"],
+            "service_fee": [Fraction(0, 1)],
+            "buffer_accounting_target": ["solver_1"],
+        }
+    ).astype(object)
+
+    pandas.testing.assert_frame_equal(solver_info, expected_solver_info)
+
+
+def test_compute_solver_info_empty():
+    """Test that code also works for empty data."""
+    config = AccountingConfig.from_network(Network.MAINNET)
+    reward_targets = DataFrame(
+        {
+            "solver": [],
+            "reward_target": [],
+            "pool_address": [],
+            "solver_name": [],
+        }
+    )
+    service_fees = DataFrame(
+        {
+            "solver": [],
+            "service_fee": [],
+        }
+    )
+
+    solver_info = compute_solver_info(reward_targets, service_fees, config)
+    expected_solver_info = DataFrame(
+        {
+            "solver": [],
+            "reward_target": [],
+            "solver_name": [],
+            "service_fee": [],
+            "buffer_accounting_target": [],
+        }
+    ).astype(object)
+
+    pandas.testing.assert_frame_equal(solver_info, expected_solver_info)
+
+
+def test_compute_solver_info_wrong_columns():
+    """Test column validation"""
+    config = AccountingConfig.from_network(Network.MAINNET)
+    legit_reward_targets = DataFrame(
+        {
+            "solver": [],
+            "reward_target": [],
+            "pool_address": [],
+            "solver_name": [],
+        }
+    )
+    legit_service_fees = DataFrame(
+        {
+            "solver": [],
+            "service_fee": [],
+        }
+    )
+    wrong_columns = DataFrame({"wrong_column": []})
+
+    with pytest.raises(AssertionError):
+        compute_solver_info(wrong_columns, legit_service_fees, config)
+
+    with pytest.raises(AssertionError):
+        compute_solver_info(legit_reward_targets, wrong_columns, config)

--- a/tests/unit/test_solver_info.py
+++ b/tests/unit/test_solver_info.py
@@ -48,7 +48,7 @@ def test_compute_solver_info():
 
 
 def test_compute_solver_info_cow_dao_buffer_target():
-    """Test that buffer accounting target is set to reward target for cow dao solvers."""
+    """Test that buffer accounting target is set to reward target for CoW DAO solvers."""
     config = AccountingConfig.from_network(Network.MAINNET)
     reward_targets = DataFrame(
         {


### PR DESCRIPTION
This PR is an attempt at implementing #427. The PR does not change the values of final results (up to rounding of floats). It changes the structure of the code and intermediate representations.

As a first step, it separates the computation of different parts of the accounting into different functions.

```python
    # compute individual components of payments
    solver_info = compute_solver_info(
        reward_target_df,
        service_fee_df,
        config,
    )
    rewards = compute_rewards(
        batch_data,
        quote_rewards_df,
        exchange_rate_native_to_cow,
        config.reward_config,
    )
    protocol_fees = compute_protocol_fees(batch_data)
    partner_fees = compute_partner_fees(batch_data, config.protocol_fee_config)
    buffer_accounting = compute_buffer_accounting(batch_data, slippage_df)
```
Those functions are implemented in separate files 

The results of these steps are converted into data frames for solver payments and for protocol and partner fee payments.

```python
    # combine into solver payouts and partner payouts
    solver_payouts = compute_solver_payouts(
        solver_info, rewards, protocol_fees, buffer_accounting
    )
    partner_payouts = (
        partner_fees  # no additional computation required here at the moment
    )
```

Payout data on transfers and overdrafts is then computed from solver and parner payouts data.

```python
    payouts = prepare_payouts(solver_payouts, partner_payouts, dune.period, config)
```

The code can be tested to produce the same transfer files as the old code.
Tests have been adapted and cover essentially what was tested before. There is a bit more strictness in the testing of the separate computations of rewards, protocol fees, partner fees, etc.
There is no end-to-end test for payments yet. This should be added at some point.

Future changes could remove data frames from intermediate results. This would make it easier to have correct types and detect and handle missing data. Data for the different parts of the accounting can be changed to use intermediate tables generated by `src/data_sync/sync_data.py`.