### PR TITLE
Manual fix for prod mainnet auction 10052057

### DIFF
--- a/queries/orderbook/order_data.sql
+++ b/queries/orderbook/order_data.sql
@@ -121,8 +121,14 @@ price_data as (
     select
         tdp.auction_id,
         tdp.order_uid,
-        ap_surplus.price / pow(10, 18) as surplus_token_native_price,
-        ap_protocol.price / pow(10, 18) as protocol_fee_token_native_price,
+        case
+            when tdp.auction_id = 10052057 and tdp.surplus_token = '\x06b964d96f5dcf7eae9d7c559b09edce244d4b8e' then 212011986287238 / pow(10, 18)
+            else ap_surplus.price / pow(10, 18)
+        end as surplus_token_native_price,
+        case
+            when tdp.auction_id = 10052057 and tdp.surplus_token = '\x06b964d96f5dcf7eae9d7c559b09edce244d4b8e' then 212011986287238 / pow(10, 18)
+            else ap_protocol.price / pow(10, 18)
+        end as protocol_fee_token_native_price,
         ap_sell.price / pow(10, 18) as network_fee_token_native_price
     from trade_data_processed as tdp
     left outer join auction_prices as ap_sell -- contains price: sell token

--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -97,8 +97,14 @@ price_data as (
     select
         tdp.auction_id,
         tdp.order_uid,
-        ap_surplus.price / pow(10, 18) as surplus_token_native_price,
-        ap_protocol.price / pow(10, 18) as protocol_fee_token_native_price,
+        case
+            when tdp.auction_id = 10052057 and tdp.surplus_token = '\x06b964d96f5dcf7eae9d7c559b09edce244d4b8e' then 212011986287238 / pow(10, 18)
+            else ap_surplus.price / pow(10, 18)
+        end as surplus_token_native_price,
+        case
+            when tdp.auction_id = 10052057 and tdp.surplus_token = '\x06b964d96f5dcf7eae9d7c559b09edce244d4b8e' then 212011986287238 / pow(10, 18)
+            else ap_protocol.price / pow(10, 18)
+        end as protocol_fee_token_native_price,
         ap_sell.price / pow(10, 18) as network_fee_token_native_price
     from trade_data_processed as tdp left outer join auction_prices as ap_sell -- contains price: sell token
         on tdp.auction_id = ap_sell.auction_id and tdp.sell_token = ap_sell.token


### PR DESCRIPTION
This PR manually corrects the native price of https://etherscan.io/address/0x06b964d96f5dcf7eae9d7c559b09edce244d4b8e

for prod mainnet auction 10052057, which causes the protocol fee calculations to explode.
