### PR TITLE
[Hotfix] Handle missing data

### DIFF
--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -107,12 +107,12 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         )
         solver = frame["solver"]
         reward_target = frame["reward_target"]
-        if reward_target is None:
+        if pandas.isna(reward_target):
             log.warning(f"Solver {solver} without reward_target. Using solver")
             reward_target = solver
 
         buffer_accounting_target = frame["buffer_accounting_target"]
-        if buffer_accounting_target is None:
+        if pandas.isna(buffer_accounting_target):
             log.warning(
                 f"Solver {solver} without buffer_accounting_target. Using solver"
             )

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -117,7 +117,7 @@ def main() -> None:
 
     config = AccountingConfig.from_network(Network(os.environ["NETWORK"]))
 
-    accounting_period = AccountingPeriod(args.start, length_days=1)
+    accounting_period = AccountingPeriod(args.start)
 
     orderbook = MultiInstanceDBFetcher(
         [config.orderbook_config.prod_db_url, config.orderbook_config.barn_db_url]


### PR DESCRIPTION
This PR changes how missing data for reward targets is identified. It fixes a bug where missing data causes the script to crash.

The issue seems to come from a column without valid values being misidentified as float column and the missing value is encoded as `NaN`. This was not identified as missing data since it only checks for `None`.

With this PR, the pandas function `isna` is used to identify missing data.

A similar approach was used in #435.

Since local tests are still running, I created this as draft PR. I will remove the draft status once the local run is successful.