### PR TITLE
Implement CIP-68

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -28,7 +28,9 @@ jobs:
           python -m pytest tests/unit
         env:
           NETWORK: 'mainnet'
+          NODE_URL_MAINNET: https://ethereum-rpc.publicnode.com
           NODE_URL: https://ethereum-rpc.publicnode.com
+          PAYOUTS_SAFE_ADDRESS_MAINNET: '0x0000000000000000000000000000000000000000'
           PAYOUTS_SAFE_ADDRESS: '0x0000000000000000000000000000000000000000'
 
   sqlfluff:

--- a/src/config.py
+++ b/src/config.py
@@ -41,53 +41,38 @@ class RewardConfig:
     def from_network(network: Network) -> RewardConfig:
         """Initialize reward config for a given network."""
         service_fee_factor = Fraction(15, 100)
+        reward_token_address = Address("0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB")
         match network:
             case Network.MAINNET:
-                return RewardConfig(
-                    reward_token_address=Address(
-                        "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB"
-                    ),
-                    batch_reward_cap_upper=12 * 10**15,
-                    batch_reward_cap_lower=10 * 10**15,
-                    quote_reward_cow=6 * 10**18,
-                    quote_reward_cap_native=6 * 10**14,
-                    service_fee_factor=service_fee_factor,
-                )
+                batch_reward_cap_upper = 12 * 10**15
+                batch_reward_cap_lower = 10 * 10**15
+                quote_reward_cow = 6 * 10**18
+                quote_reward_cap_native = 6 * 10**14
             case Network.GNOSIS:
-                return RewardConfig(
-                    reward_token_address=Address(
-                        "0x177127622c4a00f3d409b75571e12cb3c8973d3c"
-                    ),
-                    batch_reward_cap_upper=10 * 10**18,
-                    batch_reward_cap_lower=10 * 10**18,
-                    quote_reward_cow=6 * 10**18,
-                    quote_reward_cap_native=15 * 10**16,
-                    service_fee_factor=service_fee_factor,
-                )
+                batch_reward_cap_upper = 10 * 10**18
+                batch_reward_cap_lower = 10 * 10**18
+                quote_reward_cow = 6 * 10**18
+                quote_reward_cap_native = 15 * 10**16
             case Network.ARBITRUM_ONE:
-                return RewardConfig(
-                    reward_token_address=Address(
-                        "0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04"
-                    ),
-                    batch_reward_cap_upper=12 * 10**15,
-                    batch_reward_cap_lower=10 * 10**15,
-                    quote_reward_cow=6 * 10**18,
-                    quote_reward_cap_native=2 * 10**14,
-                    service_fee_factor=service_fee_factor,
-                )
+                batch_reward_cap_upper = 12 * 10**15
+                batch_reward_cap_lower = 10 * 10**15
+                quote_reward_cow = 6 * 10**18
+                quote_reward_cap_native = 2 * 10**14
             case Network.BASE:
-                return RewardConfig(
-                    reward_token_address=Address(
-                        "0xc694a91e6b071bf030a18bd3053a7fe09b6dae69"
-                    ),
-                    batch_reward_cap_upper=12 * 10**15,
-                    batch_reward_cap_lower=10 * 10**15,
-                    quote_reward_cow=6 * 10**18,
-                    quote_reward_cap_native=2 * 10**14,
-                    service_fee_factor=service_fee_factor,
-                )
+                batch_reward_cap_upper = 12 * 10**15
+                batch_reward_cap_lower = 10 * 10**15
+                quote_reward_cow = 6 * 10**18
+                quote_reward_cap_native = 2 * 10**14
             case _:
                 raise ValueError(f"No reward config set up for network {network}.")
+        return RewardConfig(
+            reward_token_address=reward_token_address,
+            batch_reward_cap_upper=batch_reward_cap_upper,
+            batch_reward_cap_lower=batch_reward_cap_lower,
+            quote_reward_cow=quote_reward_cow,
+            quote_reward_cap_native=quote_reward_cap_native,
+            service_fee_factor=service_fee_factor,
+        )
 
 
 @dataclass(frozen=True)
@@ -338,9 +323,11 @@ class PaymentConfig:
 
     network: EthereumNetwork
     cow_token_address: Address
-    payment_safe_address: ChecksumAddress
+    payment_safe_address_cow: ChecksumAddress
+    payment_safe_address_native: ChecksumAddress
     signing_key: str | None
-    safe_queue_url: str
+    safe_queue_url_cow: str
+    safe_queue_url_native: str
     verification_docs_url: str
     wrapped_native_token_address: ChecksumAddress
     wrapped_eth_address: Address
@@ -356,7 +343,16 @@ class PaymentConfig:
 
         docs_url = "https://www.notion.so/cownation/Solver-Payouts-3dfee64eb3d449ed8157a652cc817a8c"
 
-        payment_safe_address = Web3.to_checksum_address(
+        cow_token_address = Address(
+            "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB"
+        )
+        payment_safe_address_cow = Web3.to_checksum_address(
+            os.environ.get(
+                "PAYOUTS_SAFE_ADDRESS_MAINNET",
+                "",
+            )
+        )
+        payment_safe_address_native = Web3.to_checksum_address(
             os.environ.get(
                 "PAYOUTS_SAFE_ADDRESS",
                 "",
@@ -368,9 +364,6 @@ class PaymentConfig:
                 payment_network = EthereumNetwork.MAINNET
                 short_name = "eth"
 
-                cow_token_address = Address(
-                    "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB"
-                )
                 wrapped_native_token_address = Web3.to_checksum_address(
                     "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
                 )
@@ -384,9 +377,6 @@ class PaymentConfig:
                 payment_network = EthereumNetwork.GNOSIS
                 short_name = "gno"
 
-                cow_token_address = Address(
-                    "0x177127622c4a00f3d409b75571e12cb3c8973d3c"
-                )
                 wrapped_native_token_address = Web3.to_checksum_address(
                     "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d"
                 )
@@ -400,9 +390,6 @@ class PaymentConfig:
                 payment_network = EthereumNetwork.ARBITRUM_ONE
                 short_name = "arb1"
 
-                cow_token_address = Address(
-                    "0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04"
-                )
                 wrapped_native_token_address = Web3.to_checksum_address(
                     "0x82af49447d8a07e3bd95bd0d56f35241523fbab1"
                 )
@@ -416,9 +403,6 @@ class PaymentConfig:
                 payment_network = EthereumNetwork.BASE
                 short_name = "base"
 
-                cow_token_address = Address(
-                    "0xc694a91e6b071bf030a18bd3053a7fe09b6dae69"
-                )
                 wrapped_native_token_address = Web3.to_checksum_address(
                     "0x4200000000000000000000000000000000000006"
                 )
@@ -431,15 +415,19 @@ class PaymentConfig:
             case _:
                 raise ValueError(f"No payment config set up for network {network}.")
 
-        safe_url = f"https://app.safe.global/{short_name}:{payment_safe_address}"
-        safe_queue_url = f"{safe_url}/transactions/queue"
+        safe_url_cow = f"https://app.safe.global/{short_name}:{payment_safe_address_cow}"
+        safe_queue_url_cow = f"{safe_url_cow}/transactions/queue"
+        safe_url_native = f"https://app.safe.global/{short_name}:{payment_safe_address_native}"
+        safe_queue_url_native = f"{safe_url_native}/transactions/queue"
 
         return PaymentConfig(
             network=payment_network,
             cow_token_address=cow_token_address,
-            payment_safe_address=payment_safe_address,
+            payment_safe_address_cow=payment_safe_address_cow,
+            payment_safe_address_native=payment_safe_address_native,
             signing_key=signing_key,
-            safe_queue_url=safe_queue_url,
+            safe_queue_url_cow=safe_queue_url_cow,
+            safe_queue_url_native=safe_queue_url_native,
             verification_docs_url=docs_url,
             wrapped_native_token_address=wrapped_native_token_address,
             wrapped_eth_address=wrapped_eth_address,

--- a/src/config.py
+++ b/src/config.py
@@ -339,15 +339,14 @@ class PaymentConfig:
     @staticmethod
     def from_network(network: Network) -> PaymentConfig:
         """Initialize payment config for a given network."""
+        # pylint: disable=too-many-locals
         signing_key = os.getenv("PROPOSER_PK")
         if signing_key == "":
             signing_key = None
 
         docs_url = "https://www.notion.so/cownation/Solver-Payouts-3dfee64eb3d449ed8157a652cc817a8c"
 
-        cow_token_address = Address(
-            "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB"
-        )
+        cow_token_address = Address("0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB")
         payment_safe_address_cow = Web3.to_checksum_address(
             os.environ.get(
                 "PAYOUTS_SAFE_ADDRESS_MAINNET",
@@ -419,7 +418,9 @@ class PaymentConfig:
 
         safe_url_cow = f"https://app.safe.global/eth:{payment_safe_address_cow}"
         safe_queue_url_cow = f"{safe_url_cow}/transactions/queue"
-        safe_url_native = f"https://app.safe.global/{short_name}:{payment_safe_address_native}"
+        safe_url_native = (
+            f"https://app.safe.global/{short_name}:{payment_safe_address_native}"
+        )
         safe_queue_url_native = f"{safe_url_native}/transactions/queue"
 
         return PaymentConfig(

--- a/src/config.py
+++ b/src/config.py
@@ -328,6 +328,7 @@ class PaymentConfig:
     payment_safe_address_cow: ChecksumAddress
     payment_safe_address_native: ChecksumAddress
     signing_key: str | None
+    nonce_modifier: int
     safe_queue_url_cow: str
     safe_queue_url_native: str
     verification_docs_url: str
@@ -357,6 +358,21 @@ class PaymentConfig:
             os.environ.get(
                 "PAYOUTS_SAFE_ADDRESS",
                 "",
+            )
+        )
+
+        # mainnet transaction nonces are increased by this modifier to allow for proposing
+        # multiple transactions on mainnet
+        nonce_modifier_dict = {
+            Network.MAINNET: 0,
+            Network.GNOSIS: 1,
+            Network.ARBITRUM_ONE: 2,
+            Network.BASE: 3,
+        }
+        nonce_modifier = int(
+            os.environ.get(
+                "NONCE_MODIFIER",
+                nonce_modifier_dict[network],
             )
         )
 
@@ -429,6 +445,7 @@ class PaymentConfig:
             payment_safe_address_cow=payment_safe_address_cow,
             payment_safe_address_native=payment_safe_address_native,
             signing_key=signing_key,
+            nonce_modifier=nonce_modifier,
             safe_queue_url_cow=safe_queue_url_cow,
             safe_queue_url_native=safe_queue_url_native,
             verification_docs_url=docs_url,

--- a/src/config.py
+++ b/src/config.py
@@ -307,12 +307,14 @@ class NodeConfig:
     """Configuration for web3 node."""
 
     node_url: str
+    node_url_mainnet: str
 
     @staticmethod
     def from_env() -> NodeConfig:
         """Initialize node config from environment variables."""
         node_url = os.environ.get("NODE_URL", "")
-        return NodeConfig(node_url=node_url)
+        node_url_mainnet = os.environ.get("NODE_URL_MAINNET", "")
+        return NodeConfig(node_url=node_url, node_url_mainnet=node_url_mainnet)
 
 
 @dataclass(frozen=True)
@@ -415,7 +417,7 @@ class PaymentConfig:
             case _:
                 raise ValueError(f"No payment config set up for network {network}.")
 
-        safe_url_cow = f"https://app.safe.global/{short_name}:{payment_safe_address_cow}"
+        safe_url_cow = f"https://app.safe.global/eth:{payment_safe_address_cow}"
         safe_queue_url_cow = f"{safe_url_cow}/transactions/queue"
         safe_url_native = f"https://app.safe.global/{short_name}:{payment_safe_address_native}"
         safe_queue_url_native = f"{safe_url_native}/transactions/queue"

--- a/src/config.py
+++ b/src/config.py
@@ -363,12 +363,7 @@ class PaymentConfig:
 
         # mainnet transaction nonces are increased by this modifier to allow for proposing
         # multiple transactions on mainnet
-        nonce_modifier_dict = {
-            Network.MAINNET: 0,
-            Network.GNOSIS: 1,
-            Network.ARBITRUM_ONE: 2,
-            Network.BASE: 3,
-        }
+        nonce_modifier_dict = {network: idx for idx, network in enumerate(Network)}
         nonce_modifier = int(
             os.environ.get(
                 "NONCE_MODIFIER",

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -172,7 +172,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         if quote_reward_cow > 0:
             result.append(
                 Transfer(
-                    token=Token(self.reward_token_address, 18), # remove magic constant
+                    token=Token(self.reward_token_address, 18),  # remove magic constant
                     recipient=self.reward_target,
                     amount_wei=quote_reward_cow,
                 )
@@ -224,7 +224,9 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             try:
                 result.append(
                     Transfer(
-                        token=Token(self.reward_token_address, 18), # remove magic constant
+                        token=Token(
+                            self.reward_token_address, 18
+                        ),  # remove magic constant
                         recipient=self.reward_target,
                         amount_wei=reimbursement_cow + total_cow_reward,
                     )
@@ -252,7 +254,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         try:
             result.append(
                 Transfer(
-                    token=Token(self.reward_token_address, 18), # remove magic constant
+                    token=Token(self.reward_token_address, 18),  # remove magic constant
                     recipient=self.reward_target,
                     amount_wei=total_cow_reward,
                 )

--- a/src/fetch/payouts.py
+++ b/src/fetch/payouts.py
@@ -172,7 +172,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         if quote_reward_cow > 0:
             result.append(
                 Transfer(
-                    token=Token(self.reward_token_address),
+                    token=Token(self.reward_token_address, 18), # remove magic constant
                     recipient=self.reward_target,
                     amount_wei=quote_reward_cow,
                 )
@@ -224,7 +224,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
             try:
                 result.append(
                     Transfer(
-                        token=Token(self.reward_token_address),
+                        token=Token(self.reward_token_address, 18), # remove magic constant
                         recipient=self.reward_target,
                         amount_wei=reimbursement_cow + total_cow_reward,
                     )
@@ -252,7 +252,7 @@ class RewardAndPenaltyDatum:  # pylint: disable=too-many-instance-attributes
         try:
             result.append(
                 Transfer(
-                    token=Token(self.reward_token_address),
+                    token=Token(self.reward_token_address, 18), # remove magic constant
                     recipient=self.reward_target,
                     amount_wei=total_cow_reward,
                 )

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -15,6 +15,7 @@ from dune_client.client import DuneClient
 from dune_client.file.interface import FileIO
 from eth_typing import URI
 from safe_eth.eth.ethereum_client import EthereumClient
+from safe_eth.eth.ethereum_network import EthereumNetwork
 from slack.web.client import WebClient
 
 from src.config import AccountingConfig, Network
@@ -164,9 +165,9 @@ def auto_propose(
         nonce_cow = post_multisend(
             safe_address=config.payment_config.payment_safe_address_cow,
             transactions=transactions_cow,
-            network=config.payment_config.network,
+            network=EthereumNetwork.MAINNET,
             signing_key=signing_key,
-            client=client,
+            client=client_mainnet,
         )
 
         nonce_native = post_multisend(

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -168,6 +168,7 @@ def auto_propose(
             network=EthereumNetwork.MAINNET,
             signing_key=signing_key,
             client=client_mainnet,
+            nonce_modifier=config.payment_config.nonce_modifier,
         )
 
         nonce_native = post_multisend(

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -60,7 +60,8 @@ def dashboard_url(period: AccountingPeriod, config: AccountingConfig) -> str:
 
 
 def manual_propose(  # pylint: disable=too-many-arguments, too-many-positional-arguments
-    transfers: list[Transfer],
+    transfers_cow: list[Transfer],
+    transfers_native: list[Transfer],
     period: AccountingPeriod,
     config: AccountingConfig,
     send_to_slack: bool = False,
@@ -71,12 +72,22 @@ def manual_propose(  # pylint: disable=too-many-arguments, too-many-positional-a
     Entry point to manual creation of rewards payout transaction.
     This function generates the CSV transfer file to be pasted into the COW Safe app
     """
-    csv_transfers = [asdict(CSVTransfer.from_transfer(t)) for t in transfers]
+
+    csv_transfers_cow = [asdict(CSVTransfer.from_transfer(t)) for t in transfers_cow]
     FileIO(config.io_config.csv_output_dir).write_csv(
-        csv_transfers, f"transfers-{config.io_config.network.value}-{period}.csv"
+        csv_transfers_cow,
+        f"transfers-{config.io_config.network.value}-{period}-COW.csv",
     )
 
-    print(Transfer.summarize(transfers))
+    csv_transfers_native = [
+        asdict(CSVTransfer.from_transfer(t)) for t in transfers_native
+    ]
+    FileIO(config.io_config.csv_output_dir).write_csv(
+        csv_transfers_native,
+        f"transfers-{config.io_config.network.value}-{period}-NATIVE.csv",
+    )
+
+    print(Transfer.summarize(transfers_cow + transfers_native))
     print("Please cross check these results with the dashboard linked above.\n")
 
     if send_to_slack:
@@ -95,7 +106,8 @@ def manual_propose(  # pylint: disable=too-many-arguments, too-many-positional-a
 
 
 def auto_propose(
-    transfers: list[Transfer],
+    transfers_cow: list[Transfer],
+    transfers_native: list[Transfer],
     log_saver_obj: PrintStore,
     slack_client: WebClient,
     dry_run: bool,
@@ -113,15 +125,27 @@ def auto_propose(
 
     client = EthereumClient(URI(config.node_config.node_url))
 
-    log_saver_obj.print(Transfer.summarize(transfers), category=Category.TOTALS)
-    transactions = prepend_unwrap_if_necessary(
+    log_saver_obj.print(
+        Transfer.summarize(transfers_cow + transfers_native), category=Category.TOTALS
+    )
+
+    transactions_cow = prepend_unwrap_if_necessary(
         client,
-        config.payment_config.payment_safe_address,
+        config.payment_config.payment_safe_address_cow,
         wrapped_native_token=config.payment_config.wrapped_native_token_address,
-        transactions=[t.as_multisend_tx() for t in transfers],
+        transactions=[t.as_multisend_tx() for t in transfers_cow],
         skip_validation=True,
     )
-    if len(transactions) > len(transfers):
+
+    transactions_native = prepend_unwrap_if_necessary(
+        client,
+        config.payment_config.payment_safe_address_native,
+        wrapped_native_token=config.payment_config.wrapped_native_token_address,
+        transactions=[t.as_multisend_tx() for t in transfers_native],
+        skip_validation=True,
+    )
+
+    if len(transactions_native) > len(transfers_native):
         log_saver_obj.print("Prepended WETH unwrap", Category.GENERAL)
 
     log_saver_obj.print(
@@ -134,24 +158,34 @@ def auto_propose(
         slack_channel = config.io_config.slack_channel
         assert slack_channel is not None
 
-        nonce = post_multisend(
-            safe_address=config.payment_config.payment_safe_address,
-            transactions=transactions,
+        nonce_cow = post_multisend(
+            safe_address=config.payment_config.payment_safe_address_cow,
+            transactions=transactions_cow,
             network=config.payment_config.network,
             signing_key=signing_key,
             client=client,
         )
+
+        nonce_native = post_multisend(
+            safe_address=config.payment_config.payment_safe_address_native,
+            transactions=transactions_native,
+            network=config.payment_config.network,
+            signing_key=signing_key,
+            client=client,
+        )
+
         post_to_slack(
             slack_client,
             channel=slack_channel,
             message=(
-                f"""Solver Rewards transaction for network {config.dune_config.dune_blockchain}
-                with nonce {nonce} pending signatures.
-                To sign and execute, visit:\n{config.payment_config.safe_queue_url}
+                f"""Solver Rewards transactions for network {config.dune_config.dune_blockchain} pending signatures:\n
+                COW transfers on mainnet with nonce {nonce_cow}, see {config.payment_config.safe_queue_url_cow}.\n
+                Native transfers on {config.dune_config.dune_blockchain} with nonce {nonce_native}, see {config.payment_config.safe_queue_url_native}.\n
                 More details in thread"""
             ),
             sub_messages=log_saver_obj.get_values(),
         )
+
 
 
 def main() -> None:
@@ -190,14 +224,15 @@ def main() -> None:
         config=config,
     )
 
-    payout_transfers = []
+    payout_transfers_cow = []
+    payout_transfers_native = []
     for tr in payout_transfers_temp:
         if tr.token is None:
             if tr.amount_wei >= config.payment_config.min_native_token_transfer:
-                payout_transfers.append(tr)
+                payout_transfers_native.append(tr)
         else:
             if tr.amount_wei >= config.payment_config.min_cow_transfer:
-                payout_transfers.append(tr)
+                payout_transfers_cow.append(tr)
 
     if args.post_tx:
         ssl_context = ssl.create_default_context(cafile=certifi.where())
@@ -208,7 +243,8 @@ def main() -> None:
             ssl=ssl_context,
         )
         auto_propose(
-            transfers=payout_transfers,
+            transfers_cow=payout_transfers_cow,
+            transfers_native=payout_transfers_native,
             log_saver_obj=log_saver,
             slack_client=slack_client,
             dry_run=args.dry_run,
@@ -223,7 +259,8 @@ def main() -> None:
             ssl=ssl_context,
         )
         manual_propose(
-            transfers=payout_transfers,
+            transfers_cow=payout_transfers_cow,
+            transfers_native=payout_transfers_native,
             period=dune.period,
             config=config,
             send_to_slack=args.send_to_slack,
@@ -231,7 +268,12 @@ def main() -> None:
             log_saver_obj=log_saver,
         )
     else:
-        manual_propose(transfers=payout_transfers, period=dune.period, config=config)
+        manual_propose(
+            transfers_cow=payout_transfers_cow,
+            transfers_native=payout_transfers_native,
+            period=dune.period,
+            config=config,
+        )
 
 
 if __name__ == "__main__":

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -118,6 +118,8 @@ def auto_propose(
     This function encodes the multisend of reward transfers and posts
     the transaction to the COW TEAM SAFE from the proposer account.
     """
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+
     # Check for required env vars early
     # so not to wait for query execution to realize it's not available.
     signing_key = config.payment_config.signing_key
@@ -179,14 +181,16 @@ def auto_propose(
             slack_client,
             channel=slack_channel,
             message=(
-                f"""Solver Rewards transactions for network {config.dune_config.dune_blockchain} pending signatures:\n
-                COW transfers on mainnet with nonce {nonce_cow}, see {config.payment_config.safe_queue_url_cow}.\n
-                Native transfers on {config.dune_config.dune_blockchain} with nonce {nonce_native}, see {config.payment_config.safe_queue_url_native}.\n
+                f"""Solver Rewards transactions for network {config.dune_config.dune_blockchain}
+                pending signatures:\n
+                COW transfers on mainnet with nonce {nonce_cow},
+                see {config.payment_config.safe_queue_url_cow}.\n
+                Native transfers on {config.dune_config.dune_blockchain} with nonce {nonce_native},
+                see {config.payment_config.safe_queue_url_native}.\n
                 More details in thread"""
             ),
             sub_messages=log_saver_obj.get_values(),
         )
-
 
 
 def main() -> None:

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -123,6 +123,7 @@ def auto_propose(
     signing_key = config.payment_config.signing_key
     assert signing_key is not None
 
+    client_mainnet = EthereumClient(URI(config.node_config.node_url_mainnet))
     client = EthereumClient(URI(config.node_config.node_url))
 
     log_saver_obj.print(
@@ -130,7 +131,7 @@ def auto_propose(
     )
 
     transactions_cow = prepend_unwrap_if_necessary(
-        client,
+        client_mainnet,
         config.payment_config.payment_safe_address_cow,
         wrapped_native_token=config.payment_config.wrapped_native_token_address,
         transactions=[t.as_multisend_tx() for t in transfers_cow],

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -80,6 +80,7 @@ def post_multisend(
     transactions: list[MultiSendTx],
     client: EthereumClient,
     signing_key: str,
+    nonce_modifier: int = 0,
 ) -> int:
     """Posts a MultiSend Transaction from a list of Transfers."""
 
@@ -92,6 +93,7 @@ def post_multisend(
         value=0,
         data=encoded_multisend,
         operation=MultiSendOperation.DELEGATE_CALL.value,
+        safe_nonce=safe.retrieve_nonce() + nonce_modifier,
     )
     # There is a deep warning being raised here:
     # Details in issue: https://github.com/safe-global/safe-eth-py/issues/294

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -83,6 +83,7 @@ def post_multisend(
     nonce_modifier: int = 0,
 ) -> int:
     """Posts a MultiSend Transaction from a list of Transfers."""
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
 
     encoded_multisend = build_encoded_multisend(transactions, client=client)
     safe = Safe(  # type: ignore  # pylint: disable=abstract-class-instantiated

--- a/tests/unit/test_multisend.py
+++ b/tests/unit/test_multisend.py
@@ -19,7 +19,7 @@ class TestMultiSend(unittest.TestCase):
 
     def test_prepend_unwrap(self):
         many_eth = 99999999 * 10**18
-        safe_address = self.payment_config.payment_safe_address
+        safe_address = self.payment_config.payment_safe_address_native
         big_native_transfer = Transfer(
             token=None, recipient=Address.zero(), amount_wei=many_eth
         ).as_multisend_tx()


### PR DESCRIPTION
This PR implements the changes proposed in CIP-68. The main difference is that all COW transfers are proposed on mainnet, while buffer accounting is still handled on individual chains.

With this PR, two transactions are proposed on every chain.
- One transaction containing COW transfers on mainnet.
- One transaction containing native transfers on the respective chain.

In case of a run without the `--post-tx` flag, two csv files are created.

I have tested the creation of csv files and the bare creation of transactions. I have not tested the actual proposal of transactions yet.