### PR TITLE
Revert column name change to surplus_fee

### DIFF
--- a/queries/orderbook/order_data.sql
+++ b/queries/orderbook/order_data.sql
@@ -192,7 +192,7 @@ select
     concat('0x', encode(trade_hashes.solver, 'hex')) as solver,
     quote_solver,
     concat('0x', encode(trade_hashes.tx_hash, 'hex')) as tx_hash,
-    cast(coalesce(executed_fee, 0) as text) as executed_fee,
+    cast(coalesce(executed_fee, 0) as text) as surplus_fee,
     coalesce(reward, 0.0) as amount,
     cast(coalesce(cast(protocol_fee as numeric(78, 0)), 0) as text) as protocol_fee,
     case


### PR DESCRIPTION
PR #471 adjusted the sql queries to work with the renamed column in the backend db; surplus_fee was changed to executed_fee. However, dune-sync and some dune-queries break because of that so this PR just renames the final column stored during the order data sync job to surplus_fee.

A proper migration to executed_fee needs to happen, but this can wait a bit.