### PR TITLE
Make custom partner fees case-insensitive

### DIFF
--- a/src/fetch/partner_fees.py
+++ b/src/fetch/partner_fees.py
@@ -125,8 +125,11 @@ def compute_partner_fees_per_partner(
 
     partner_fees_df["partner_fee_tax"] = (
         partner_fees_df["partner"]
-        .map(config.custom_partner_fee_dict)
-        .fillna(config.default_partner_fee_cut)
+        .str.lower()  # Convert the partner column to lowercase
+        .map(
+            {k.lower(): v for k, v in config.custom_partner_fee_dict.items()}
+        )  # Convert keys to lowercase
+        .fillna(config.default_partner_fee_cut)  # Fill missing values
     )
 
     # change all types to object to use native python types


### PR DESCRIPTION
The implementation of PR #509 made the checks for partner fees case-sensitive. This PR fixes this.