### PR TITLE
Remove index column from postgres table

### DIFF
--- a/src/data_sync/sync_data.py
+++ b/src/data_sync/sync_data.py
@@ -71,6 +71,7 @@ async def sync_data_to_db(  # pylint: disable=too-many-arguments
             table_name,
             OrderbookFetcher.pg_engine(OrderbookEnv.ANALYTICS),
             if_exists="replace",
+            index=False,
         )
         log.info(
             f"{type_of_data} data sync run completed successfully for month {months_list[i]}"


### PR DESCRIPTION
This PR removes the 'index' column, that is written by default, when writing a dataframe to the analytics db. See also documentation here.
https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_sql.html
