### PR TITLE
Add list of bonding pools where we redirect everything to rewards addresses

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -31,7 +31,7 @@ class RewardConfig:
     """Configuration for reward mechanism."""
 
     reward_token_address: Address
-    cow_bonding_pool: Address
+    send_everything_to_rewards_address_bonding_pools: list[Address]
     batch_reward_cap_upper: int
     batch_reward_cap_lower: int
     quote_reward_cow: int
@@ -41,7 +41,14 @@ class RewardConfig:
     @staticmethod
     def from_network(network: Network) -> RewardConfig:
         """Initialize reward config for a given network."""
-        cow_bonding_pool = Address("0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6")
+        send_everything_to_rewards_address_bonding_pools = [
+            Address(
+                "0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6"
+            ),  # CoW DAO bonding pool
+            Address(
+                "0x0deb0ae9c4399c51289adb1f3ed83557a56df657"
+            ),  # Rizzolver bonding pool
+        ]
         service_fee_factor = Fraction(15, 100)
         match network:
             case Network.MAINNET:
@@ -54,7 +61,7 @@ class RewardConfig:
                     quote_reward_cow=6 * 10**18,
                     quote_reward_cap_native=6 * 10**14,
                     service_fee_factor=service_fee_factor,
-                    cow_bonding_pool=cow_bonding_pool,
+                    send_everything_to_rewards_address_bonding_pools=send_everything_to_rewards_address_bonding_pools,
                 )
             case Network.GNOSIS:
                 return RewardConfig(
@@ -66,7 +73,7 @@ class RewardConfig:
                     quote_reward_cow=6 * 10**18,
                     quote_reward_cap_native=15 * 10**16,
                     service_fee_factor=service_fee_factor,
-                    cow_bonding_pool=cow_bonding_pool,
+                    send_everything_to_rewards_address_bonding_pools=send_everything_to_rewards_address_bonding_pools,
                 )
             case Network.ARBITRUM_ONE:
                 return RewardConfig(
@@ -78,7 +85,7 @@ class RewardConfig:
                     quote_reward_cow=6 * 10**18,
                     quote_reward_cap_native=2 * 10**14,
                     service_fee_factor=service_fee_factor,
-                    cow_bonding_pool=cow_bonding_pool,
+                    send_everything_to_rewards_address_bonding_pools=send_everything_to_rewards_address_bonding_pools,
                 )
             case Network.BASE:
                 return RewardConfig(
@@ -90,7 +97,7 @@ class RewardConfig:
                     quote_reward_cow=6 * 10**18,
                     quote_reward_cap_native=2 * 10**14,
                     service_fee_factor=service_fee_factor,
-                    cow_bonding_pool=cow_bonding_pool,
+                    send_everything_to_rewards_address_bonding_pools=send_everything_to_rewards_address_bonding_pools,
                 )
             case _:
                 raise ValueError(f"No reward config set up for network {network}.")

--- a/src/config.py
+++ b/src/config.py
@@ -31,7 +31,6 @@ class RewardConfig:
     """Configuration for reward mechanism."""
 
     reward_token_address: Address
-    send_gas_to_rewards_address_pools: list[Address]
     batch_reward_cap_upper: int
     batch_reward_cap_lower: int
     quote_reward_cow: int
@@ -41,14 +40,6 @@ class RewardConfig:
     @staticmethod
     def from_network(network: Network) -> RewardConfig:
         """Initialize reward config for a given network."""
-        send_gas_to_rewards_address_pools = [
-            Address(
-                "0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6"
-            ),  # CoW DAO bonding pool
-            Address(
-                "0x0deb0ae9c4399c51289adb1f3ed83557a56df657"
-            ),  # Rizzolver bonding pool
-        ]
         service_fee_factor = Fraction(15, 100)
         match network:
             case Network.MAINNET:
@@ -61,7 +52,6 @@ class RewardConfig:
                     quote_reward_cow=6 * 10**18,
                     quote_reward_cap_native=6 * 10**14,
                     service_fee_factor=service_fee_factor,
-                    send_gas_to_rewards_address_pools=send_gas_to_rewards_address_pools,
                 )
             case Network.GNOSIS:
                 return RewardConfig(
@@ -73,7 +63,6 @@ class RewardConfig:
                     quote_reward_cow=6 * 10**18,
                     quote_reward_cap_native=15 * 10**16,
                     service_fee_factor=service_fee_factor,
-                    send_gas_to_rewards_address_pools=send_gas_to_rewards_address_pools,
                 )
             case Network.ARBITRUM_ONE:
                 return RewardConfig(
@@ -85,7 +74,6 @@ class RewardConfig:
                     quote_reward_cow=6 * 10**18,
                     quote_reward_cap_native=2 * 10**14,
                     service_fee_factor=service_fee_factor,
-                    send_gas_to_rewards_address_pools=send_gas_to_rewards_address_pools,
                 )
             case Network.BASE:
                 return RewardConfig(
@@ -97,7 +85,6 @@ class RewardConfig:
                     quote_reward_cow=6 * 10**18,
                     quote_reward_cap_native=2 * 10**14,
                     service_fee_factor=service_fee_factor,
-                    send_gas_to_rewards_address_pools=send_gas_to_rewards_address_pools,
                 )
             case _:
                 raise ValueError(f"No reward config set up for network {network}.")
@@ -177,10 +164,19 @@ class BufferAccountingConfig:
     """Configuration for buffer accounting."""
 
     include_slippage: bool
+    send_buffers_to_rewards_address_pools: list[Address]
 
     @staticmethod
     def from_network(network: Network) -> BufferAccountingConfig:
         """Initialize buffer accounting config for a given network."""
+        send_buffers_to_rewards_address_pools = [
+            Address(
+                "0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6"
+            ),  # CoW DAO bonding pool
+            Address(
+                "0x0deb0ae9c4399c51289adb1f3ed83557a56df657"
+            ),  # Rizzolver bonding pool
+        ]
         match network:
             case Network.MAINNET | Network.GNOSIS | Network.ARBITRUM_ONE | Network.BASE:
                 include_slippage = True
@@ -191,6 +187,7 @@ class BufferAccountingConfig:
 
         return BufferAccountingConfig(
             include_slippage=include_slippage,
+            send_buffers_to_rewards_address_pools=send_buffers_to_rewards_address_pools,
         )
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -31,7 +31,7 @@ class RewardConfig:
     """Configuration for reward mechanism."""
 
     reward_token_address: Address
-    send_everything_to_rewards_address_bonding_pools: list[Address]
+    send_gas_to_rewards_address_pools: list[Address]
     batch_reward_cap_upper: int
     batch_reward_cap_lower: int
     quote_reward_cow: int
@@ -41,7 +41,7 @@ class RewardConfig:
     @staticmethod
     def from_network(network: Network) -> RewardConfig:
         """Initialize reward config for a given network."""
-        send_everything_to_rewards_address_bonding_pools = [
+        send_gas_to_rewards_address_pools = [
             Address(
                 "0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6"
             ),  # CoW DAO bonding pool
@@ -61,7 +61,7 @@ class RewardConfig:
                     quote_reward_cow=6 * 10**18,
                     quote_reward_cap_native=6 * 10**14,
                     service_fee_factor=service_fee_factor,
-                    send_everything_to_rewards_address_bonding_pools=send_everything_to_rewards_address_bonding_pools,
+                    send_gas_to_rewards_address_pools=send_gas_to_rewards_address_pools,
                 )
             case Network.GNOSIS:
                 return RewardConfig(
@@ -73,7 +73,7 @@ class RewardConfig:
                     quote_reward_cow=6 * 10**18,
                     quote_reward_cap_native=15 * 10**16,
                     service_fee_factor=service_fee_factor,
-                    send_everything_to_rewards_address_bonding_pools=send_everything_to_rewards_address_bonding_pools,
+                    send_gas_to_rewards_address_pools=send_gas_to_rewards_address_pools,
                 )
             case Network.ARBITRUM_ONE:
                 return RewardConfig(
@@ -85,7 +85,7 @@ class RewardConfig:
                     quote_reward_cow=6 * 10**18,
                     quote_reward_cap_native=2 * 10**14,
                     service_fee_factor=service_fee_factor,
-                    send_everything_to_rewards_address_bonding_pools=send_everything_to_rewards_address_bonding_pools,
+                    send_gas_to_rewards_address_pools=send_gas_to_rewards_address_pools,
                 )
             case Network.BASE:
                 return RewardConfig(
@@ -97,7 +97,7 @@ class RewardConfig:
                     quote_reward_cow=6 * 10**18,
                     quote_reward_cap_native=2 * 10**14,
                     service_fee_factor=service_fee_factor,
-                    send_everything_to_rewards_address_bonding_pools=send_everything_to_rewards_address_bonding_pools,
+                    send_gas_to_rewards_address_pools=send_gas_to_rewards_address_pools,
                 )
             case _:
                 raise ValueError(f"No reward config set up for network {network}.")

--- a/src/fetch/solver_info.py
+++ b/src/fetch/solver_info.py
@@ -93,11 +93,14 @@ def compute_solver_info(
         service_fees[SERVICE_FEES_COLUMNS], how="outer", on="solver"
     )
 
-    send_gas_to_rewards_address_pools_addresses = [
-        pool.address for pool in config.reward_config.send_gas_to_rewards_address_pools
+    send_buffers_to_rewards_address_pools_addresses = [
+        pool.address
+        for pool in config.buffer_accounting_config.send_buffers_to_rewards_address_pools
     ]
     solver_info["buffer_accounting_target"] = np.where(
-        solver_info["pool_address"].isin(send_gas_to_rewards_address_pools_addresses),
+        solver_info["pool_address"].isin(
+            send_buffers_to_rewards_address_pools_addresses
+        ),
         solver_info["reward_target"],
         solver_info["solver"],
     )

--- a/src/fetch/solver_info.py
+++ b/src/fetch/solver_info.py
@@ -93,10 +93,16 @@ def compute_solver_info(
         service_fees[SERVICE_FEES_COLUMNS], how="outer", on="solver"
     )
 
+    send_everything_to_rewards_address_bonding_pools_addresses = [
+        pool.address
+        for pool in config.reward_config.send_everything_to_rewards_address_bonding_pools
+    ]
     solver_info["buffer_accounting_target"] = np.where(
-        solver_info["pool_address"] != config.reward_config.cow_bonding_pool.address,
-        solver_info["solver"],
+        solver_info["pool_address"].isin(
+            send_everything_to_rewards_address_bonding_pools_addresses
+        ),
         solver_info["reward_target"],
+        solver_info["solver"],
     )
     solver_info = solver_info.drop("pool_address", axis=1)
 

--- a/src/fetch/solver_info.py
+++ b/src/fetch/solver_info.py
@@ -93,14 +93,11 @@ def compute_solver_info(
         service_fees[SERVICE_FEES_COLUMNS], how="outer", on="solver"
     )
 
-    send_everything_to_rewards_address_bonding_pools_addresses = [
-        pool.address
-        for pool in config.reward_config.send_everything_to_rewards_address_bonding_pools
+    send_gas_to_rewards_address_pools_addresses = [
+        pool.address for pool in config.reward_config.send_gas_to_rewards_address_pools
     ]
     solver_info["buffer_accounting_target"] = np.where(
-        solver_info["pool_address"].isin(
-            send_everything_to_rewards_address_bonding_pools_addresses
-        ),
+        solver_info["pool_address"].isin(send_gas_to_rewards_address_pools_addresses),
         solver_info["reward_target"],
         solver_info["solver"],
     )

--- a/tests/unit/test_solver_info.py
+++ b/tests/unit/test_solver_info.py
@@ -54,7 +54,7 @@ def test_compute_solver_info_cow_dao_buffer_target():
         {
             "solver": ["solver_1"],
             "reward_target": ["target_1"],
-            "pool_address": [str(config.reward_config.cow_bonding_pool)],
+            "pool_address": ["0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6"],
             "solver_name": ["solver_name_1"],
         }
     )


### PR DESCRIPTION
This PR implements a request from the Rizzolver bonding pool and introduces a list of bonding pools where all relevant solvers receive their native token reimbursements in their rewards addresses (instead of their submission addresses)