### PR TITLE
[Multi-Chain] Adapt caps on new chains

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -61,10 +61,10 @@ class RewardConfig:
                     reward_token_address=Address(
                         "0x177127622c4a00f3d409b75571e12cb3c8973d3c"
                     ),
-                    batch_reward_cap_upper=30 * 10**18,
-                    batch_reward_cap_lower=5 * 10**18,
+                    batch_reward_cap_upper=10 * 10**18,
+                    batch_reward_cap_lower=10 * 10**18,
                     quote_reward_cow=6 * 10**18,
-                    quote_reward_cap_native=1 * 10**18,
+                    quote_reward_cap_native=15 * 10**16,
                     service_fee_factor=service_fee_factor,
                     cow_bonding_pool=cow_bonding_pool,
                 )
@@ -76,7 +76,7 @@ class RewardConfig:
                     batch_reward_cap_upper=12 * 10**15,
                     batch_reward_cap_lower=10 * 10**15,
                     quote_reward_cow=6 * 10**18,
-                    quote_reward_cap_native=6 * 10**14,
+                    quote_reward_cap_native=2 * 10**14,
                     service_fee_factor=service_fee_factor,
                     cow_bonding_pool=cow_bonding_pool,
                 )


### PR DESCRIPTION
This PR adapts caps for rewards to what is being proposed in [this CIP draft](https://forum.cow.fi/t/cip-draft-solver-rewards-on-all-chains/2634).

The caps are set as follows:
* Ethereum mainnet
  * batch_reward_cap_upper: 0.012 ETH (`12 * 10**15` wei)
  * batch_reward_cap_lower: 0.01 ETH (`10 * 10**15` wei)
  * quote_reward_cow: 6 COW (`6 * 10**18` atoms)
  * quote_reward_cap_native: 0.0006 ETH (`6 * 10**14` wei)
* Gnosis
  * batch_reward_cap_upper: 10 xDAI (`10 * 10**18` wei)
  * batch_reward_cap_lower: 10 xDAI (`10 * 10**18` wei)
  * quote_reward_cow: 6 COW (`6 * 10**18` atoms)
  * quote_reward_cap_native: 0.15 xDAI (`15 * 10**16` wei)
* Arbitrum One
  * batch_reward_cap_upper: 0.012 ETH (`12 * 10**15` wei)
  * batch_reward_cap_lower: 0.01 ETH (`10 * 10**15` wei)
  * quote_reward_cow: 6 COW (`6 * 10**18` atoms)
  * quote_reward_cap_native: 0.0002 ETH (`2 * 10**14` wei)