### PR TITLE
Fix Lens Safe url

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -496,7 +496,7 @@ class PaymentConfig:
 
             case Network.LENS:
                 payment_network = EthereumNetwork.LENS
-                short_name = "gho"
+                short_name = "lens"
 
                 cow_token_address = Address(  # dummy address
                     "0x0000000000000000000000000000000000000006"


### PR DESCRIPTION
This PR fixes the url that is pushed to slack, and is supposed to link to the Payouts safe on Lens