### PR TITLE
Enable slippage calculations on Arbitrum and Gnosis Chain by default

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -140,8 +140,10 @@ class BufferAccountingConfig:
         match network:
             case Network.MAINNET:
                 include_slippage = True
-            case Network.GNOSIS | Network.ARBITRUM_ONE:
-                include_slippage = False
+            case Network.GNOSIS:
+                include_slippage = True
+            case Network.ARBITRUM_ONE:
+                include_slippage = True
             case _:
                 raise ValueError(
                     f"No buffer accounting config set up for network {network}."


### PR DESCRIPTION
This PR enables slippage calculations by default for Gnosis Chain and Arbitrum. Some preliminary testing suggests things work fine and since we want to do slippage accounting anyways, this PR addresses that