### PR TITLE
[Hotfix] Materialize intermediate trade data view

### DIFF
--- a/queries/orderbook/order_data.sql
+++ b/queries/orderbook/order_data.sql
@@ -133,7 +133,7 @@ price_data as (
         on tdp.auction_id = ap_protocol.auction_id and tdp.surplus_token = ap_protocol.token
 ),
 
-trade_data_processed_with_prices as (
+trade_data_processed_with_prices as materialized (
     select --noqa: ST06
         tdp.auction_id,
         tdp.solver,


### PR DESCRIPTION
This draft PR is for testing a fix to a performance degradation of the base trade data query.

The PR only add a `materialized` to an intermediate table.

This fix should not be required if the database is configured correctly. This is only for testing a hotfix.