### PR TITLE
Shift native transfer/overdraft nonces by one and propose an empty tx

### DIFF
--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -175,10 +175,7 @@ def auto_propose(
             nonce_modifier=config.payment_config.nonce_modifier,
         )
 
-        # Proposing an empty transfer in the native safe, as a placeholder in case
-        # wrapping/unwrapping of native token or other operation is needed
-        # before native payments
-        nonce_modifier_empty = ( # Adds empty nonce to allow for wrapping/unwrapping
+        nonce_modifier_empty = (  # Adds empty nonce to allow for wrapping/unwrapping
             len(Network)
             if config.payment_config.network == EthereumNetwork.MAINNET
             else 0

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -213,7 +213,7 @@ def auto_propose(
             network=config.payment_config.network,
             signing_key=signing_key,
             client=client,
-            nonce_modifier=nonce_modifier_overdrafts
+            nonce_modifier=nonce_modifier_overdrafts,
         )
 
         post_to_slack(

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -25,7 +25,11 @@ from src.logger import log_saver, set_log
 from src.models.accounting_period import AccountingPeriod
 from src.models.transfer import Transfer, CSVTransfer
 from src.models.overdraft import Overdraft
-from src.multisend import post_multisend, prepend_unwrap_if_necessary
+from src.multisend import (
+    post_empty_transaction,
+    post_multisend,
+    prepend_unwrap_if_necessary,
+)
 from src.pg_client import MultiInstanceDBFetcher
 from src.slack_utils import post_to_slack
 from src.utils.print_store import Category, PrintStore
@@ -171,17 +175,30 @@ def auto_propose(
             nonce_modifier=config.payment_config.nonce_modifier,
         )
 
+        # Base (unshifted) nonce offset for the native safe: reserved for an empty
+        # transaction, so the team can wrap/unwrap the native token on this nonce
+        # whenever needed, without having to repropose the native transfers/overdrafts.
+        nonce_modifier_empty = (
+            len(Network)
+            if config.payment_config.network == EthereumNetwork.MAINNET
+            else 0
+        )
+
+        nonce_empty = post_empty_transaction(
+            safe_address=config.payment_config.payment_safe_address_native,
+            network=config.payment_config.network,
+            signing_key=signing_key,
+            client=client,
+            nonce_modifier=nonce_modifier_empty,
+        )
+
         nonce_native = post_multisend(
             safe_address=config.payment_config.payment_safe_address_native,
             transactions=transactions_native,
             network=config.payment_config.network,
             signing_key=signing_key,
             client=client,
-            nonce_modifier=(
-                len(Network)
-                if config.payment_config.network == EthereumNetwork.MAINNET
-                else 0
-            ),
+            nonce_modifier=nonce_modifier_empty + 1,
         )
 
         nonce_overdrafts = post_multisend(
@@ -191,9 +208,9 @@ def auto_propose(
             signing_key=signing_key,
             client=client,
             nonce_modifier=(
-                len(Network) + 1
+                nonce_modifier_empty + 2
                 if config.payment_config.network == EthereumNetwork.MAINNET
-                else (1 if nonce_native is not None else 0)
+                else (2 if nonce_native is not None else 1)
             ),
         )
 
@@ -205,6 +222,9 @@ def auto_propose(
                 pending signatures:\n
                 COW transfers on mainnet with nonce {nonce_cow},
                 see {config.payment_config.safe_queue_url_cow}.\n
+                Empty tx reserved on {config.dune_config.dune_blockchain} with nonce
+                {nonce_empty} for wrapping/unwrapping the native token if needed,
+                see {config.payment_config.safe_queue_url_native}.\n
                 Native transfers on {config.dune_config.dune_blockchain} with nonce {nonce_native},
                 see {config.payment_config.safe_queue_url_native}.\n
                 Overdrafts on {config.dune_config.dune_blockchain} with nonce {nonce_overdrafts},

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -178,7 +178,7 @@ def auto_propose(
         # Proposing an empty transfer in the native safe, as a placeholder in case
         # wrapping/unwrapping of native token or other operation is needed
         # before native payments
-        nonce_modifier_empty = (
+        nonce_modifier_empty = ( # Adds empty nonce to allow for wrapping/unwrapping
             len(Network)
             if config.payment_config.network == EthereumNetwork.MAINNET
             else 0

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -175,9 +175,9 @@ def auto_propose(
             nonce_modifier=config.payment_config.nonce_modifier,
         )
 
-        # Base (unshifted) nonce offset for the native safe: reserved for an empty
-        # transaction, so the team can wrap/unwrap the native token on this nonce
-        # whenever needed, without having to repropose the native transfers/overdrafts.
+        # Proposing an empty transfer in the native safe, as a placeholder in case
+        # wrapping/unwrapping of native token or other operation is needed
+        # before native payments
         nonce_modifier_empty = (
             len(Network)
             if config.payment_config.network == EthereumNetwork.MAINNET
@@ -192,13 +192,19 @@ def auto_propose(
             nonce_modifier=nonce_modifier_empty,
         )
 
+        nonce_modifier_native_transfer = nonce_modifier_empty + 1
+
         nonce_native = post_multisend(
             safe_address=config.payment_config.payment_safe_address_native,
             transactions=transactions_native,
             network=config.payment_config.network,
             signing_key=signing_key,
             client=client,
-            nonce_modifier=nonce_modifier_empty + 1,
+            nonce_modifier=nonce_modifier_native_transfer,
+        )
+
+        nonce_modifier_overdrafts = nonce_modifier_empty + (
+            2 if nonce_native is not None else 1
         )
 
         nonce_overdrafts = post_multisend(
@@ -207,11 +213,7 @@ def auto_propose(
             network=config.payment_config.network,
             signing_key=signing_key,
             client=client,
-            nonce_modifier=(
-                nonce_modifier_empty + 2
-                if config.payment_config.network == EthereumNetwork.MAINNET
-                else (2 if nonce_native is not None else 1)
-            ),
+            nonce_modifier=nonce_modifier_overdrafts
         )
 
         post_to_slack(
@@ -223,7 +225,7 @@ def auto_propose(
                 COW transfers on mainnet with nonce {nonce_cow},
                 see {config.payment_config.safe_queue_url_cow}.\n
                 Empty tx reserved on {config.dune_config.dune_blockchain} with nonce
-                {nonce_empty} for wrapping/unwrapping the native token if needed,
+                {nonce_empty},
                 see {config.payment_config.safe_queue_url_native}.\n
                 Native transfers on {config.dune_config.dune_blockchain} with nonce {nonce_native},
                 see {config.payment_config.safe_queue_url_native}.\n

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -118,3 +118,33 @@ def post_multisend(
     tx_service.post_transaction(safe_tx=safe_tx)
     time.sleep(2)  # attempt to avoid Safe API's rate limits
     return int(safe_tx.safe_nonce)
+
+
+def post_empty_transaction(
+    safe_address: ChecksumAddress,
+    network: EthereumNetwork,
+    client: EthereumClient,
+    signing_key: str,
+    nonce_modifier: int = 0,
+) -> int:
+    """Posts a no-op Safe transaction, reserving a nonce for manual use
+    (e.g. wrapping/unwrapping the native token before executing subsequent payouts)."""
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    safe = Safe(  # type: ignore  # pylint: disable=abstract-class-instantiated
+        address=safe_address, ethereum_client=client
+    )
+    safe_tx = safe.build_multisig_tx(
+        to=safe_address,
+        value=0,
+        data=b"",
+        safe_nonce=safe.retrieve_nonce() + nonce_modifier,
+    )
+    safe_tx.sign(signing_key)
+    tx_service = TransactionServiceApi(network, client, api_key=api_key)
+    print(
+        f"Posting empty transaction with hash"
+        f" {safe_tx.safe_tx_hash.hex()} to {safe.address}"
+    )
+    tx_service.post_transaction(safe_tx=safe_tx)
+    time.sleep(2)  # attempt to avoid Safe API's rate limits
+    return int(safe_tx.safe_nonce)


### PR DESCRIPTION
Shift native transfer/overdraft nonces by one and propose an empty tx on the freed nonce, so it is possible to wrap/unwrap the native token without having to repropose and re-sign transactions.

Context: https://nomevlabs.slack.com/archives/C04V9D9JTEV/p1786607224284309