### PR TITLE
Don't propose tx if we have zero transfers

### DIFF
--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -182,6 +182,7 @@ def auto_propose(
             time.sleep(2)  # attempt to avoid Safe API's rate limits
         else:
             nonce_cow = None
+
         if len(transactions_native) > 0:
             nonce_native = post_multisend(
                 safe_address=config.payment_config.payment_safe_address_native,

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -180,6 +180,7 @@ def auto_propose(
         )
         time.sleep(2)  # attempt to avoid Safe API's rate limits
 
+        nonce_native: int | None = None
         if len(transactions_native) > 0:
             nonce_native = post_multisend(
                 safe_address=config.payment_config.payment_safe_address_native,
@@ -194,9 +195,8 @@ def auto_propose(
                 ),
             )
             time.sleep(2)  # attempt to avoid Safe API's rate limits
-        else:
-            nonce_native = None
 
+        nonce_overdrafts: int | None = None
         if len(ovedrafts_txs) > 0:
             nonce_overdrafts = post_multisend(
                 safe_address=config.payment_config.payment_safe_address_native,
@@ -207,12 +207,11 @@ def auto_propose(
                 nonce_modifier=(
                     len(Network) + 1
                     if config.payment_config.network == EthereumNetwork.MAINNET
-                    else 1
+                    else (1 if nonce_native is not None else 0)
                 ),
             )
             time.sleep(2)  # attempt to avoid Safe API's rate limits
-        else:
-            nonce_overdrafts = None
+
         post_to_slack(
             slack_client,
             channel=slack_channel,

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -170,18 +170,16 @@ def auto_propose(
         slack_channel = config.io_config.slack_channel
         assert slack_channel is not None
 
-        if len(transactions_cow) > 0:
-            nonce_cow = post_multisend(
-                safe_address=config.payment_config.payment_safe_address_cow,
-                transactions=transactions_cow,
-                network=EthereumNetwork.MAINNET,
-                signing_key=signing_key,
-                client=client_mainnet,
-                nonce_modifier=config.payment_config.nonce_modifier,
-            )
-            time.sleep(2)  # attempt to avoid Safe API's rate limits
-        else:
-            nonce_cow = None
+        nonce_cow = post_multisend(
+            safe_address=config.payment_config.payment_safe_address_cow,
+            transactions=transactions_cow,
+            network=EthereumNetwork.MAINNET,
+            signing_key=signing_key,
+            client=client_mainnet,
+            nonce_modifier=config.payment_config.nonce_modifier,
+        )
+        time.sleep(2)  # attempt to avoid Safe API's rate limits
+
 
         if len(transactions_native) > 0:
             nonce_native = post_multisend(

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -191,7 +191,7 @@ def auto_propose(
                 nonce_modifier=(
                     len(Network)
                     if config.payment_config.network == EthereumNetwork.MAINNET
-                    else 0
+                    else (1 if nonce_native is not None else 0)
                 ),
             )
             time.sleep(2)  # attempt to avoid Safe API's rate limits

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -170,41 +170,51 @@ def auto_propose(
         slack_channel = config.io_config.slack_channel
         assert slack_channel is not None
 
-        nonce_cow = post_multisend(
-            safe_address=config.payment_config.payment_safe_address_cow,
-            transactions=transactions_cow,
-            network=EthereumNetwork.MAINNET,
-            signing_key=signing_key,
-            client=client_mainnet,
-            nonce_modifier=config.payment_config.nonce_modifier,
-        )
-        time.sleep(2)  # attempt to avoid Safe API's rate limits
-        nonce_native = post_multisend(
-            safe_address=config.payment_config.payment_safe_address_native,
-            transactions=transactions_native,
-            network=config.payment_config.network,
-            signing_key=signing_key,
-            client=client,
-            nonce_modifier=(
-                len(Network)
-                if config.payment_config.network == EthereumNetwork.MAINNET
-                else 0
-            ),
-        )
-        time.sleep(2)  # attempt to avoid Safe API's rate limits
-        nonce_overdrafts = post_multisend(
-            safe_address=config.payment_config.payment_safe_address_native,
-            transactions=ovedrafts_txs,
-            network=config.payment_config.network,
-            signing_key=signing_key,
-            client=client,
-            nonce_modifier=(
-                len(Network) + 1
-                if config.payment_config.network == EthereumNetwork.MAINNET
-                else 1
-            ),
-        )
-        time.sleep(2)  # attempt to avoid Safe API's rate limits
+        if len(transactions_cow) > 0:
+            nonce_cow = post_multisend(
+                safe_address=config.payment_config.payment_safe_address_cow,
+                transactions=transactions_cow,
+                network=EthereumNetwork.MAINNET,
+                signing_key=signing_key,
+                client=client_mainnet,
+                nonce_modifier=config.payment_config.nonce_modifier,
+            )
+            time.sleep(2)  # attempt to avoid Safe API's rate limits
+        else:
+            nonce_cow = None
+        if len(transactions_native) > 0:
+            nonce_native = post_multisend(
+                safe_address=config.payment_config.payment_safe_address_native,
+                transactions=transactions_native,
+                network=config.payment_config.network,
+                signing_key=signing_key,
+                client=client,
+                nonce_modifier=(
+                    len(Network)
+                    if config.payment_config.network == EthereumNetwork.MAINNET
+                    else 0
+                ),
+            )
+            time.sleep(2)  # attempt to avoid Safe API's rate limits
+        else:
+            nonce_native = None
+
+        if len(ovedrafts_txs) > 0:
+            nonce_overdrafts = post_multisend(
+                safe_address=config.payment_config.payment_safe_address_native,
+                transactions=ovedrafts_txs,
+                network=config.payment_config.network,
+                signing_key=signing_key,
+                client=client,
+                nonce_modifier=(
+                    len(Network) + 1
+                    if config.payment_config.network == EthereumNetwork.MAINNET
+                    else 1
+                ),
+            )
+            time.sleep(2)  # attempt to avoid Safe API's rate limits
+        else:
+            nonce_overdrafts = None
         post_to_slack(
             slack_client,
             channel=slack_channel,

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -180,7 +180,6 @@ def auto_propose(
         )
         time.sleep(2)  # attempt to avoid Safe API's rate limits
 
-
         if len(transactions_native) > 0:
             nonce_native = post_multisend(
                 safe_address=config.payment_config.payment_safe_address_native,


### PR DESCRIPTION
This PR adds some sanity checks on when to propose a tx; the requirement being that you need to have at least one interaction included in it.

Note we still always include a COW rewards tx, even if that is empty, as these txs are proposed on mainnet and if such a tx is not proposed, then subsequent nonces for other chains might be delayed

(we run into txs that are empty when proposing payouts for Lens and also when proposing the overdrafts tx)