### PR TITLE
Propose Lens last and only if needed

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -20,9 +20,10 @@ load_dotenv()
 class Network(Enum):
     """Network class for networks supported by the accounting."""
 
-    # As the script is proposing COW transfers for all chains on mainnet based on a nonce shift that is chain-dependent,
-    # we would like, for convenience, to have Lens last, as it is the chain most likely to have zero transfers (and thus produce a nonce gap).
-    # Nothing breaks if this order is not maintained but nonce gaps will be more likely to occur
+    # As the script is proposing COW transfers for all chains on mainnet based on a nonce shift
+    # that is chain-dependent, we would like, for convenience, to have Lens last, as it is the
+    # chain most likely to have zero transfers (and thus produce a nonce gap).
+    # Nothing breaks if this order is not maintained but nonce gaps will be more likely to occur.
     LENS = "lens"
     MAINNET = "mainnet"
     BASE = "base"

--- a/src/config.py
+++ b/src/config.py
@@ -20,10 +20,10 @@ load_dotenv()
 class Network(Enum):
     """Network class for networks supported by the accounting."""
 
+    LENS = "lens"
     MAINNET = "mainnet"
     BASE = "base"
     ARBITRUM_ONE = "arbitrum"
-    LENS = "lens"
     GNOSIS = "gnosis"
     AVALANCHE = "avalanche"
     POLYGON = "polygon"

--- a/src/config.py
+++ b/src/config.py
@@ -20,6 +20,9 @@ load_dotenv()
 class Network(Enum):
     """Network class for networks supported by the accounting."""
 
+    # As the script is proposing COW transfers for all chains on mainnet based on a nonce shift that is chain-dependent,
+    # we would like, for convenience, to have Lens last, as it is the chain most likely to have zero transfers (and thus produce a nonce gap).
+    # Nothing breaks if this order is not maintained but nonce gaps will be more likely to occur
     LENS = "lens"
     MAINNET = "mainnet"
     BASE = "base"

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -5,7 +5,6 @@ Script to generate the CSV Airdrop file for Solver Rewards over an Accounting Pe
 from __future__ import annotations
 
 import os
-import time
 import ssl
 from dataclasses import asdict
 from fractions import Fraction
@@ -170,49 +169,40 @@ def auto_propose(
         slack_channel = config.io_config.slack_channel
         assert slack_channel is not None
 
-        nonce_cow: int | None = None
-        if len(transactions_cow) > 0:
-            nonce_cow = post_multisend(
-                safe_address=config.payment_config.payment_safe_address_cow,
-                transactions=transactions_cow,
-                network=EthereumNetwork.MAINNET,
-                signing_key=signing_key,
-                client=client_mainnet,
-                nonce_modifier=config.payment_config.nonce_modifier,
-            )
-            time.sleep(2)  # attempt to avoid Safe API's rate limits
+        nonce_cow = post_multisend(
+            safe_address=config.payment_config.payment_safe_address_cow,
+            transactions=transactions_cow,
+            network=EthereumNetwork.MAINNET,
+            signing_key=signing_key,
+            client=client_mainnet,
+            nonce_modifier=config.payment_config.nonce_modifier,
+        )
 
-        nonce_native: int | None = None
-        if len(transactions_native) > 0:
-            nonce_native = post_multisend(
-                safe_address=config.payment_config.payment_safe_address_native,
-                transactions=transactions_native,
-                network=config.payment_config.network,
-                signing_key=signing_key,
-                client=client,
-                nonce_modifier=(
-                    len(Network)
-                    if config.payment_config.network == EthereumNetwork.MAINNET
-                    else (1 if nonce_native is not None else 0)
-                ),
-            )
-            time.sleep(2)  # attempt to avoid Safe API's rate limits
+        nonce_native = post_multisend(
+            safe_address=config.payment_config.payment_safe_address_native,
+            transactions=transactions_native,
+            network=config.payment_config.network,
+            signing_key=signing_key,
+            client=client,
+            nonce_modifier=(
+                len(Network)
+                if config.payment_config.network == EthereumNetwork.MAINNET
+                else (1 if nonce_native is not None else 0)
+            ),
+        )
 
-        nonce_overdrafts: int | None = None
-        if len(ovedrafts_txs) > 0:
-            nonce_overdrafts = post_multisend(
-                safe_address=config.payment_config.payment_safe_address_native,
-                transactions=ovedrafts_txs,
-                network=config.payment_config.network,
-                signing_key=signing_key,
-                client=client,
-                nonce_modifier=(
-                    len(Network) + 1
-                    if config.payment_config.network == EthereumNetwork.MAINNET
-                    else (1 if nonce_native is not None else 0)
-                ),
-            )
-            time.sleep(2)  # attempt to avoid Safe API's rate limits
+        nonce_overdrafts = post_multisend(
+            safe_address=config.payment_config.payment_safe_address_native,
+            transactions=ovedrafts_txs,
+            network=config.payment_config.network,
+            signing_key=signing_key,
+            client=client,
+            nonce_modifier=(
+                len(Network) + 1
+                if config.payment_config.network == EthereumNetwork.MAINNET
+                else (1 if nonce_native is not None else 0)
+            ),
+        )
 
         post_to_slack(
             slack_client,

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -170,6 +170,7 @@ def auto_propose(
         slack_channel = config.io_config.slack_channel
         assert slack_channel is not None
 
+        nonce_cow: int | None = None
         if len(transactions_cow) > 0:
             nonce_cow = post_multisend(
                 safe_address=config.payment_config.payment_safe_address_cow,

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -169,7 +169,7 @@ def auto_propose(
         slack_channel = config.io_config.slack_channel
         assert slack_channel is not None
 
-        nonce_cow: int | None = post_multisend(
+        nonce_cow = post_multisend(
             safe_address=config.payment_config.payment_safe_address_cow,
             transactions=transactions_cow,
             network=EthereumNetwork.MAINNET,
@@ -178,7 +178,7 @@ def auto_propose(
             nonce_modifier=config.payment_config.nonce_modifier,
         )
 
-        nonce_native: int | None = post_multisend(
+        nonce_native = post_multisend(
             safe_address=config.payment_config.payment_safe_address_native,
             transactions=transactions_native,
             network=config.payment_config.network,
@@ -187,11 +187,11 @@ def auto_propose(
             nonce_modifier=(
                 len(Network)
                 if config.payment_config.network == EthereumNetwork.MAINNET
-                else (1 if nonce_native is not None else 0)
+                else 0
             ),
         )
 
-        nonce_overdrafts: int | None = post_multisend(
+        nonce_overdrafts = post_multisend(
             safe_address=config.payment_config.payment_safe_address_native,
             transactions=ovedrafts_txs,
             network=config.payment_config.network,

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -169,7 +169,7 @@ def auto_propose(
         slack_channel = config.io_config.slack_channel
         assert slack_channel is not None
 
-        nonce_cow = post_multisend(
+        nonce_cow: int | None = post_multisend(
             safe_address=config.payment_config.payment_safe_address_cow,
             transactions=transactions_cow,
             network=EthereumNetwork.MAINNET,
@@ -178,7 +178,7 @@ def auto_propose(
             nonce_modifier=config.payment_config.nonce_modifier,
         )
 
-        nonce_native = post_multisend(
+        nonce_native: int | None = post_multisend(
             safe_address=config.payment_config.payment_safe_address_native,
             transactions=transactions_native,
             network=config.payment_config.network,
@@ -191,7 +191,7 @@ def auto_propose(
             ),
         )
 
-        nonce_overdrafts = post_multisend(
+        nonce_overdrafts: int | None = post_multisend(
             safe_address=config.payment_config.payment_safe_address_native,
             transactions=ovedrafts_txs,
             network=config.payment_config.network,

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -170,15 +170,16 @@ def auto_propose(
         slack_channel = config.io_config.slack_channel
         assert slack_channel is not None
 
-        nonce_cow = post_multisend(
-            safe_address=config.payment_config.payment_safe_address_cow,
-            transactions=transactions_cow,
-            network=EthereumNetwork.MAINNET,
-            signing_key=signing_key,
-            client=client_mainnet,
-            nonce_modifier=config.payment_config.nonce_modifier,
-        )
-        time.sleep(2)  # attempt to avoid Safe API's rate limits
+        if len(transactions_cow) > 0:
+            nonce_cow = post_multisend(
+                safe_address=config.payment_config.payment_safe_address_cow,
+                transactions=transactions_cow,
+                network=EthereumNetwork.MAINNET,
+                signing_key=signing_key,
+                client=client_mainnet,
+                nonce_modifier=config.payment_config.nonce_modifier,
+            )
+            time.sleep(2)  # attempt to avoid Safe API's rate limits
 
         nonce_native: int | None = None
         if len(transactions_native) > 0:

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -4,6 +4,7 @@ Safe Multisend transaction consisting of Transfers
 """
 
 import os
+import time
 from eth_typing.evm import ChecksumAddress
 from safe_eth.eth.ethereum_client import EthereumClient
 from safe_eth.eth.ethereum_network import EthereumNetwork
@@ -90,10 +91,12 @@ def post_multisend(
     client: EthereumClient,
     signing_key: str,
     nonce_modifier: int = 0,
-) -> int:
+) -> int | None:
     """Posts a MultiSend Transaction from a list of Transfers."""
     # pylint: disable=too-many-arguments,too-many-positional-arguments
 
+    if len(transactions) == 0:
+        return None
     encoded_multisend = build_encoded_multisend(transactions, client=client)
     safe = Safe(  # type: ignore  # pylint: disable=abstract-class-instantiated
         address=safe_address, ethereum_client=client
@@ -114,4 +117,5 @@ def post_multisend(
         f" {safe_tx.safe_tx_hash.hex()} to {safe.address}"
     )
     tx_service.post_transaction(safe_tx=safe_tx)
+    time.sleep(2)  # attempt to avoid Safe API's rate limits
     return int(safe_tx.safe_nonce)


### PR DESCRIPTION
This PR changes the orders of proposals, and proposes Lens last; note network list is processed in reverse order, as shown [here](https://github.com/cowprotocol/solver-rewards/blob/35a54d4ed405fcbbfff5568f8c7a90b53a93c78f/src/config.py#L403). 

We also apply a change similar to the one in #597  for COW transfers, now that Lens is last, as it is extremely unlikely that we will have zero COW transfers for any other chain except for Lens. On the way, we clean up the code a bit and incorporate all checks within the `post_multisend()` function, as was suggested [here](https://github.com/cowprotocol/solver-rewards/pull/597#discussion_r2413057134).