### PR TITLE
Fix nonce gaps for manual mainnet proposal

### DIFF
--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -176,7 +176,7 @@ def auto_propose(
         )
 
         nonce_modifier_empty = (  # Adds empty nonce to allow for wrapping/unwrapping
-            len(Network)
+            config.payment_config.nonce_modifier + 1
             if config.payment_config.network == EthereumNetwork.MAINNET
             else 0
         )


### PR DESCRIPTION
This PR fixes some issue/bug wrt nonces for the mainnet payouts proposal.

Specifically, it ensures that COW rewards, empty tx, native transfers and overdrafts are proposed in consecutive nonces