### PR TITLE
Fix connection timeout for order rewards

### DIFF
--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -51,8 +51,16 @@ class OrderbookFetcher:
         else:
             db_url = os.environ[f"{db_env}_DB_URL"]
 
-        db_string = f"postgresql+psycopg2://{db_url}"
-        return create_engine(db_string)
+        return create_engine(
+            f"postgresql+psycopg2://{db_url}",
+            pool_pre_ping=True,
+            connect_args={
+                "keepalives": 1,
+                "keepalives_idle": 30,
+                "keepalives_interval": 10,
+                "keepalives_count": 5,
+            },
+        )
 
     @classmethod
     def _read_query_for_env(

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -51,7 +51,7 @@ class OrderbookFetcher:
         else:
             db_url = os.environ[f"{db_env}_DB_URL"]
 
-        return create_engine(
+        return create_engine( # pylint: disable=duplicate-code
             f"postgresql+psycopg2://{db_url}",
             pool_pre_ping=True,
             connect_args={

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 """Basic client for connecting to postgres database with login credentials"""
 
 from __future__ import annotations
@@ -51,7 +52,7 @@ class OrderbookFetcher:
         else:
             db_url = os.environ[f"{db_env}_DB_URL"]
 
-        return create_engine( # pylint: disable=duplicate-code
+        return create_engine(
             f"postgresql+psycopg2://{db_url}",
             pool_pre_ping=True,
             connect_args={


### PR DESCRIPTION
This PR matches the changes to the `pg_client` from PR #456 to update the `OrderbookFetcher`. This fixes a connection timeout error for some of the order-rewards jobs.