### PR TITLE
Correct auction prices from analytics table

### DIFF
--- a/queries/orderbook/.sqlfluff
+++ b/queries/orderbook/.sqlfluff
@@ -5,3 +5,4 @@ EPSILON_LOWER=10000000000000000
 EPSILON_UPPER=12000000000000000
 results=solver_rewards_script_table
 env=prod
+auction_prices_corrections=

--- a/queries/orderbook/barn_batch_rewards.sql
+++ b/queries/orderbook/barn_batch_rewards.sql
@@ -93,6 +93,17 @@ trade_data_processed as (
     from trade_data_unprocessed
 ),
 
+{{auction_prices_corrections}}
+
+auction_prices_processed as (
+    select
+        ap.auction_id,
+        ap.token,
+        coalesce(apc.price, ap.price) as price
+    from auction_prices as ap left outer join auction_prices_corrections as apc
+        on ap.auction_id = apc.auction_id and ap.token = apc.token
+),
+
 price_data as (
     select
         tdp.auction_id,
@@ -100,11 +111,11 @@ price_data as (
         ap_surplus.price / pow(10, 18) as surplus_token_native_price,
         ap_protocol.price / pow(10, 18) as protocol_fee_token_native_price,
         ap_sell.price / pow(10, 18) as network_fee_token_native_price
-    from trade_data_processed as tdp left outer join auction_prices as ap_sell -- contains price: sell token
+    from trade_data_processed as tdp left outer join auction_prices_processed as ap_sell -- contains price: sell token
         on tdp.auction_id = ap_sell.auction_id and tdp.sell_token = ap_sell.token
-    left outer join auction_prices as ap_surplus -- contains price: surplus token
+    left outer join auction_prices_processed as ap_surplus -- contains price: surplus token
         on tdp.auction_id = ap_surplus.auction_id and tdp.surplus_token = ap_surplus.token
-    left outer join auction_prices as ap_protocol -- contains price: protocol fee token
+    left outer join auction_prices_processed as ap_protocol -- contains price: protocol fee token
         on tdp.auction_id = ap_protocol.auction_id and tdp.surplus_token = ap_protocol.token
 ),
 

--- a/queries/orderbook/order_data.sql
+++ b/queries/orderbook/order_data.sql
@@ -117,6 +117,17 @@ trade_data_processed as (
         on tdu.order_uid = pfk.order_uid and tdu.auction_id = pfk.auction_id
 ),
 
+{{auction_prices_corrections}}
+
+auction_prices_processed as (
+    select
+        ap.auction_id,
+        ap.token,
+        coalesce(apc.price, ap.price) as price
+    from auction_prices as ap left outer join auction_prices_corrections as apc
+        on ap.auction_id = apc.auction_id and ap.token = apc.token
+),
+
 price_data as (
     select
         tdp.auction_id,
@@ -125,11 +136,11 @@ price_data as (
         ap_protocol.price / pow(10, 18) as protocol_fee_token_native_price,
         ap_sell.price / pow(10, 18) as network_fee_token_native_price
     from trade_data_processed as tdp
-    left outer join auction_prices as ap_sell -- contains price: sell token
+    left outer join auction_prices_processed as ap_sell -- contains price: sell token
         on tdp.auction_id = ap_sell.auction_id and tdp.sell_token = ap_sell.token
-    left outer join auction_prices as ap_surplus -- contains price: surplus token
+    left outer join auction_prices_processed as ap_surplus -- contains price: surplus token
         on tdp.auction_id = ap_surplus.auction_id and tdp.surplus_token = ap_surplus.token
-    left outer join auction_prices as ap_protocol -- contains price: protocol fee token
+    left outer join auction_prices_processed as ap_protocol -- contains price: protocol fee token
         on tdp.auction_id = ap_protocol.auction_id and tdp.surplus_token = ap_protocol.token
 ),
 

--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -93,6 +93,17 @@ trade_data_processed as (
     from trade_data_unprocessed
 ),
 
+{{auction_prices_corrections}}
+
+auction_prices_processed as (
+    select
+        ap.auction_id,
+        ap.token,
+        coalesce(apc.price, ap.price) as price
+    from auction_prices as ap left outer join auction_prices_corrections as apc
+        on ap.auction_id = apc.auction_id and ap.token = apc.token
+),
+
 price_data as (
     select
         tdp.auction_id,
@@ -100,11 +111,11 @@ price_data as (
         ap_surplus.price / pow(10, 18) as surplus_token_native_price,
         ap_protocol.price / pow(10, 18) as protocol_fee_token_native_price,
         ap_sell.price / pow(10, 18) as network_fee_token_native_price
-    from trade_data_processed as tdp left outer join auction_prices as ap_sell -- contains price: sell token
+    from trade_data_processed as tdp left outer join auction_prices_processed as ap_sell -- contains price: sell token
         on tdp.auction_id = ap_sell.auction_id and tdp.sell_token = ap_sell.token
-    left outer join auction_prices as ap_surplus -- contains price: surplus token
+    left outer join auction_prices_processed as ap_surplus -- contains price: surplus token
         on tdp.auction_id = ap_surplus.auction_id and tdp.surplus_token = ap_surplus.token
-    left outer join auction_prices as ap_protocol -- contains price: protocol fee token
+    left outer join auction_prices_processed as ap_protocol -- contains price: protocol fee token
         on tdp.auction_id = ap_protocol.auction_id and tdp.surplus_token = ap_protocol.token
 ),
 

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -107,7 +107,7 @@ class OrderbookFetcher:
 auction_prices_corrections as (
     select
         0 as auction_id,
-        '\\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token,
+        '\\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::bytea as token,
         1000000000000000000 as price
     where false
 ),
@@ -125,7 +125,7 @@ auction_prices_corrections as (
             token_str = "\\x" + row["token"].hex()
             formatted_row = (
                 f"    {row['auction_id']} as auction_id,\n"
-                f"    '{token_str}' as token,\n"
+                f"    '{token_str}'::bytea as token,\n"
                 f"    {int(row['price'])} as price\n"
             )
 

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -122,7 +122,7 @@ auction_prices_corrections as (
         for _, row in auction_correction_prices.iterrows():
             if row["blockchain"] != blockchain:
                 continue
-            token_str = "\\" + row["token"].hex()[1:]
+            token_str = "\\x" + row["token"].hex()
             formatted_row = (
                 f"    {row['auction_id']} as auction_id,\n"
                 f"    '{token_str}' as token,\n"

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -81,7 +81,7 @@ class OrderbookFetcher:
         return barn, prod
 
     @classmethod
-    def fetch_auction_price_corrections(
+    def fetch_auction_prices_corrections(
         cls, config: AccountingConfig
     ) -> tuple[str, str]:
         """
@@ -167,7 +167,7 @@ auction_prices_corrections as (
         """
         load_dotenv()
         prod_prices_corrections_str, barn_prices_corrections_str = (
-            cls.fetch_auction_price_corrections(config)
+            cls.fetch_auction_prices_corrections(config)
         )
         batch_data_query_prod = (
             open_query("orderbook/prod_batch_rewards.sql")
@@ -254,7 +254,7 @@ auction_prices_corrections as (
         Fetches and validates Order Data DataFrame as concatenation from Prod and Staging DB
         """
         prod_prices_corrections_str, barn_prices_corrections_str = (
-            cls.fetch_auction_price_corrections(config)
+            cls.fetch_auction_prices_corrections(config)
         )
         cow_reward_query_prod = (
             open_query("orderbook/order_data.sql")

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -106,7 +106,7 @@ class OrderbookFetcher:
         empty_table = """
 auction_prices_corrections as (
     select
-        0 as action_id,
+        0 as auction_id,
         '\\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token,
         1000000000000000000 as price
     where false

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -84,6 +84,9 @@ class OrderbookFetcher:
     def fetch_auction_price_corrections(
         cls, config: AccountingConfig
     ) -> tuple[str, str]:
+        """
+        Fetches potentially relevant native price corrections from the analytics db
+        """
         query_str = "select * from auction_prices_corrections"
         auction_correction_prices = cls._read_query_for_env(
             query_str, OrderbookEnv.ANALYTICS

--- a/src/pg_client.py
+++ b/src/pg_client.py
@@ -43,6 +43,7 @@ class MultiInstanceDBFetcher:
         return pd.read_sql(sql=query, con=engine)
 
     def get_solver_rewards(  # pylint: disable=too-many-arguments
+        self,
         start_block: str,
         end_block: str,
         reward_cap_upper: int,

--- a/src/pg_client.py
+++ b/src/pg_client.py
@@ -48,6 +48,8 @@ class MultiInstanceDBFetcher:
         end_block: str,
         reward_cap_upper: int,
         reward_cap_lower: int,
+        prod_prices_corrections_str: str,
+        barn_prices_corrections_str: str,
     ) -> DataFrame:
         """
         Returns aggregated solver rewards for accounting period defined by block range
@@ -59,6 +61,7 @@ class MultiInstanceDBFetcher:
             .replace("{{EPSILON_LOWER}}", str(reward_cap_lower))
             .replace("{{EPSILON_UPPER}}", str(reward_cap_upper))
             .replace("{{results}}", "solver_rewards_script_table")
+            .replace("{{auction_prices_corrections}}", prod_prices_corrections_str)
         )
         batch_reward_query_barn = (
             open_query("orderbook/barn_batch_rewards.sql")
@@ -67,6 +70,7 @@ class MultiInstanceDBFetcher:
             .replace("{{EPSILON_LOWER}}", str(reward_cap_lower))
             .replace("{{EPSILON_UPPER}}", str(reward_cap_upper))
             .replace("{{results}}", "solver_rewards_script_table")
+            .replace("{{auction_prices_corrections}}", barn_prices_corrections_str)
         )
         results = []
 

--- a/src/pg_client.py
+++ b/src/pg_client.py
@@ -43,7 +43,6 @@ class MultiInstanceDBFetcher:
         return pd.read_sql(sql=query, con=engine)
 
     def get_solver_rewards(  # pylint: disable=too-many-arguments
-        self,
         start_block: str,
         end_block: str,
         reward_cap_upper: int,

--- a/src/pg_client.py
+++ b/src/pg_client.py
@@ -42,7 +42,7 @@ class MultiInstanceDBFetcher:
         """Executes query on DB engine"""
         return pd.read_sql(sql=query, con=engine)
 
-    def get_solver_rewards(
+    def get_solver_rewards(  # pylint: disable=too-many-arguments
         self,
         start_block: str,
         end_block: str,

--- a/tests/queries/test_batch_rewards.py
+++ b/tests/queries/test_batch_rewards.py
@@ -24,13 +24,22 @@ class TestBatchRewards(unittest.TestCase):
 
     def test_get_batch_rewards(self):
         start_block, end_block = "0", "100"
+        empty_table = """
+auction_prices_corrections as (
+    select
+        0 as action_id,
+        '\\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token,
+        1000000000000000000 as price
+    where false
+),
+        """
         batch_rewards = self.fetcher.get_solver_rewards(
             start_block,
             end_block,
             self.batch_reward_cap_upper,
             self.batch_reward_cap_lower,
-            "",
-            "",
+            empty_table,
+            empty_table,
         )
         expected = DataFrame(
             {

--- a/tests/queries/test_batch_rewards.py
+++ b/tests/queries/test_batch_rewards.py
@@ -28,7 +28,7 @@ class TestBatchRewards(unittest.TestCase):
 auction_prices_corrections as (
     select
         0 as auction_id,
-        '\\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token,
+        '\\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'::bytea as token,
         1000000000000000000 as price
     where false
 ),

--- a/tests/queries/test_batch_rewards.py
+++ b/tests/queries/test_batch_rewards.py
@@ -27,7 +27,7 @@ class TestBatchRewards(unittest.TestCase):
         empty_table = """
 auction_prices_corrections as (
     select
-        0 as action_id,
+        0 as auction_id,
         '\\xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token,
         1000000000000000000 as price
     where false

--- a/tests/queries/test_batch_rewards.py
+++ b/tests/queries/test_batch_rewards.py
@@ -29,6 +29,8 @@ class TestBatchRewards(unittest.TestCase):
             end_block,
             self.batch_reward_cap_upper,
             self.batch_reward_cap_lower,
+            "",
+            "",
         )
         expected = DataFrame(
             {


### PR DESCRIPTION
This PR introduces a preprocessing of the backend db `auction_prices` table. This allows for "manual" corrections of wrong native prices, that from time to time cause protocol/partner fees to explode.