### PR TITLE
Update Safe url

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -460,12 +460,9 @@ class PaymentConfig:
             case _:
                 raise ValueError(f"No payment config set up for network {network}.")
 
-        safe_url_cow = f"https://app.safe.global/eth:{payment_safe_address_cow}"
-        safe_queue_url_cow = f"{safe_url_cow}/transactions/queue"
-        safe_url_native = (
-            f"https://app.safe.global/{short_name}:{payment_safe_address_native}"
-        )
-        safe_queue_url_native = f"{safe_url_native}/transactions/queue"
+        safe_queue_url_cow = f"https://app.safe.global/transactions/queue?safe=eth:{payment_safe_address_cow}"
+
+        safe_queue_url_native = f"https://app.safe.global/transactions/queue?safe={short_name}:{payment_safe_address_native}"
 
         return PaymentConfig(
             network=payment_network,

--- a/src/config.py
+++ b/src/config.py
@@ -460,9 +460,15 @@ class PaymentConfig:
             case _:
                 raise ValueError(f"No payment config set up for network {network}.")
 
-        safe_queue_url_cow = f"https://app.safe.global/transactions/queue?safe=eth:{payment_safe_address_cow}"
+        safe_queue_url_cow = (
+            f"https://app.safe.global/transactions/queue?safe=eth:"
+            f"{payment_safe_address_cow}"
+        )
 
-        safe_queue_url_native = f"https://app.safe.global/transactions/queue?safe={short_name}:{payment_safe_address_native}"
+        safe_queue_url_native = (
+            f"https://app.safe.global/transactions/queue?safe="
+            f"{short_name}:{payment_safe_address_native}"
+        )
 
         return PaymentConfig(
             network=payment_network,


### PR DESCRIPTION
This PR updates the Safe url that is printed as part of the msg on slack as current one doesn't seem to be working anymore

Current one: [https://app.safe.global/eth:0xA03be496e67Ec29bC62F01a428683D7F9c204930/transactions/queue](https://app.safe.global/eth:0xA03be496e67Ec29bC62F01a428683D7F9c204930/transactions/queue)

Correct:[ https://app.safe.global/transactions/queue?safe=eth:0xA03be496e67Ec29bC62F01a428683D7F9c204930]( https://app.safe.global/transactions/queue?safe=eth:0xA03be496e67Ec29bC62F01a428683D7F9c204930)