### PR TITLE
Fix merging of data frames for payments

### DIFF
--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -509,11 +509,15 @@ def construct_payouts(
         quote_rewards_df, batch_rewards_df, on="solver", how="outer"
     ).fillna(0)
 
-    service_fee_df = pandas.DataFrame(dune.get_service_fee_status())
-    service_fee_df["service_fee"] = [
-        service_fee_flag * config.reward_config.service_fee_factor
-        for service_fee_flag in service_fee_df["service_fee"]
-    ]
+    service_fee_dune = dune.get_service_fee_status()
+    if service_fee_dune:
+        service_fee_df = pandas.DataFrame(service_fee_dune)
+        service_fee_df["service_fee"] = [
+            service_fee_flag * config.reward_config.service_fee_factor
+            for service_fee_flag in service_fee_df["service_fee"]
+        ]
+    else:
+        service_fee_df = DataFrame(columns=["solver", "service_fee"])
 
     vouches = dune.get_vouches()
     if vouches:

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -415,9 +415,12 @@ def construct_payout_dataframe(
 
     # 3. Merge the three dataframes (joining on solver)
     merged_df = (
-        payment_df.merge(slippage_df, on=join_column, how="left")
-        .merge(reward_target_df, on=join_column, how="left")
-        .merge(service_fee_df, on=join_column, how="left")
+        payment_df[list(PAYMENT_COLUMNS)]
+        .merge(slippage_df[list(SLIPPAGE_COLUMNS)], on=join_column, how="left")
+        .merge(
+            reward_target_df[list(REWARD_TARGET_COLUMNS)], on=join_column, how="left"
+        )
+        .merge(service_fee_df[list(SERVICE_FEE_COLUMNS)], on=join_column, how="left")
     )
 
     # 4. Add slippage from fees to slippage

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -36,10 +36,9 @@ PAYMENT_COLUMNS = {
 }
 SLIPPAGE_COLUMNS = {
     "solver",
-    "solver_name",
     "eth_slippage_wei",
 }
-REWARD_TARGET_COLUMNS = {"solver", "reward_target", "pool_address"}
+REWARD_TARGET_COLUMNS = {"solver", "solver_name", "reward_target", "pool_address"}
 SERVICE_FEE_COLUMNS = {"solver", "service_fee"}
 ADDITIONAL_PAYMENT_COLUMNS = {"buffer_accounting_target", "reward_token_address"}
 
@@ -525,15 +524,8 @@ def construct_payouts(
         )
     # construct slippage df
     if ignore_slippage_flag or (not config.buffer_accounting_config.include_slippage):
-        slippage_df_temp = pandas.merge(
-            merged_df[["solver"]],
-            reward_target_df[["solver", "solver_name"]],
-            on="solver",
-            how="inner",
-        )
-        slippage_df = slippage_df_temp.assign(
-            eth_slippage_wei=[0] * slippage_df_temp.shape[0]
-        )
+        slippage_df = merged_df[["solver"]].copy()
+        slippage_df["eth_slippage_wei"] = [0] * slippage_df.shape[0]
     else:
         slippage_df = pandas.DataFrame(dune.get_period_slippage())
         # TODO - After CIP-20 phased in, adapt query to return `solver` like all the others


### PR DESCRIPTION
This PR changes which columns are expected from dune results and restricts columns before merging.

This is necessary since multiple queries now contain a `solver_name` field. In merging, the filed was renamed to `solver_name_x`, `solver_name_y`, ..., resulting in uncaught exceptions.

This can be tested by running `python -m src.fetch.transfer_file --start 2024-11-26 --post-tx --dry-run --min-transfer-amount-wei "1000000000000000" --min-transfer-amount-cow-atoms "1000000000000000000" --ignore-slippage` with suitable environments set up for Gnosis and Arbitrum One.