### PR TITLE
Update block range query

### DIFF
--- a/src/queries.py
+++ b/src/queries.py
@@ -32,7 +32,7 @@ class QueryData:
 QUERIES = {
     "PERIOD_BLOCK_INTERVAL": QueryData(
         name="Block Interval for Accounting Period",
-        q_id=4227027,
+        q_id=3333356,
     ),
     "VOUCH_REGISTRY": QueryData(
         name="Vouch Registry",


### PR DESCRIPTION
This PR changes the query id of the block range query. The two queries are identical but only one of them is under version control and also used by the main Dune rewards dashboard.