### PR TITLE
Change unwrap to exactly what is needed to execute

### DIFF
--- a/src/multisend.py
+++ b/src/multisend.py
@@ -53,22 +53,26 @@ def prepend_unwrap_if_necessary(
     if eth_balance < eth_needed:
         weth = weth9(client.w3, wrapped_native_token)
         weth_balance = weth.functions.balanceOf(safe_address).call()
+        weth_unwrap_amount = eth_needed - eth_balance
+
         if weth_balance + eth_balance < eth_needed:
             message = (
                 f"{safe_address} has insufficient WETH + ETH balance for transaction!"
+                f"Additional {(weth_unwrap_amount - weth_balance) / 10**18} WETH required to "
+                "execute."
             )
             if not skip_validation:
                 raise ValueError(message)
             log.warning(f"{message} - proceeding to build transaction anyway")
 
-        log.info(f"prepending unwrap of {weth_balance/10**18}")
+        log.info(f"prepending unwrap of {weth_unwrap_amount / 10**18}")
         transactions.insert(
             0,
             MultiSendTx(
                 operation=MultiSendOperation.CALL,
                 to=weth.address,
                 value=0,
-                data=weth.encodeABI(fn_name="withdraw", args=[weth_balance]),
+                data=weth.encodeABI(fn_name="withdraw", args=[weth_unwrap_amount]),
             ),
         )
     return transactions

--- a/tests/unit/test_multisend.py
+++ b/tests/unit/test_multisend.py
@@ -18,30 +18,16 @@ class TestMultiSend(unittest.TestCase):
         self.payment_config = PaymentConfig.from_network(Network.MAINNET)
 
     def test_prepend_unwrap(self):
-        many_eth = 99999999 * 10**18
         safe_address = self.payment_config.payment_safe_address_native
-        big_native_transfer = Transfer(
-            token=None, recipient=Address.zero(), amount_wei=many_eth
-        ).as_multisend_tx()
-
-        with self.assertRaises(ValueError):
-            # Nobody has that much ETH!
-            prepend_unwrap_if_necessary(
-                client=self.client,
-                safe_address=safe_address,
-                transactions=[big_native_transfer],
-                wrapped_native_token=self.payment_config.wrapped_native_token_address,
-            )
-
         eth_balance = self.client.get_balance(safe_address)
         weth = weth9(self.client.w3, self.payment_config.wrapped_native_token_address)
-        weth_balance = weth.functions.balanceOf(safe_address).call()
 
+        weth_unwrap_amount = 1
         transactions = [
             Transfer(
                 token=None,
                 recipient=Address.zero(),
-                amount_wei=eth_balance + 1,  # More ETH than account has!
+                amount_wei=eth_balance + weth_unwrap_amount,  # More ETH than account has!
             ).as_multisend_tx()
         ]
         transactions = prepend_unwrap_if_necessary(
@@ -58,11 +44,27 @@ class TestMultiSend(unittest.TestCase):
 
         unwrap_method_id = "0x2e1a7d4d"
         # 32-byte hex encoding of weth balance
-        hex_weth_balance = hex(weth_balance)[2:].rjust(64, "0")
+        hex_weth_unwrap_amount = hex(weth_unwrap_amount)[2:].rjust(64, "0")
         self.assertEqual(
-            f"{unwrap_method_id}{hex_weth_balance}",
+            f"{unwrap_method_id}{hex_weth_unwrap_amount}",
             unwrap.data.hex(),
         )
+
+    def test_prepend_unwrap_error(self):
+        many_eth = 99999999 * 10**18
+        safe_address = self.payment_config.payment_safe_address_native
+        big_native_transfer = Transfer(
+            token=None, recipient=Address.zero(), amount_wei=many_eth
+        ).as_multisend_tx()
+
+        with self.assertRaises(ValueError):
+            # Nobody has that much ETH!
+            prepend_unwrap_if_necessary(
+                client=self.client,
+                safe_address=safe_address,
+                transactions=[big_native_transfer],
+                wrapped_native_token=self.payment_config.wrapped_native_token_address,
+            )
 
     def test_multisend_encoding(self):
         receiver = Address("0xde786877a10dbb7eba25a4da65aecf47654f08ab")

--- a/tests/unit/test_multisend.py
+++ b/tests/unit/test_multisend.py
@@ -27,7 +27,8 @@ class TestMultiSend(unittest.TestCase):
             Transfer(
                 token=None,
                 recipient=Address.zero(),
-                amount_wei=eth_balance + weth_unwrap_amount,  # More ETH than account has!
+                amount_wei=eth_balance
+                + weth_unwrap_amount,  # More ETH than account has!
             ).as_multisend_tx()
         ]
         transactions = prepend_unwrap_if_necessary(


### PR DESCRIPTION
This PR changes the amount unwrapped when creating payout transactions.

Before, all wrapped native tokens on the payout safe were unwrapped. This can lead to issues if the native token and wrapped native token together are not enough to execute payment. This required sending native tokens to the payout safe. But that process is more difficult than getting additiona wrapped native tokens into the safe, e.g. via fee withdrawals.

With this change, the unwrap is always for the total amount missing in native funds compared to what is needed for payments. The transaction might not be executable as is, as not enough wrapped native tokens are in the safe. But sending enough wrapped tokens (or doing fee withdrawals) will make it executable. Since fee withdrawals do not require collecting signatures, some cases of missing native tokens might can be handled with little delay.