### PR TITLE
Add min transfer amounts per network

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ looking at the script help menu can help provide a list of options!
 $  python -m src.fetch.transfer_file --help 
 
 usage: Fetch Complete Reimbursement [-h] [--start START] [--post-tx POST_TX] [--consolidate-transfers CONSOLIDATE_TRANSFERS] [--dry-run DRY_RUN]
-                                    [--min-transfer-amount-wei MIN_TRANSFER_AMOUNT_WEI] [--min-transfer-amount-cow-atoms MIN_TRANSFER_AMOUNT_COW_ATOMS] 
 
 options:
   -h, --help            show this help message and exit
@@ -85,10 +84,6 @@ options:
                         Flag to indicate whether payout transfer file should be optimized (i.e. squash transfers having same receiver-token pair)
   --dry-run DRY_RUN     Flag indicating whether script should not post alerts or transactions. Only relevant in combination with --post-tx TruePrimarily intended for
                         deployment in staging environment.
-  --min-transfer-amount-wei MIN_TRANSFER_AMOUNT_WEI
-                        Ignore ETH transfers with amount less than this
-  --min-transfer-amount-cow-atoms MIN_TRANSFER_AMOUNT_COW_ATOMS
-                        Ignore COW transfers with amount less than this
   --ignore-slippage IGNORE_SLIPPAGE
                         Ignore slippage computations
 ```

--- a/src/config.py
+++ b/src/config.py
@@ -268,8 +268,8 @@ class PaymentConfig:
                 wrapped_eth_address = Address(
                     "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
                 )
-                min_native_token_transfer = 1000000000000000  # 0.001 ETH
-                min_cow_transfer = 20000000000000000000  # 20 COW
+                min_native_token_transfer = 10**15  # 0.001 ETH
+                min_cow_transfer = 10 * 10**18  # 10 COW
 
             case Network.GNOSIS:
                 payment_network = EthereumNetwork.GNOSIS
@@ -284,8 +284,8 @@ class PaymentConfig:
                 wrapped_eth_address = Address(
                     "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1"
                 )
-                min_native_token_transfer = 10000000000000000  # 0.01 xDAI
-                min_cow_transfer = 1000000000000000000  # 1 COW
+                min_native_token_transfer = 10**16  # 0.01 xDAI
+                min_cow_transfer = 10**18  # 1 COW
 
             case Network.ARBITRUM_ONE:
                 payment_network = EthereumNetwork.ARBITRUM_ONE
@@ -300,8 +300,8 @@ class PaymentConfig:
                 wrapped_eth_address = Address(
                     "0x82af49447d8a07e3bd95bd0d56f35241523fbab1"
                 )
-                min_native_token_transfer = 100000000000000  # 0.0001 ETH
-                min_cow_transfer = 1000000000000000000  # 1 COW
+                min_native_token_transfer = 10**14  # 0.0001 ETH
+                min_cow_transfer = 10**18  # 1 COW
 
             case Network.BASE:
                 payment_network = EthereumNetwork.BASE_MAINNET
@@ -316,8 +316,8 @@ class PaymentConfig:
                 wrapped_eth_address = Address(
                     "0x4200000000000000000000000000000000000006"
                 )
-                min_native_token_transfer = 100000000000000  # 0.0001 ETH
-                min_cow_transfer = 1000000000000000000  # 1 COW
+                min_native_token_transfer = 10**14  # 0.0001 ETH
+                min_cow_transfer = 10**18  # 1 COW
 
             case _:
                 raise ValueError(f"No payment config set up for network {network}.")

--- a/src/config.py
+++ b/src/config.py
@@ -235,6 +235,8 @@ class PaymentConfig:
     verification_docs_url: str
     wrapped_native_token_address: ChecksumAddress
     wrapped_eth_address: Address
+    min_native_token_transfer: int
+    min_cow_transfer: int
 
     @staticmethod
     def from_network(network: Network) -> PaymentConfig:
@@ -266,6 +268,8 @@ class PaymentConfig:
                 wrapped_eth_address = Address(
                     "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
                 )
+                min_native_token_transfer = 1000000000000000
+                min_cow_transfer = 20000000000000000000
 
             case Network.GNOSIS:
                 payment_network = EthereumNetwork.GNOSIS
@@ -280,6 +284,9 @@ class PaymentConfig:
                 wrapped_eth_address = Address(
                     "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1"
                 )
+                min_native_token_transfer = 10000000000000000
+                min_cow_transfer = 1000000000000000000
+
             case Network.ARBITRUM_ONE:
                 payment_network = EthereumNetwork.ARBITRUM_ONE
                 short_name = "arb1"
@@ -293,6 +300,9 @@ class PaymentConfig:
                 wrapped_eth_address = Address(
                     "0x82af49447d8a07e3bd95bd0d56f35241523fbab1"
                 )
+                min_native_token_transfer = 100000000000000
+                min_cow_transfer = 1000000000000000000
+
             case Network.BASE:
                 payment_network = EthereumNetwork.BASE_MAINNET
                 short_name = "base"
@@ -306,6 +316,9 @@ class PaymentConfig:
                 wrapped_eth_address = Address(
                     "0x4200000000000000000000000000000000000006"
                 )
+                min_native_token_transfer = 100000000000000
+                min_cow_transfer = 1000000000000000000
+
             case _:
                 raise ValueError(f"No payment config set up for network {network}.")
 
@@ -321,6 +334,8 @@ class PaymentConfig:
             verification_docs_url=docs_url,
             wrapped_native_token_address=wrapped_native_token_address,
             wrapped_eth_address=wrapped_eth_address,
+            min_native_token_transfer=min_native_token_transfer,
+            min_cow_transfer=min_cow_transfer,
         )
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -268,8 +268,8 @@ class PaymentConfig:
                 wrapped_eth_address = Address(
                     "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
                 )
-                min_native_token_transfer = 1000000000000000
-                min_cow_transfer = 20000000000000000000
+                min_native_token_transfer = 1000000000000000  # 0.001 ETH
+                min_cow_transfer = 20000000000000000000  # 20 COW
 
             case Network.GNOSIS:
                 payment_network = EthereumNetwork.GNOSIS
@@ -284,8 +284,8 @@ class PaymentConfig:
                 wrapped_eth_address = Address(
                     "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1"
                 )
-                min_native_token_transfer = 10000000000000000
-                min_cow_transfer = 1000000000000000000
+                min_native_token_transfer = 10000000000000000  # 0.01 xDAI
+                min_cow_transfer = 1000000000000000000  # 1 COW
 
             case Network.ARBITRUM_ONE:
                 payment_network = EthereumNetwork.ARBITRUM_ONE
@@ -300,8 +300,8 @@ class PaymentConfig:
                 wrapped_eth_address = Address(
                     "0x82af49447d8a07e3bd95bd0d56f35241523fbab1"
                 )
-                min_native_token_transfer = 100000000000000
-                min_cow_transfer = 1000000000000000000
+                min_native_token_transfer = 100000000000000  # 0.0001 ETH
+                min_cow_transfer = 1000000000000000000  # 1 COW
 
             case Network.BASE:
                 payment_network = EthereumNetwork.BASE_MAINNET
@@ -316,8 +316,8 @@ class PaymentConfig:
                 wrapped_eth_address = Address(
                     "0x4200000000000000000000000000000000000006"
                 )
-                min_native_token_transfer = 100000000000000
-                min_cow_transfer = 1000000000000000000
+                min_native_token_transfer = 100000000000000  # 0.0001 ETH
+                min_cow_transfer = 1000000000000000000  # 1 COW
 
             case _:
                 raise ValueError(f"No payment config set up for network {network}.")

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -113,11 +113,8 @@ def auto_propose(
 def main() -> None:
     """Generate transfers for an accounting period"""
 
+    args = generic_script_init(description="Fetch Complete Reimbursement")
     config = AccountingConfig.from_network(Network(os.environ["NETWORK"]))
-
-    args = generic_script_init(
-        description="Fetch Complete Reimbursement", config=config
-    )
 
     accounting_period = AccountingPeriod(args.start)
 

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -113,9 +113,9 @@ def auto_propose(
 def main() -> None:
     """Generate transfers for an accounting period"""
 
-    args = generic_script_init(description="Fetch Complete Reimbursement")
-
     config = AccountingConfig.from_network(Network(os.environ["NETWORK"]))
+
+    args = generic_script_init(description="Fetch Complete Reimbursement")
 
     accounting_period = AccountingPeriod(args.start)
 

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -115,7 +115,9 @@ def main() -> None:
 
     config = AccountingConfig.from_network(Network(os.environ["NETWORK"]))
 
-    args = generic_script_init(description="Fetch Complete Reimbursement")
+    args = generic_script_init(
+        description="Fetch Complete Reimbursement", config=config
+    )
 
     accounting_period = AccountingPeriod(args.start)
 

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -148,10 +148,10 @@ def main() -> None:
     payout_transfers = []
     for tr in payout_transfers_temp:
         if tr.token is None:
-            if tr.amount_wei >= args.min_transfer_amount_wei:
+            if tr.amount_wei >= config.payment_config.min_native_token_transfer:
                 payout_transfers.append(tr)
         else:
-            if tr.amount_wei >= args.min_transfer_amount_cow_atoms:
+            if tr.amount_wei >= config.payment_config.min_cow_transfer:
                 payout_transfers.append(tr)
 
     if args.post_tx:

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -114,6 +114,7 @@ def main() -> None:
     """Generate transfers for an accounting period"""
 
     args = generic_script_init(description="Fetch Complete Reimbursement")
+
     config = AccountingConfig.from_network(Network(os.environ["NETWORK"]))
 
     accounting_period = AccountingPeriod(args.start)

--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -3,7 +3,6 @@
 import argparse
 from datetime import date, timedelta
 from dataclasses import dataclass
-from src.config import AccountingConfig
 
 
 @dataclass
@@ -18,7 +17,7 @@ class ScriptArgs:
     ignore_slippage: bool
 
 
-def generic_script_init(description: str, config: AccountingConfig) -> ScriptArgs:
+def generic_script_init(description: str) -> ScriptArgs:
     """
     1. parses parses command line arguments,
     2. establishes dune connection
@@ -45,18 +44,6 @@ def generic_script_init(description: str, config: AccountingConfig) -> ScriptArg
         "Primarily intended for deployment in staging environment.",
     )
     parser.add_argument(
-        "--min-transfer-amount-wei",
-        type=int,
-        help="Ignore ETH transfers with amount less than this",
-        default=config.payment_config.min_native_token_transfer,
-    )
-    parser.add_argument(
-        "--min-transfer-amount-cow-atoms",
-        type=int,
-        help="Ignore COW transfers with amount less than this",
-        default=config.payment_config.min_cow_transfer,
-    )
-    parser.add_argument(
         "--ignore-slippage",
         action="store_true",
         help="Flag for ignoring slippage computations",
@@ -66,7 +53,5 @@ def generic_script_init(description: str, config: AccountingConfig) -> ScriptArg
         start=args.start,
         post_tx=args.post_tx,
         dry_run=args.dry_run,
-        min_transfer_amount_wei=args.min_transfer_amount_wei,
-        min_transfer_amount_cow_atoms=args.min_transfer_amount_cow_atoms,
         ignore_slippage=args.ignore_slippage,
     )

--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -12,8 +12,6 @@ class ScriptArgs:
     start: str
     post_tx: bool
     dry_run: bool
-    min_transfer_amount_wei: int
-    min_transfer_amount_cow_atoms: int
     ignore_slippage: bool
 
 

--- a/src/utils/script_args.py
+++ b/src/utils/script_args.py
@@ -3,6 +3,7 @@
 import argparse
 from datetime import date, timedelta
 from dataclasses import dataclass
+from src.config import AccountingConfig
 
 
 @dataclass
@@ -17,7 +18,7 @@ class ScriptArgs:
     ignore_slippage: bool
 
 
-def generic_script_init(description: str) -> ScriptArgs:
+def generic_script_init(description: str, config: AccountingConfig) -> ScriptArgs:
     """
     1. parses parses command line arguments,
     2. establishes dune connection
@@ -47,13 +48,13 @@ def generic_script_init(description: str) -> ScriptArgs:
         "--min-transfer-amount-wei",
         type=int,
         help="Ignore ETH transfers with amount less than this",
-        default=1000000000000000,
+        default=config.payment_config.min_native_token_transfer,
     )
     parser.add_argument(
         "--min-transfer-amount-cow-atoms",
         type=int,
         help="Ignore COW transfers with amount less than this",
-        default=20000000000000000000,
+        default=config.payment_config.min_cow_transfer,
     )
     parser.add_argument(
         "--ignore-slippage",


### PR DESCRIPTION
This PR sets min transfer amounts (native token and COW) for all networks, and removes the runtime arg for determining those as it has been rarely (if ever) used in the past.