### PR TITLE
Fix bug with orders in orders and jit_orders

### DIFF
--- a/queries/orderbook/barn_batch_rewards.sql
+++ b/queries/orderbook/barn_batch_rewards.sql
@@ -25,7 +25,9 @@ order_data as (
         kind,
         app_data
     from orders
-    union all
+    union distinct -- A _distinct_ union is needed since orders can appear in the normal orders
+    -- table and in the jit orders table. Since the uid is otherwise unique, no valid order is
+    -- removed by the _distinct_ union.
     select
         uid,
         sell_token,

--- a/queries/orderbook/order_data.sql
+++ b/queries/orderbook/order_data.sql
@@ -36,7 +36,9 @@ order_data as (
         kind,
         app_data
     from orders
-    union all
+    union distinct -- A _distinct_ union is needed since orders can appear in the normal orders
+    -- table and in the jit orders table. Since the uid is otherwise unique, no valid order is
+    -- removed by the _distinct_ union.
     select
         uid,
         sell_token,

--- a/queries/orderbook/prod_batch_rewards.sql
+++ b/queries/orderbook/prod_batch_rewards.sql
@@ -25,7 +25,9 @@ order_data as (
         kind,
         app_data
     from orders
-    union all
+    union distinct -- A _distinct_ union is needed since orders can appear in the normal orders
+    -- table and in the jit orders table. Since the uid is otherwise unique, no valid order is
+    -- removed by the _distinct_ union.
     select
         uid,
         sell_token,


### PR DESCRIPTION
This PR fixes a bug in order and batch data which lead to duplicate entries.

The problem is that orders can currently be part of the `orders` and `jit_orders` table. In our queries, we `union all` those to create an `order_data` table which keeps those duplicates. In following joins we keep those duplicates and even create new ones.

This PR just changes the `union all` to a `union distinct`. This removed duplicates from `order_data`. Due to the unique `uid` column of that table there cannot be legitimate duplicates.

The change has been tested locally for auction `10114998`, which currently has duplicate data for order `0xdb57e3403321e6565da156f1f9c8e4b8e305ee0e257ccde6d2628ae532d76a28fb84bcea1442dc40b903ebe17c3dffebe9a20cf3679a1184` on Dune.