### PR TITLE
Rename surplus to executed

### DIFF
--- a/queries/orderbook/barn_batch_rewards.sql
+++ b/queries/orderbook/barn_batch_rewards.sql
@@ -48,7 +48,7 @@ trade_data_unprocessed as (
         od.buy_token,
         t.sell_amount, -- the total amount the user sends
         t.buy_amount, -- the total amount the user receives
-        oe.surplus_fee as observed_fee, -- the total discrepancy between what the user sends and what they would have send if they traded at clearing price
+        oe.executed_fee as observed_fee, -- the total discrepancy between what the user sends and what they would have send if they traded at clearing price
         od.kind,
         case
             when od.kind = 'sell' then od.buy_token
@@ -63,7 +63,7 @@ trade_data_unprocessed as (
         on s.block_number = t.block_number -- given the join that follows with the order execution table, this works even when multiple txs appear in the same block
     inner join order_data as od -- contains tokens and limit amounts
         on t.order_uid = od.uid
-    inner join order_execution as oe -- contains surplus fee
+    inner join order_execution as oe -- contains executed fee
         on t.order_uid = oe.order_uid and s.auction_id = oe.auction_id
     left outer join app_data as ad -- contains full app data
         on od.app_data = ad.contract_app_data

--- a/queries/orderbook/order_data.sql
+++ b/queries/orderbook/order_data.sql
@@ -69,7 +69,7 @@ trade_data_unprocessed as (
         od.buy_token,
         t.sell_amount, -- the total amount the user sends
         t.buy_amount, -- the total amount the user receives
-        oe.surplus_fee as observed_fee, -- the total discrepancy between what the user sends and what they would have send if they traded at clearing price
+        oe.executed_fee as observed_fee, -- the total discrepancy between what the user sends and what they would have send if they traded at clearing price
         od.kind,
         case
             when od.kind = 'sell' then od.buy_token
@@ -85,7 +85,7 @@ trade_data_unprocessed as (
         on s.block_number = t.block_number -- given the join that follows with the order execution table, this works even when multiple txs appear in the same block
     inner join order_data as od -- contains tokens and limit amounts
         on t.order_uid = od.uid
-    inner join order_execution as oe -- contains surplus fee
+    inner join order_execution as oe -- contains executed fee
         on t.order_uid = oe.order_uid and s.auction_id = oe.auction_id
     left outer join app_data as ad -- contains full app data
         on od.app_data = ad.contract_app_data
@@ -192,7 +192,7 @@ select
     concat('0x', encode(trade_hashes.solver, 'hex')) as solver,
     quote_solver,
     concat('0x', encode(trade_hashes.tx_hash, 'hex')) as tx_hash,
-    cast(coalesce(surplus_fee, 0) as text) as surplus_fee,
+    cast(coalesce(executed_fee, 0) as text) as executed_fee,
     coalesce(reward, 0.0) as amount,
     cast(coalesce(cast(protocol_fee as numeric(78, 0)), 0) as text) as protocol_fee,
     case

--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -48,7 +48,7 @@ trade_data_unprocessed as (
         od.buy_token,
         t.sell_amount, -- the total amount the user sends
         t.buy_amount, -- the total amount the user receives
-        oe.surplus_fee as observed_fee, -- the total discrepancy between what the user sends and what they would have send if they traded at clearing price
+        oe.executed_fee as observed_fee, -- the total discrepancy between what the user sends and what they would have send if they traded at clearing price
         od.kind,
         case
             when od.kind = 'sell' then od.buy_token
@@ -63,7 +63,7 @@ trade_data_unprocessed as (
         on s.block_number = t.block_number -- given the join that follows with the order execution table, this works even when multiple txs appear in the same block
     inner join order_data as od -- contains tokens and limit amounts
         on t.order_uid = od.uid
-    inner join order_execution as oe -- contains surplus fee
+    inner join order_execution as oe -- contains executed fee
         on t.order_uid = oe.order_uid and s.auction_id = oe.auction_id
     left outer join app_data as ad -- contains full app data
         on od.app_data = ad.contract_app_data

--- a/tests/queries/batch_rewards_test_db.sql
+++ b/tests/queries/batch_rewards_test_db.sql
@@ -116,7 +116,7 @@ CREATE TABLE IF NOT EXISTS order_execution
   order_uid bytea NOT NULL,
   auction_id bigint NOT NULL,
   reward double precision NOT NULL,
-  surplus_fee numeric(78, 0) NOT NULL,
+  executed_fee numeric(78, 0) NOT NULL,
   protocol_fee_amounts numeric(78, 0)[],
 
   PRIMARY KEY (order_uid, auction_id)
@@ -246,7 +246,7 @@ VALUES (51, 0, '\x01'::bytea, 100000000, 95000000000000000000, 5000000),
 (59, 0, '\x09'::bytea, 100000000, 95000000000000000000, 0),
 (60, 0, '\x0a'::bytea, 100000000, 94500000000000000000, 0);
 
-INSERT INTO order_execution (order_uid, auction_id, reward, surplus_fee, protocol_fee_amounts)
+INSERT INTO order_execution (order_uid, auction_id, reward, executed_fee, protocol_fee_amounts)
 VALUES ('\x03'::bytea, 53, 0, 6000000, ARRAY[1000000000000000000]),
 ('\x04'::bytea, 54, 0, 6000000, ARRAY[1000000]),
 ('\x05'::bytea, 55, 0, 6000000, ARRAY[1000000000000000000, 500000000000000000]),


### PR DESCRIPTION
https://github.com/cowprotocol/services/pull/2966 adds the token in which the `order_execution::surplus_fee` is taken. Note that we still use sell token to save it here, and switching to saving fees in surplus token will be implemented in a separate PR.

However, the linked PR also renames `order_execution::surplus_fee` into `order_execution::executed_fee`. This PR adjusts the solver rewards according to this change.