### PR TITLE
[Testing] Fix broken rpc link

### DIFF
--- a/tests/e2e/test_token_details.py
+++ b/tests/e2e/test_token_details.py
@@ -5,7 +5,7 @@ from web3 import Web3
 
 from src.utils.token_details import get_token_decimals
 
-W3 = Web3(Web3.HTTPProvider("https://rpc.ankr.com/eth_sepolia"))
+W3 = Web3(Web3.HTTPProvider("https://sepolia.drpc.org"))
 
 
 class TestTokenDecimals(unittest.TestCase):


### PR DESCRIPTION
This PR changes the RPC used for e2e testing. The old link did not work anymore (due to requiring an api key).

The change can be tested by running `make test-e2e`. It should skip two tests and pass all other tests. Without the change, most test should fail.