### PR TITLE
Fix dashboard url

### DIFF
--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -59,10 +59,6 @@ def manual_propose(
     Entry point to manual creation of rewards payout transaction.
     This function generates the CSV transfer file to be pasted into the COW Safe app
     """
-    print(
-        f"Please double check the batches with unusual slippage: "
-        f"{period.unusual_slippage_url()}"
-    )
     csv_transfers = [asdict(CSVTransfer.from_transfer(t)) for t in transfers]
     FileIO(config.io_config.csv_output_dir).write_csv(
         csv_transfers, f"transfers-{config.io_config.network.value}-{period}.csv"

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -37,12 +37,17 @@ def dashboard_url(period: AccountingPeriod, config: AccountingConfig) -> str:
     base = "https://dune.com/cowprotocol/"
     slug = "cow-solver-rewards"
     # reward parameters
-    decimals = 18  # this might need to be network dependent
-    upper_cap = Fraction(config.reward_config.batch_reward_cap_upper, 10**decimals)
-    lower_cap = -Fraction(config.reward_config.batch_reward_cap_lower, 10**decimals)
-    quote_reward = Fraction(config.reward_config.quote_reward_cow, 10**decimals)
+    decimals_native_token = 18  # this could be fetched from a node
+    decimals_cow = 18  # this could be fetched from a node
+    upper_cap = Fraction(
+        config.reward_config.batch_reward_cap_upper, 10**decimals_native_token
+    )
+    lower_cap = -Fraction(
+        config.reward_config.batch_reward_cap_lower, 10**decimals_native_token
+    )
+    quote_reward = Fraction(config.reward_config.quote_reward_cow, 10**decimals_cow)
     quote_cap_native_token = Fraction(
-        config.reward_config.quote_reward_cap_native, 10**decimals
+        config.reward_config.quote_reward_cap_native, 10**decimals_native_token
     )
     query = (
         f"?start_time={period.start}&end_time={period.end}"

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -36,15 +36,19 @@ def dashboard_url(period: AccountingPeriod, config: AccountingConfig) -> str:
     """Returns a link to the solver accounting dashboard.s"""
     base = "https://dune.com/cowprotocol/"
     slug = "cow-solver-rewards"
-    upper_cap = Fraction(config.reward_config.batch_reward_cap_upper, 10**18)
-    lower_cap = -Fraction(config.reward_config.batch_reward_cap_lower, 10**18)
+    # reward parameters
+    decimals = 18  # this might need to be network dependent
+    upper_cap = Fraction(config.reward_config.batch_reward_cap_upper, 10**decimals)
+    lower_cap = -Fraction(config.reward_config.batch_reward_cap_lower, 10**decimals)
+    quote_reward = Fraction(config.reward_config.quote_reward_cow, 10**decimals)
     quote_cap_native_token = Fraction(
-        config.reward_config.quote_reward_cap_native, 10**18
+        config.reward_config.quote_reward_cap_native, 10**decimals
     )
     query = (
         f"?start_time={period.start}&end_time={period.end}"
         f"&blockchain={config.dune_config.dune_blockchain}"
         f"&upper_cap={upper_cap:g}&lower_cap={lower_cap:g}"
+        f"&quote_reward={quote_reward:g}"
         f"&quote_cap_native_token={quote_cap_native_token:g}"
     )
     return base + urllib.parse.quote_plus(slug + query, safe="=&?")

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -33,6 +33,7 @@ log = set_log(__name__)
 
 
 def dashboard_url(period: AccountingPeriod, config: AccountingConfig) -> str:
+    """Returns a link to the solver accounting dashboard.s"""
     base = "https://dune.com/cowprotocol/"
     slug = "cow-solver-rewards"
     upper_cap = Fraction(config.reward_config.batch_reward_cap_upper, 10**18)

--- a/src/models/accounting_period.py
+++ b/src/models/accounting_period.py
@@ -4,7 +4,6 @@ Common location for shared resources throughout the project.
 
 from __future__ import annotations
 
-import urllib.parse
 from datetime import datetime, timedelta
 
 from dune_client.types import QueryParameter
@@ -36,9 +35,3 @@ class AccountingPeriod:
             QueryParameter.date_type("start_time", self.start),
             QueryParameter.date_type("end_time", self.end),
         ]
-
-    def unusual_slippage_url(self) -> str:
-        """Returns a link to unusual slippage query for period"""
-        base = "https://dune.com/queries/2332678"
-        query = f"?start_time={self.start}&end_time={self.end}"
-        return base + urllib.parse.quote_plus(query, safe="=&?")

--- a/src/models/accounting_period.py
+++ b/src/models/accounting_period.py
@@ -37,13 +37,6 @@ class AccountingPeriod:
             QueryParameter.date_type("end_time", self.end),
         ]
 
-    def dashboard_url(self) -> str:
-        """Constructs Solver Accounting Dashboard URL for Period"""
-        base = "https://dune.com/cowprotocol/"
-        slug = "cow-solver-rewards"
-        query = f"?start_time={self.start}&end_time={self.end}"
-        return base + urllib.parse.quote_plus(slug + query, safe="=&?")
-
     def unusual_slippage_url(self) -> str:
         """Returns a link to unusual slippage query for period"""
         base = "https://dune.com/queries/2332678"


### PR DESCRIPTION
This PR fixes the dashboard url for verifying payments.

It now takes into account the network and network specific parameters.

A follow up PR should fix parameters for unusual slippage.

At some point the function `dashboard_url` should be moved to some other file. It is not related to creating transfer files. The old place with the accounting period does not work though, as the url does depend on additional parameters.

This closes #473.