### PR TITLE
Add list for custom partner fees

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -102,15 +102,13 @@ class ProtocolFeeConfig:
 
     Attributes:
     protocol_fee_safe -- address to forward protocol fees to
-    partner_fee_cut -- fraction of partner fees withheld from integration partners
-    partner_fee_reduced_cut -- reduced amount withheld from partner specified as reduced_cut_address
-    reduced_cut_address -- partner fee recipient who pays the reduced cut partner_fee_reduced_cut
+    default_partner_fee_cut -- default fraction of partner fees withheld from integration partners
+    reduced_partner_fee_list -- list of partner fee recipients and corresponding fractions for custom fee cuts
     """
 
     protocol_fee_safe: Address
-    partner_fee_cut: float
-    partner_fee_reduced_cut: float
-    reduced_cut_address: str
+    default_partner_fee_cut: float
+    reduced_partner_fee_list: list[dict[str, float]]
 
     @staticmethod
     def from_network(network: Network) -> ProtocolFeeConfig:
@@ -138,9 +136,12 @@ class ProtocolFeeConfig:
                 )
         return ProtocolFeeConfig(
             protocol_fee_safe=protocol_fee_safe,
-            partner_fee_cut=0.15,
-            partner_fee_reduced_cut=0.10,
-            reduced_cut_address="0x63695Eee2c3141BDE314C5a6f89B98E62808d716",
+            default_partner_fee_cut=0.5,
+            partner_fee_reduced_cut=[
+                {"0xe37da2d07e769b7fcb808bdeaeffb84561ff4eca": 0.15},
+                {"0x63695eee2c3141bde314c5a6f89b98e62808d716": 0.10},
+                {"0x352a3666b27bb09aca7b4a71ed624429b7549551": 0.15},
+            ],
         )
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -103,7 +103,7 @@ class ProtocolFeeConfig:
     Attributes:
     protocol_fee_safe -- address to forward protocol fees to
     default_partner_fee_cut -- default fraction of partner fees withheld from integration partners
-    custom_partner_fee_list -- list of partner fee recipients and corresponding fractions for custom fee cuts
+    custom_partner_fee_list -- list of partner fee recipients and corresponding fractions
     """
 
     protocol_fee_safe: Address

--- a/src/config.py
+++ b/src/config.py
@@ -141,6 +141,7 @@ class ProtocolFeeConfig:
                 "0xe37da2d07e769b7fcb808bdeaeffb84561ff4eca": 0.15,
                 "0x63695eee2c3141bde314c5a6f89b98e62808d716": 0.10,
                 "0x352a3666b27bb09aca7b4a71ed624429b7549551": 0.15,
+                "0x90a48d5cf7343b08da12e067680b4c6dbfe551be": 0.15,
             },
         )
 

--- a/src/config.py
+++ b/src/config.py
@@ -103,12 +103,12 @@ class ProtocolFeeConfig:
     Attributes:
     protocol_fee_safe -- address to forward protocol fees to
     default_partner_fee_cut -- default fraction of partner fees withheld from integration partners
-    custom_partner_fee_list -- list of partner fee recipients and corresponding fractions
+    custom_partner_fee_dict -- dictionary of partner fee recipients and corresponding fractions
     """
 
     protocol_fee_safe: Address
     default_partner_fee_cut: float
-    custom_partner_fee_list: list[dict[str, float]]
+    custom_partner_fee_dict: dict[str, float]
 
     @staticmethod
     def from_network(network: Network) -> ProtocolFeeConfig:
@@ -137,11 +137,11 @@ class ProtocolFeeConfig:
         return ProtocolFeeConfig(
             protocol_fee_safe=protocol_fee_safe,
             default_partner_fee_cut=0.5,
-            custom_partner_fee_list=[
-                {"0xe37da2d07e769b7fcb808bdeaeffb84561ff4eca": 0.15},
-                {"0x63695eee2c3141bde314c5a6f89b98e62808d716": 0.10},
-                {"0x352a3666b27bb09aca7b4a71ed624429b7549551": 0.15},
-            ],
+            custom_partner_fee_dict={
+                "0xe37da2d07e769b7fcb808bdeaeffb84561ff4eca": 0.15,
+                "0x63695eee2c3141bde314c5a6f89b98e62808d716": 0.10,
+                "0x352a3666b27bb09aca7b4a71ed624429b7549551": 0.15,
+            },
         )
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -103,7 +103,7 @@ class ProtocolFeeConfig:
     Attributes:
     protocol_fee_safe -- address to forward protocol fees to
     default_partner_fee_cut -- default fraction of partner fees withheld from integration partners
-    reduced_partner_fee_list -- list of partner fee recipients and corresponding fractions for custom fee cuts
+    custom_partner_fee_list -- list of partner fee recipients and corresponding fractions for custom fee cuts
     """
 
     protocol_fee_safe: Address

--- a/src/config.py
+++ b/src/config.py
@@ -108,7 +108,7 @@ class ProtocolFeeConfig:
 
     protocol_fee_safe: Address
     default_partner_fee_cut: float
-    reduced_partner_fee_list: list[dict[str, float]]
+    custom_partner_fee_list: list[dict[str, float]]
 
     @staticmethod
     def from_network(network: Network) -> ProtocolFeeConfig:
@@ -137,7 +137,7 @@ class ProtocolFeeConfig:
         return ProtocolFeeConfig(
             protocol_fee_safe=protocol_fee_safe,
             default_partner_fee_cut=0.5,
-            partner_fee_reduced_cut=[
+            custom_partner_fee_list=[
                 {"0xe37da2d07e769b7fcb808bdeaeffb84561ff4eca": 0.15},
                 {"0x63695eee2c3141bde314c5a6f89b98e62808d716": 0.10},
                 {"0x352a3666b27bb09aca7b4a71ed624429b7549551": 0.15},

--- a/src/fetch/partner_fees.py
+++ b/src/fetch/partner_fees.py
@@ -124,10 +124,10 @@ def compute_partner_fees_per_partner(
         columns=["partner", "partner_fee_eth"],
     )
 
-    partner_fees_df["partner_fee_tax"] = np.where(
-        partner_fees_df["partner"] in config.custom_partner_fee_list,
-        config.custom_partner_fee_list[partner_fees_df["partner"]],
-        config.default_partner_fee_cut,
+    partner_fees_df["partner_fee_tax"] = (
+        partner_fees_df["partner"]
+        .map(config.custom_partner_fee_dict)
+        .fillna(config.default_partner_fee_cut)
     )
 
     # change all types to object to use native python types

--- a/src/fetch/partner_fees.py
+++ b/src/fetch/partner_fees.py
@@ -125,9 +125,9 @@ def compute_partner_fees_per_partner(
     )
 
     partner_fees_df["partner_fee_tax"] = np.where(
-        partner_fees_df["partner"] == config.reduced_cut_address,
-        config.partner_fee_reduced_cut,
-        config.partner_fee_cut,
+        partner_fees_df["partner"] in config.reduced_partner_fee_list,
+        config.reduced_partner_fee_list[partner_fees_df["partner"]],
+        config.default_partner_fee_cut,
     )
 
     # change all types to object to use native python types

--- a/src/fetch/partner_fees.py
+++ b/src/fetch/partner_fees.py
@@ -2,7 +2,6 @@
 
 from collections import defaultdict
 
-import numpy as np
 import pandas as pd
 from pandas import DataFrame
 

--- a/src/fetch/partner_fees.py
+++ b/src/fetch/partner_fees.py
@@ -125,8 +125,8 @@ def compute_partner_fees_per_partner(
     )
 
     partner_fees_df["partner_fee_tax"] = np.where(
-        partner_fees_df["partner"] in config.reduced_partner_fee_list,
-        config.reduced_partner_fee_list[partner_fees_df["partner"]],
+        partner_fees_df["partner"] in config.custom_partner_fee_list,
+        config.custom_partner_fee_list[partner_fees_df["partner"]],
         config.default_partner_fee_cut,
     )
 

--- a/tests/unit/test_partner_fees.py
+++ b/tests/unit/test_partner_fees.py
@@ -24,7 +24,7 @@ def test_compute_partner_fees_per_partner():
         {
             "partner": ["partner_1", "partner_2", "partner_3"],
             "partner_fee_eth": [10**16, 10**17 + 10**18, 10**19],
-            "partner_fee_tax": [0.15, 0.15, 0.15],
+            "partner_fee_tax": [0.5, 0.5, 0.5],
         }
     ).astype(object)
 
@@ -58,7 +58,7 @@ def test_compute_partner_fees_per_partner_reduced_cut():
     config = ProtocolFeeConfig.from_network(Network.MAINNET)
     partner_fee_lists = DataFrame(
         {
-            "partner_list": [[config.reduced_cut_address]],
+            "partner_list": [["0x63695eee2c3141bde314c5a6f89b98e62808d716"]],
             "partner_fee_eth": [[10**18]],
         }
     )
@@ -66,9 +66,13 @@ def test_compute_partner_fees_per_partner_reduced_cut():
     partner_fees_df = compute_partner_fees_per_partner(partner_fee_lists, config)
     expected_protocol_fees_df = DataFrame(
         {
-            "partner": [config.reduced_cut_address],
+            "partner": ["0x63695eee2c3141bde314c5a6f89b98e62808d716"],
             "partner_fee_eth": [10**18],
-            "partner_fee_tax": [config.partner_fee_reduced_cut],
+            "partner_fee_tax": [
+                config.custom_partner_fee_dict[
+                    "0x63695eee2c3141bde314c5a6f89b98e62808d716"
+                ]
+            ],
         }
     ).astype(object)
 
@@ -92,7 +96,7 @@ def test_compute_partner_fees_per_partner_duplicates():
         {
             "partner": ["partner_1"],
             "partner_fee_eth": [10**17 + 10**18],
-            "partner_fee_tax": [0.15],
+            "partner_fee_tax": [0.5],
         }
     ).astype(object)
 


### PR DESCRIPTION
This PR allows to set different percents for the partner fee cut, depending on the partner. Up till now, there was only one partner address that could have a custom fee