### PR TITLE
Use mainnet dai price for xdai

### DIFF
--- a/src/fetch/prices.py
+++ b/src/fetch/prices.py
@@ -29,7 +29,7 @@ class TokenId(Enum):
     """Coin Ids for coin paprika"""
 
     ETH = "eth-ethereum"
-    XDAI = "xdai-xdai"
+    XDAI = "dai-dai"
     COW = "cow-cow-protocol-token"
     USDC = "usdc-usd-coin"
 


### PR DESCRIPTION
This PR changes the price feed for xDAI on Gnosis to the one for DAI on mainnet.

There is a discrepancy of around 1% between the dai (0.999917) and xdai (1.008912) price on coin paprika on 2024-12-09.

Since Dune seems to be using the DAI price for WXDAI, there is a discrepancy between conversions done on Dune and conversions done in the payout script.

This change does not make the payout more accurate. But it makes it easier to check payments against the corresponding Dune dashboards.

It is still up to an internal discussino if this should be merged.