### PR TITLE
Fix nonce increment

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -371,7 +371,9 @@ class PaymentConfig:
 
         # mainnet transaction nonces are increased by this modifier to allow for proposing
         # multiple transactions on mainnet
-        nonce_modifier_dict = {network: idx for idx, network in enumerate(Network)}
+        nonce_modifier_dict = {
+            network: idx for idx, network in enumerate(Network, start=1)
+        }
         nonce_modifier = int(
             os.environ.get(
                 "NONCE_MODIFIER",


### PR DESCRIPTION
This PR fixes an issue with the implementation of CIP-68 from #557.

The issue was that there were two transactions proposed for the mainnet rewards safe for `safe_nonce`, the native transfers on mainnet and the COW transfer on mainnet. 

With this PR, the native transfer on mainnet uses `safe_nonce`, and the COW transfers use `safe_nonce + 1`, ..., `safe_nonce + len(Network)`. This is achieved by just incrementing all nonces for COW transfers on mainnet by one.