### PR TITLE
Fix usdc native price issue

### DIFF
--- a/queries/orderbook/auction_prices_corrections.sql
+++ b/queries/orderbook/auction_prices_corrections.sql
@@ -81,6 +81,42 @@ auction_prices_corrections (blockchain, environment, auction_id, token, price) a
         -- price taken from nearby auction 10325156
         ('ethereum', 'prod', 10325171::bigint, '\x35d8949372d46b7a3d5a56006ae77b215fc69bc0'::bytea, 533247805376780::numeric(78, 0)),
 
+        -- bogus baseline price for USDC that caused a crazy native price for the token
+        -- query to confirm results: select * from auction_prices where token='\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' and price > 56150942718177291268870111000;
+        -- fixing 29 auctions in total
+
+        ('ethereum', 'prod', 10410755::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410754::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410753::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410752::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410751::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410750::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410749::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410748::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410747::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410746::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410745::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410744::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410743::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410742::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410741::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410740::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410739::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410738::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410737::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410736::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410735::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410734::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410733::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410732::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410731::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410730::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410729::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410728::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+        ('ethereum', 'prod', 10410727::bigint, '\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::bytea, 524485367578693373855268864::numeric(78, 0)),
+
+        ----------- USDC fix done -----------
+
         -- correction only relevant for the tests in the test_batch_rewards.py file
         ('ethereum', 'prod', 53::bigint, '\x02'::bytea, 500000000000000::numeric(78, 0))
 

--- a/queries/orderbook/excluded_quotes.sql
+++ b/queries/orderbook/excluded_quotes.sql
@@ -1,9 +1,9 @@
--- this table excludes certain accounts due to wash-trading
+-- this table excludes certain accounts due to repetitive trading back and forth
 excluded_quotes as ( --noqa: PRS
     select uid as order_uid
     from orders
     where (
-        -- wash-trading USDC/DAI on mainnet
+        -- repetitive trading USDC/DAI on mainnet
         (
             owner = '\x687f584fd1f4a4d9eb277c03a24fe28f4b0675b7'
             or
@@ -20,7 +20,7 @@ excluded_quotes as ( --noqa: PRS
     )
     or
     (
-        -- wash-trading USDC/USDT on mainnet
+        -- repetitive trading USDC/USDT on mainnet
         (
             owner = '\x9071bfe89d0880edc21e977f3837b5503200f11d'
             or
@@ -55,7 +55,7 @@ excluded_quotes as ( --noqa: PRS
     )
     or
     (
-        -- wash-trading DAI/USDT on mainnet
+        -- repetitive trading DAI/USDT on mainnet
         owner = '\xbde2ff8a6c87594dff3ef96ef7809be5d5eacde4'
         and
         (
@@ -66,7 +66,7 @@ excluded_quotes as ( --noqa: PRS
     )
     or
     (
-        -- wash-trading WETH/WSTETH on mainnet
+        -- repetitive trading WETH/WSTETH on mainnet
         owner = '\x8ca1187f83f434d5db5c7688fd64bffa281acccc'
         and
         (
@@ -77,7 +77,7 @@ excluded_quotes as ( --noqa: PRS
     )
     or
     (
-        -- wash-trading USDC/USDBC on Base
+        -- repetitive trading USDC/USDBC on Base
         owner = '\xd5c813a01224cabc76e4cd8e10e4029dca0bd7f9'
         and
         (
@@ -88,7 +88,7 @@ excluded_quotes as ( --noqa: PRS
     )
     or
     (
-        -- wash-trading USDC/USDCE on Arbitrum
+        -- repetitive trading USDC/USDCE on Arbitrum
         owner = '\xd7fcb6fdb9e51507f872442efb4d5c40a60c6d36'
         and
         (
@@ -99,7 +99,7 @@ excluded_quotes as ( --noqa: PRS
     )
     or
     (
-        -- wash-trading WETH/USDC on Base
+        -- repetitive trading WETH/USDC on Base
         owner = '\x2bcd269ff2c06c95834cb3eca0e52987e58cc5b1'
         and
         (


### PR DESCRIPTION
This PR corrects the USDC native price on mainnet for certain auctions, due to a bogus USDC native price that temporarily appeared.

The bogus price that appeared was this one: 56150942718177291268870111232
which suggests that the price of ETH is
```
10^36 / 56150942718177291268870111232 / 10^6 = 17.80914 USDC.
```

Prod mainnet auctions with id in [10410727, 10410755] were affected.  No barn auctions seem to have been affected

We use the correct price that appeared in auction 10410756 to correct all previous ones

```
mainnet=> select * from auction_prices where token='\xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' and auction_id = 10410756;
 auction_id |                   token                    |            price            
------------+--------------------------------------------+-----------------------------
   10410756 | \xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 | 523378898648164562100027392
(1 row)
```